### PR TITLE
Docs/add exclude label feature

### DIFF
--- a/content/en/docs/scenarios/pod-network-scenario/_index.md
+++ b/content/en/docs/scenarios/pod-network-scenario/_index.md
@@ -5,5 +5,60 @@ date: 2017-01-04
 ---
 
 ### Pod outage
-Scenario to block the traffic ( Ingress/Egress ) of a pod matching the labels for the specified duration of time to understand the behavior of the service/other services which depend on it during downtime. This helps with planning the requirements accordingly, be it improving the timeouts or tweaking the alerts etc.
+Scenario to block the traffic (Ingress/Egress) of a pod matching the labels for the specified duration of time to understand the behavior of the service/other services which depend on it during downtime. This helps with planning the requirements accordingly, be it improving the timeouts or tweaking the alerts etc.
 With the current network policies, it is not possible to explicitly block ports which are enabled by allowed network policy rule. This chaos scenario addresses this issue by using OVS flow rules to block ports related to the pod. It supports OpenShiftSDN and OVNKubernetes based networks.
+
+#### Excluding Pods from Network Outage
+
+The pod outage scenario now supports excluding specific pods from chaos testing using the `exclude_label` parameter. This allows you to target a namespace or group of pods with your chaos testing while deliberately preserving certain critical workloads.
+
+##### Why Use Pod Exclusion?
+
+This feature addresses several common use cases:
+
+- Testing resiliency of an application while keeping critical monitoring pods operational
+- Preserving designated "control plane" pods within a microservice architecture
+- Allowing targeted chaos without affecting auxiliary services in the same namespace
+- Enabling more precise pod selection when network policies require all related services to be in the same namespace
+
+##### How to Use the `exclude_label` Parameter
+
+The `exclude_label` parameter works alongside existing pod selection parameters (`label_selector` and `pod_name`). The system will:
+1. Identify all pods in the target namespace
+2. Exclude pods matching the `exclude_label` criteria (in format "key=value")
+3. Apply the existing filters (`label_selector` or `pod_name`)
+4. Apply the chaos scenario to the resulting pod list
+
+##### Example Configurations
+
+**Basic exclude configuration:**
+```yaml
+- id: pod_network_outage
+  config:
+    namespace: my-application
+    label_selector: "app=my-service"
+    exclude_label: "critical=true"
+    direction:
+      - egress
+    test_duration: 600
+```
+
+In this example, network disruption is applied to all pods with the label `app=my-service` in the `my-application` namespace, except for those that also have the label `critical=true`.
+
+**Complete scenario example:**
+```yaml
+- id: pod_network_outage
+  config:
+    namespace: openshift-console
+    direction:
+      - ingress
+    ingress_ports:
+      - 8443
+    label_selector: 'component=ui'
+    exclude_label: 'excluded=true'
+    test_duration: 600
+```
+
+This scenario blocks ingress traffic on port 8443 for pods matching `component=ui` label in the `openshift-console` namespace, but will skip any pods labeled with `excluded=true`.
+
+The `exclude_label` parameter is also supported in the pod network shaping scenarios (`pod_egress_shaping` and `pod_ingress_shaping`), allowing for the same selective application of network latency, packet loss, and bandwidth restriction.

--- a/content/en/docs/scenarios/pod-network-scenario/pod-network-chaos-krkn-hub.md
+++ b/content/en/docs/scenarios/pod-network-scenario/pod-network-chaos-krkn-hub.md
@@ -51,6 +51,7 @@ Parameter               | Description                                           
 NAMESPACE               | Required - Namespace of the pod to which filter need to be applied    | ""                                     |
 LABEL_SELECTOR          | Label of the pod(s) to target                                         | ""                                   | 
 POD_NAME                | When label_selector is not specified, pod matching the name will be selected for the chaos scenario | "" |
+EXCLUDE_LABEL           | Pods matching this label will be excluded from the chaos even if they match other criteria | "" |
 INSTANCE_COUNT          | Number of pods to perform action/select that match the label selector | 1 |
 TRAFFIC_TYPE            | List of directions to apply filters - egress/ingress ( needs to be a list ) | [ingress, egress] |
 INGRESS_PORTS           | Ingress ports to block ( needs to be a list ) | [] i.e all ports |

--- a/content/en/docs/scenarios/pod-network-scenario/pod-network-scenarios-krkn.md
+++ b/content/en/docs/scenarios/pod-network-scenario/pod-network-scenarios-krkn.md
@@ -9,11 +9,12 @@ weight: 2
 - id: pod_network_outage
   config:
     namespace: openshift-console   # Required - Namespace of the pod to which filter need to be applied
-    direction:                     # Optioinal - List of directions to apply filters
+    direction:                     # Optional - List of directions to apply filters
         - ingress                  # Blocks ingress traffic, Default both egress and ingress
     ingress_ports:                 # Optional - List of ports to block traffic on
         - 8443                     # Blocks 8443, Default [], i.e. all ports.
     label_selector: 'component=ui' # Blocks access to openshift console
+    exclude_label: 'critical=true' # Optional - Pods matching this label will be excluded from the chaos
 ```
 ### Pod Network shaping
 Scenario to introduce network latency, packet loss, and bandwidth restriction in the Pod's network interface. The purpose of this scenario is to observe faults caused by random variations in the network.
@@ -24,6 +25,7 @@ Scenario to introduce network latency, packet loss, and bandwidth restriction in
   config:
     namespace: openshift-console   # Required - Namespace of the pod to which filter need to be applied.
     label_selector: 'component=ui' # Applies traffic shaping to access openshift console.
+    exclude_label: 'critical=true' # Optional - Pods matching this label will be excluded from the chaos
     network_params:
         latency: 500ms             # Add 500ms latency to egress traffic from the pod.
 ```
@@ -33,6 +35,7 @@ Scenario to introduce network latency, packet loss, and bandwidth restriction in
   config:
     namespace: openshift-console   # Required - Namespace of the pod to which filter need to be applied.
     label_selector: 'component=ui' # Applies traffic shaping to access openshift console.
+    exclude_label: 'critical=true' # Optional - Pods matching this label will be excluded from the chaos
     network_params:
         latency: 500ms             # Add 500ms latency to egress traffic from the pod.
 ```


### PR DESCRIPTION
## Documentation Update
**Related Feature:** Feature/add exclude label

**Changes:** 

Added comprehensive documentation for the new `exclude_label` feature in pod network scenario plugins. This documentation update:

1. Explains what the `exclude_label` feature is and how it works
2. Details the use cases for excluding pods from chaos testing
3. Provides configuration examples showing proper syntax
4. Shows how the feature integrates with existing pod selection parameters
5. Includes examples for both pod network outage and pod network shaping scenarios

This documentation update corresponds to the implementation PR: https://github.com/krkn-chaos/krkn/pull/811