### PR TITLE
Update RBAC documentation : Add privileged and non-privileged RBAC configurations

### DIFF
--- a/content/en/docs/krkn/rbac.md
+++ b/content/en/docs/krkn/rbac.md
@@ -4,100 +4,151 @@ description: RBAC Authorization rules required to run Krkn scenarios.
 weight: 2
 ---
 
-# RBAC rules
+# RBAC Configurations
 
-Following is the compilation of all the rbac config required to run [run_kraken](https://github.com/krkn-chaos/krkn/blob/main/run_kraken.py) and each of the krkn test scenarios.
+Krkn supports two types of RBAC configurations:
 
-> **_NOTE:_** Below configuration assumes the user executing the krkrkn as `user1` and the user would be using the namespace `testnamespace` to test his application and run krn tests.
+1. **Non-Privileged RBAC**: Provides namespace-scoped permissions for scenarios that only require access to resources within a specific namespace.
+2. **Privileged RBAC**: Provides cluster-wide permissions for scenarios that require access to cluster-level resources like nodes.
 
-## [run_kraken](https://github.com/krkn-chaos/krkn/blob/main/run_kraken.py)
+> **_NOTE:_** The examples below use placeholders such as `target-namespace` and `krkn-namespace` which should be replaced with your actual namespaces. The service account name `krkn-sa` is also a placeholder that you can customize.
 
-Allow the user to query prometheus metrics and get infrastructure,network level details.
+## RBAC YAML Files
 
-namespace/clusterRole  | apigroups  | resources | verb    
----------------------- | ---------- | --------- | ----
-openshift-monitoring   |  ""        |  "serviceaccounts/token" |   "create"
-clusterRole    | "config.openshift.io"               | "networks","infrastructures","clusterversions" | "get","list"  
+### Non-Privileged Role
 
-Allow the use user1 to view resources in test1 namespace
+The non-privileged role provides permissions limited to namespace-scoped resources:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: krkn-non-privileged-role
+  namespace: <target-namespace>
+rules:
+- apiGroups: [""]
+  resources: ["pods", "services"]
+  verbs: ["get", "list", "watch", "create", "delete"]
+- apiGroups: ["apps"]
+  resources: ["deployments", "statefulsets"]
+  verbs: ["get", "list", "watch", "create", "delete"]
+- apiGroups: ["batch"]
+  resources: ["jobs"]
+  verbs: ["get", "list", "watch", "create", "delete"]
 ```
-kubectl create rolebinding view-role-binding --clusterrole=view --user=user1 --namespace=testnamespace
+
+### Non-Privileged RoleBinding
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: krkn-non-privileged-rolebinding
+  namespace: <target-namespace>
+subjects:
+- kind: ServiceAccount
+  name: <krkn-sa>
+  namespace: <target-namespace>
+roleRef:
+  kind: Role
+  name: krkn-non-privileged-role
+  apiGroup: rbac.authorization.k8s.io
 ```
 
-## [Pod Scenarios](../scenarios/pod-scenario/_index.md)
+### Privileged ClusterRole
 
-| namespace/clusterRole  | apigroups  | resources | verb    | 
-| ---------------------- | ---------- | --------- | ---- | 
-| testnamespace    | ""               | "pods"    | "delete" | 
+The privileged ClusterRole provides permissions for cluster-wide resources:
 
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: krkn-privileged-clusterrole
+rules:
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get", "list", "watch", "create", "delete", "update", "patch"]
+- apiGroups: [""]
+  resources: ["pods", "services"]
+  verbs: ["get", "list", "watch", "create", "delete", "update", "patch"]
+- apiGroups: ["apps"]
+  resources: ["deployments", "statefulsets"]
+  verbs: ["get", "list", "watch", "create", "delete", "update", "patch"]
+- apiGroups: ["batch"]
+  resources: ["jobs"]
+  verbs: ["get", "list", "watch", "create", "delete", "update", "patch"]
+```
 
-## [Container Scenarios](../scenarios/container-scenario/_index.md) 
+### Privileged ClusterRoleBinding
 
-namespace/clusterRole  | apigroups  | resources | verb    
----------------------- | ---------- | --------- | ----
-testnamespace    | ""               | "pods","pods/exec" | "get","create","delete"
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: krkn-privileged-clusterrolebinding
+subjects:
+- kind: ServiceAccount
+  name: <krkn-sa>
+  namespace: <krkn-namespace>
+roleRef:
+  kind: ClusterRole
+  name: krkn-privileged-clusterrole
+  apiGroup: rbac.authorization.k8s.io
+```
 
-## [Service Disruption Scenarios](../scenarios/service-disruption-scenarios/_index.md) 
+## How to Apply RBAC Configuration
 
-namespace/clusterRole  | apigroups  | resources | verb    
----------------------- | ---------- | --------- | ----
-testnamespace    | ""               | "pods","pods/exec","services" | "get","create","delete"
-testnamespace    | "apps"           | "daemonsets","statefulsets","replicasets","deployments" | "get","delete"
+1. Customize the namespace in the YAML files:
+   - Replace `target-namespace` with the namespace where you want to run Krkn scenarios
+   - Replace `krkn-namespace` with the namespace where Krkn itself is deployed
 
-## [Application_outages](../scenarios/application-outage/_index.md)
+2. Create a service account for Krkn:
+   ```bash
+   kubectl create serviceaccount krkn-sa -n <namespace>
+   ```
 
-namespace/clusterRole  | apigroups  | resources | verb    
----------------------- | ---------- | --------- | ----
-testnamespace    | "networking.k8s.io"         | "networkpolicies" | "get","create","delete"
+3. Apply the RBAC configuration:
+   ```bash
+   # For non-privileged access
+   kubectl apply -f rbac/non-privileged-role.yaml
+   kubectl apply -f rbac/non-privileged-rolebinding.yaml
+   
+   # For privileged access
+   kubectl apply -f rbac/privileged-clusterrole.yaml
+   kubectl apply -f rbac/privileged-clusterrolebinding.yaml
+   ```
 
-## [PVC scenario](../scenarios/pvc-scenario/_index.md)
+## OpenShift-specific Configuration
 
-namespace/clusterRole  | apigroups  | resources | verb    
----------------------- | ---------- | --------- | ----
-testnamespace    | ""               | "pods","pods/exec" | "get","create","delete"
+For OpenShift clusters, you may need to grant the privileged Security Context Constraint (SCC) to the service account:
 
-## [Time Scenarios](../scenarios/time-scenarios/_index.md)
+```bash
+oc adm policy add-scc-to-user privileged -z krkn-sa -n <namespace>
+```
 
-namespace/clusterRole  | apigroups  | resources | verb    
----------------------- | ---------- | --------- | ----
-testnamespace    | ""               | "pods","pods/exec" | "get","create","delete"
+## Krkn Scenarios and Required RBAC Permissions
+
+The following table lists the available Krkn scenarios and their required RBAC permission levels:
+
+| Scenario Type | Plugin Type | Required RBAC | Description |
+|---------------|-------------|--------------|-------------|
+| pod_disruption_scenarios | Namespace | Non-Privileged | Scenarios that disrupt or kill pods |
+| container_scenarios | Namespace | Non-Privileged | Scenarios that affect containers |
+| service_disruption_scenarios | Namespace | Non-Privileged | Scenarios that disrupt services |
+| application_outages_scenarios | Namespace | Non-Privileged | Scenarios that cause application outages |
+| pvc_scenarios | Namespace | Non-Privileged | Scenarios that affect persistent volume claims |
+| pod_network_scenarios | Namespace | Non-Privileged | Scenarios that affect pod network connectivity |
+| service_hijacking_scenarios | Namespace | Non-Privileged | Scenarios that hijack services |
+| node_scenarios | Cluster | Privileged | Scenarios that affect nodes |
+| zone_outages_scenarios | Cluster | Privileged | Scenarios that simulate zone outages |
+| time_scenarios | Cluster | Privileged | Scenarios that manipulate system time |
+| hog_scenarios | Cluster | Privileged | Scenarios that consume resources |
+| cluster_shut_down_scenarios | Cluster | Privileged | Scenarios that shut down the cluster |
+| network_chaos_scenarios | Cluster | Privileged | Scenarios that cause network chaos |
+| network_chaos_ng_scenarios | Cluster | Privileged | Next-gen network chaos scenarios |
+| syn_flood_scenarios | Cluster | Privileged | SYN flood attack scenarios |
 
 **_NOTE:_** Grant the privileged SCC to the user running the pod, to execute all the below krkn testscenarios
 ```
 oc adm policy add-scc-to-user privileged user1
 ```
-
-## [Hog Scenarios: CPU, Memory](../scenarios/hog-scenarios/_index.md)
-
-namespace/clusterRole  | apigroups  | resources | verb    
----------------------- | ---------- | --------- | ----
-testnamespace    | ""               | "pods","pods/exec" | "get","create","delete"
-clusterRole    | ""               | "nodes","nodes/proxy" | "list","get"
-
-## [Network_Chaos](../scenarios/network-chaos-scenario/_index.md)
-
-namespace/clusterRole  | apigroups  | resources | verb    
----------------------- | ---------- | --------- | ----
-testnamespace    | ""               | "pods","pods/exec" | "get","create","delete"
-testnamespace    | "batch"              | "jobs" | "get","delete","list","create"
-clusterRole    | ""               | "nodes","nodes/proxy" | "list","get"
-
-## [Pod Network Scenarios](../scenarios/pod-network-scenario/_index.md)
-
-namespace/clusterRole  | apigroups  | resources | verb    
----------------------- | ---------- | --------- | ----
-testnamespace    | ""               | "pods","pods/exec" | "get","create","delete"
-testnamespace    | "batch"              | "jobs" | "get","delete","list","create"
-clusterRole    | ""               | "nodes","nodes/proxy" | "list","get"
-clusterRole    | "apiextensions.k8s.io"              | "customresourcedefinitions" | "get", "list", "watch"
-clusterRole    | "config.openshift.io"               | "networks" | "get"
-
-## Compounded list of all rbac rules
-
-namespace/clusterRole  | apigroups  | resources | verb    
----------------------- | ---------- | --------- | ----
-testnamespace    | ""               | "pods","pods/exec","services" | "get","create","delete"
-testnamespace    | "batch"              | "jobs" | "get","delete","list","create"
-clusterRole    | ""               | "nodes","nodes/proxy" | "list","get"
-clusterRole    | "apiextensions.k8s.io"              | "customresourcedefinitions" | "get", "list", "watch"
-clusterRole    | "config.openshift.io"               | "networks","infrastructures","clusterversions" | "get","list"


### PR DESCRIPTION
## Documentation Update: Add privileged and non-privileged RBAC configurations
Related Feature: krkn/rbac 
Issue: https://github.com/krkn-chaos/krkn/issues/759
PR: https://github.com/krkn-chaos/krkn/pull/812

Changes: 
- Added documentation for the new RBAC model in Krkn
- Created documentation for both non-privileged (namespace-scoped) and privileged (cluster-wide) RBAC configurations
- Included YAML examples for Role, RoleBinding, ClusterRole, and ClusterRoleBinding resources
- Added a detailed table mapping Krkn scenarios to their required RBAC permission levels.