### PR TITLE
Fix application outage POD_SELECTOR format in documentation [krkn/fix-app-outage-pod-selector]

### DIFF
--- a/content/en/docs/scenarios/application-outage/_index.md
+++ b/content/en/docs/scenarios/application-outage/_index.md
@@ -7,4 +7,79 @@ date: 2017-01-04
 ### Application outages
 Scenario to block the traffic ( Ingress/Egress ) of an application matching the labels for the specified duration of time to understand the behavior of the service/other services which depend on it during downtime. This helps with planning the requirements accordingly, be it improving the timeouts or tweaking the alerts etc.
 
-You can add in your applications URL into the [health checks section](../../krkn/config.md#health-checks) of the config to track the downtime of your application during this scenario 
+You can add in your applications URL into the [health checks section](../../krkn/config.md#health-checks) of the config to track the downtime of your application during this scenario
+
+## Overview
+
+This scenario creates a network outage for selected pods by applying a NetworkPolicy that blocks ingress and/or egress traffic. After the specified duration, the NetworkPolicy is automatically removed, restoring normal network connectivity.
+
+## Use Cases
+
+- Test application resilience to network disruptions
+- Validate service mesh retry and timeout configurations
+- Simulate temporary network partitions between components
+- Test failover mechanisms when connectivity is lost
+
+## How It Works
+
+1. The plugin creates a NetworkPolicy in the specified namespace with the given pod selector
+2. The NetworkPolicy is configured with empty ingress/egress rules (which explicitly denies all traffic)
+3. The policy targets only pods matching the selector labels
+4. After the specified duration, the NetworkPolicy is deleted, restoring normal traffic
+
+## Configuration
+
+This scenario can be configured with parameters that control which pods are affected, 
+what traffic is blocked, and how long the outage lasts. See the implementation-specific 
+pages for detailed configuration:
+
+- [Configuration with Krkn](./application-outage-krkn.md#configuration-parameters)
+- [Configuration with Krkn-hub](./application-outages-krkn-hub.md#configuration)
+
+
+### Requirements
+
+- A working Kubernetes/OpenShift cluster
+- kubectl/oc CLI tools configured
+- NetworkPolicy support in your cluster
+- Access to create and delete NetworkPolicies in the target namespace
+
+### Monitoring and Validation
+
+During the scenario run, you can:
+
+1. Verify the NetworkPolicy creation:
+   ```bash
+   kubectl get networkpolicy -n <namespace>
+   ```
+
+2. Test connectivity is blocked:
+   ```bash
+   kubectl run -i --rm test-pod --image=busybox --restart=Never -n <namespace> -- wget -T 5 -O- <service-name>
+   ```
+
+3. Monitor application logs and metrics to observe impact.
+
+After the duration expires, verify the NetworkPolicy is removed and traffic is restored.
+
+## Troubleshooting
+
+- Verify that the NetworkPolicy is created and deleted as expected with:
+  ```
+  kubectl get networkpolicy -n <namespace>
+  ```
+- Check application logs for connectivity issues during the test period
+- Ensure the pod selector matches the intended pods
+- If you see errors about empty pod selectors, make sure to specify at least one label in your pod_selector
+
+## Manual Recovery
+
+In case the scenario exits prematurely without cleaning up, you can manually delete the NetworkPolicy:
+
+```bash
+kubectl delete networkpolicy/krkn-deny-* -n <targeted-namespace>
+```
+
+## Demo
+
+You can find a link to a demo of the scenario [here](https://asciinema.org/a/452403?speed=3&theme=solarized-dark)

--- a/content/en/docs/scenarios/application-outage/application-outage-krkn.md
+++ b/content/en/docs/scenarios/application-outage/application-outage-krkn.md
@@ -1,20 +1,156 @@
 ---
-title: Application Outage Scenarios using Krkn
-description: 
+title: Application Outage Scenarios with Krkn
+description: Blocking traffic to applications with Krkn
 date: 2017-01-04
-weight: 2
 ---
-##### Sample scenario config
+
+## Using Application Outage Scenarios with Krkn
+
+The Application Outage scenario plugin enables simulating network connectivity issues for specific pods by creating temporary NetworkPolicies that block traffic.
+
+### Sample Scenario File
+
+Create a scenario file (e.g., `app_outage.yaml`) with the following content:
+
 ```yaml
-application_outage:                                  # Scenario to create an outage of an application by blocking traffic
-  duration: 600                                      # Duration in seconds after which the routes will be accessible
-  namespace: <namespace-with-application>            # Namespace to target - all application routes will go inaccessible if pod selector is empty
-  pod_selector: {app: foo}                            # Pods to target
-  block: [Ingress, Egress]                           # It can be Ingress or Egress or Ingress, Egress
+application_outage:
+  namespace: "app-namespace"  # Namespace containing your application
+  pod_selector:               # Target specific pods with these labels
+    app: backend
+    tier: database
+  block:                      # Traffic types to block
+    - Ingress                 # Block only incoming traffic
+    # - Egress                # Uncomment to also block outgoing traffic
+  duration: 120               # Block for 2 minutes
 ```
 
-##### Debugging steps in case of failures
-Kraken creates a network policy blocking the ingress/egress traffic to create an outage, in case of failures before reverting back the network policy, you can delete it manually by executing the following commands to stop the outage:
+### Configuration Parameters
+
+| Parameter | Type | Description | Default |
+|-----------|------|-------------|---------|
+| namespace | string | Namespace where the NetworkPolicy will be applied | (Required) |
+| pod_selector | dict | Pod selector labels for the NetworkPolicy (matchLabels) - must contain at least one key-value pair | (Required) |
+| block | list | Traffic types to block (`Ingress`, `Egress`, or both) | [Ingress, Egress] |
+| duration | int | Duration in seconds to keep traffic blocked | 60 |
+
+> **Important**: The `pod_selector` parameter must be a non-empty dictionary of Kubernetes labels to select target pods. 
+> A NetworkPolicy with an empty pod selector would apply to all pods in the namespace, which is not supported by this plugin.
+
+### Adding to Krkn Configuration
+
+Add this scenario to your Krkn configuration file:
+
+```yaml
+kraken:
+  chaos_scenarios:
+    - application_outages_scenarios:
+        - scenarios/app_outage.yaml
+```
+
+### How It Works
+
+1. The plugin creates a NetworkPolicy in the specified namespace with the given pod selector
+2. The NetworkPolicy is configured with empty ingress/egress rules (which explicitly denies all traffic)
+3. The policy targets only pods matching the selector labels
+4. After the specified duration, the NetworkPolicy is deleted, restoring normal traffic
+
+### Testing
+
+#### Unit Tests
+
+To run the unit tests for the application outage plugin:
+
 ```bash
-$ oc delete networkpolicy/kraken-deny -n <targeted-namespace>
+# Run only the application outage tests
+python -m unittest tests/application_outage_test.py
+
+# Run all tests with coverage
+python -m coverage run -m unittest discover -s tests/
+python -m coverage report -m
+```
+
+#### Integration Tests
+
+For testing with Kubernetes:
+
+1. Set up a test configuration file:
+
+```yaml
+# Save this as test-config.yaml in your Kraken root directory
+kraken:
+  chaos_scenarios:
+    - application_outages_scenarios:
+        - /krkn/test_app_outage.yaml  # Full path to your scenario file
+  kubeconfig_path: ~/.kube/config
+
+tunings:
+  wait_duration: 10
+  iterations: 1
+  daemon_mode: False
+
+cerberus:
+  cerberus_enabled: False
+```
+
+2. Create a test scenario:
+
+```yaml
+# Save this as test_app_outage.yaml in your Kraken root directory
+application_outage:
+  namespace: "default"                # Namespace containing your application pods
+  pod_selector:                       # Target specific pods with these labels
+    app: your-app-name                # Required: at least one label must be specified
+    component: your-component         # Optional: add more labels for more specific targeting
+  block:
+    - Ingress                         # Block incoming traffic
+    # - Egress                        # Uncomment to also block outgoing traffic
+  duration: 30                        # Duration in seconds before traffic is restored
+```
+
+3. Run the integration test:
+
+```bash
+# Run through Kraken
+python run_kraken.py --config test-config.yaml
+```
+
+### Manual Testing
+
+To test the network policy creation and traffic blocking:
+
+1. Create a test deployment:
+```bash
+kubectl create deployment nginx-test --image=nginx
+kubectl label deployment nginx-test app=nginx test-selector=true
+kubectl expose deployment nginx-test --port=80 --name=nginx-service
+```
+
+2. Verify initial connectivity:
+```bash
+kubectl run -i --rm test-pod --image=busybox --restart=Never -- wget -O- nginx-service
+```
+
+3. Run the application outage scenario
+4. Verify connectivity is blocked during the outage
+5. After the duration expires, verify connectivity is restored:
+```bash
+kubectl run -i --rm test-pod --image=busybox --restart=Never -- wget -O- nginx-service
+```
+
+### Troubleshooting
+
+- Verify that the NetworkPolicy is created and deleted as expected with:
+  ```
+  kubectl get networkpolicy -n <namespace>
+  ```
+- Check application logs for connectivity issues during the test period
+- Ensure the pod selector matches the intended pods
+- If you see errors about empty pod selectors, make sure to specify at least one label in your pod_selector
+
+### Manual Recovery
+
+In case the scenario exits prematurely without cleaning up, you can manually delete the NetworkPolicy:
+
+```bash
+kubectl delete networkpolicy/krkn-deny-* -n <targeted-namespace>
 ```


### PR DESCRIPTION
## Documentation Update
**Related Feature:** Application Outage scenario in Krkn-hub

**Changes:** 
- Fixed incorrect JSON format in POD_SELECTOR examples (using proper quotes)
- Added warning about empty pod selectors not being supported
- Added "Common Issues and Solutions" section with correct/incorrect examples
- Ensured consistent quoting across all command examples
- Provided guidance for multiple label selectors in same JSON object