### PR TITLE
docs: add details of kubevirt outage scenario feature

### DIFF
--- a/content/en/docs/scenarios/_index.md
+++ b/content/en/docs/scenarios/_index.md
@@ -27,8 +27,7 @@ weight: 4
 | [Pod Network Chaos](docs/scenarios/pod-network-scenario/_index.md) | pod_network_scenarios | Introduces network chaos at pod level                        | 
 | [Service Hijacking](docs/scenarios/service-hijacking-scenario/_index.md) | service_hijacking_scenarios | Hijacks a service http traffic to simulate custom HTTP responses |
 | [Syn Flood](docs/scenarios/syn-flood-scenario/_index.md) | syn_flood_scenarios | Generates a substantial amount of TCP traffic directed at one or more Kubernetes services |
-
-
+| [KubeVirt VM Outage](docs/scenarios/kubevirt-vm-outage-scenario/_index.md) | kubevirt_vm_outage | Simulates VM-level disruptions by deleting a Virtual Machine Instance (VMI) to test resilience and recovery mechanisms |
 
 ## How to Use Plugin Names
 Use the plugin type in the second column above when creating your chaos_scenarios section in the config/config.yaml file

--- a/content/en/docs/scenarios/kubevirt-vm-outage-scenario/_index.md
+++ b/content/en/docs/scenarios/kubevirt-vm-outage-scenario/_index.md
@@ -1,0 +1,106 @@
+---
+title: KubeVirt VM Outage Scenario
+description: Simulating VM-level disruptions in KubeVirt/OpenShift CNV environments
+date: 2025-05-17
+---
+
+This scenario enables the simulation of VM-level disruptions in clusters where KubeVirt or OpenShift Containerized Network Virtualization (CNV) is installed. It allows users to delete a Virtual Machine Instance (VMI) to simulate a VM crash and test recovery capabilities.
+
+## Purpose
+
+The `kubevirt_vm_outage` scenario deletes a specific KubeVirt Virtual Machine Instance (VMI) to simulate a VM crash or outage. This helps users:
+
+- Test the resilience of applications running inside VMs
+- Verify that VM monitoring and recovery mechanisms work as expected
+- Validate high availability configurations for VM workloads
+- Understand the impact of sudden VM failures on workloads and the overall system
+
+## Prerequisites
+
+Before using this scenario, ensure the following:
+
+1. KubeVirt or OpenShift CNV is installed in your cluster
+2. The target VMI exists and is running in the specified namespace
+3. You have the kubevirt Python client installed (included in krkn requirements.txt)
+4. Your cluster credentials have sufficient permissions to delete and create VMIs
+
+## Parameters
+
+The scenario supports the following parameters:
+
+| Parameter | Description | Required | Default |
+|-----------|-------------|----------|---------|
+| vm_name | The name of the VMI to delete | Yes | N/A |
+| namespace | The namespace where the VMI is located | No | "default" |
+| duration | How long to wait (in seconds) before attempting recovery | No | 60 |
+
+## Expected Behavior
+
+When executed, the scenario will:
+
+1. Validate that KubeVirt is installed and the target VMI exists
+2. Save the initial state of the VMI
+3. Delete the VMI using the KubeVirt API
+4. Wait for the specified duration
+5. Attempt to recover the VMI:
+   - If the VMI is managed by a VirtualMachine resource with runStrategy: Always, it will automatically recover
+   - If automatic recovery doesn't occur, the plugin will manually recreate the VMI using the saved state
+6. Validate that the VMI is running again
+
+{{% alert title="Note" %}}If the VM is managed by a VirtualMachine resource with `runStrategy: Always`, KubeVirt will automatically try to recreate the VMI after deletion. In this case, the scenario will wait for this automatic recovery to complete.{{% /alert %}}
+
+## Sample Configuration
+
+Here's an example configuration for using the `kubevirt_vm_outage` scenario:
+
+```yaml
+scenarios:
+  - name: "kubevirt outage test"
+    scenario: kubevirt_vm_outage
+    parameters:
+      vm_name: my-vm
+      namespace: kubevirt
+      duration: 60
+```
+
+For multiple VMs in different namespaces:
+
+```yaml
+scenarios:
+  - name: "kubevirt outage test - app VM"
+    scenario: kubevirt_vm_outage
+    parameters:
+      vm_name: app-vm
+      namespace: application
+      duration: 120
+  
+  - name: "kubevirt outage test - database VM"
+    scenario: kubevirt_vm_outage
+    parameters:
+      vm_name: db-vm
+      namespace: database
+      duration: 180
+```
+
+## Recovery Strategies
+
+The plugin implements two recovery strategies:
+
+1. **Automated Recovery**: If the VM is managed by a VirtualMachine resource with `runStrategy: Always`, the plugin will wait for KubeVirt's controller to automatically recreate the VMI.
+
+2. **Manual Recovery**: If automatic recovery doesn't occur within the timeout period, the plugin will attempt to manually recreate the VMI using the saved state from before the deletion.
+
+## Limitations
+
+- The scenario currently supports deleting a single VMI at a time
+- If VM spec changes during the outage window, the manual recovery may not reflect those changes
+- The scenario doesn't simulate partial VM failures (e.g., VM freezing) - only complete VM outage
+
+## Troubleshooting
+
+If the scenario fails, check the following:
+
+1. Ensure KubeVirt/CNV is properly installed in your cluster
+2. Verify that the target VMI exists and is running
+3. Check that your credentials have sufficient permissions to delete and create VMIs
+4. Examine the logs for specific error messages

--- a/content/en/docs/scenarios/kubevirt-vm-outage-scenario/kubevirt-vm-outage-scenario-krkn.md
+++ b/content/en/docs/scenarios/kubevirt-vm-outage-scenario/kubevirt-vm-outage-scenario-krkn.md
@@ -1,0 +1,90 @@
+---
+title: KubeVirt VM Outage Scenario - Kraken
+description: Detailed implementation of the KubeVirt VM Outage Scenario in Kraken
+date: 2025-05-17
+---
+
+# KubeVirt VM Outage Scenario in Kraken
+
+The `kubevirt_vm_outage` scenario in Kraken enables users to simulate VM-level disruptions by deleting a Virtual Machine Instance (VMI) to test resilience and recovery capabilities.
+
+## Implementation
+
+This scenario is implemented in Kraken's core repository, with the following key functionality:
+
+1. Finding and validating the target VMI
+2. Deleting the VMI using the KubeVirt API
+3. Monitoring the recovery process
+4. Implementing fallback recovery if needed
+
+## Usage
+
+You can use this scenario in your Kraken configuration file as follows:
+
+```yaml
+scenarios:
+  - name: "kubevirt vm outage"
+    scenario: kubevirt_vm_outage
+    parameters:
+      vm_name: <my-application-vm>
+      namespace: <vm-workloads>
+      duration: 60
+```
+
+## Detailed Parameters
+
+| Parameter | Description | Required | Default | Example Values |
+|-----------|-------------|----------|---------|----------------|
+| vm_name | The name of the VMI to delete | Yes | N/A | "database-vm", "web-server-vm" |
+| namespace | The namespace where the VMI is located | No | "default" | "openshift-cnv", "vm-workloads" |
+| duration | How long to wait (in seconds) before attempting recovery | No | 60 | 30, 120, 300 |
+
+## Execution Flow
+
+When executed, the scenario follows this process:
+
+1. **Initialization**: Validates KubeVirt is installed and configures the KubeVirt client
+2. **VMI Validation**: Checks if the target VMI exists and is in Running state
+3. **State Preservation**: Saves the initial state of the VMI
+4. **Chaos Injection**: Deletes the VMI using the KubeVirt API
+5. **Wait Period**: Waits for the specified duration
+6. **Recovery Monitoring**: Checks if the VMI is automatically restored
+7. **Manual Recovery**: If automatic recovery doesn't occur, manually recreates the VMI
+8. **Validation**: Confirms the VMI is running correctly
+
+## Integration with KubeVirt API
+
+The scenario utilizes the KubeVirt Python client to interact with the KubeVirt API. Key API operations include:
+
+- Reading VMI objects: `kubevirt_api.read_namespaced_virtual_machine_instance()`
+- Deleting VMI objects: `kubevirt_api.delete_namespaced_virtual_machine_instance()`
+- Creating VMI objects: `kubevirt_api.create_namespaced_virtual_machine_instance()`
+
+## Advanced Use Cases
+
+### Testing High Availability VM Configurations
+
+This scenario is particularly useful for testing high availability configurations, such as:
+
+- Clustered applications running across multiple VMs
+- VMs with automatic restart policies
+- Applications with cross-VM resilience mechanisms
+
+### Combining with Other Scenarios
+
+For more comprehensive testing, you can combine this scenario with other Kraken scenarios:
+
+```yaml
+scenarios:
+  - name: "node outage with vm recovery test"
+    scenario: node_stop_start_scenario
+    parameters:
+      # Node scenario parameters
+  
+  - name: "vm outage during node recovery"
+    scenario: kubevirt_vm_outage
+    parameters:
+      vm_name: <critical-vm>
+      namespace: <production>
+      duration: 120
+```


### PR DESCRIPTION
## Documentation Update
**Related Feature:**  
KubeVirt VM Outage Scenario 
Issue : https://github.com/krkn-chaos/krkn/issues/762
PR : https://github.com/krkn-chaos/krkn/pull/816

**Changes:**  
- Added documentation for the new KubeVirt VM Outage Scenario
- Created a dedicated scenario page with purpose, prerequisites, and parameters
- Added detailed implementation guide for Kraken integration
- Updated the main scenarios index to include the new scenario
- Included sample configurations and usage examples
- Documented recovery strategies and troubleshooting steps

The documentation follows the existing structure and format of other scenario documentation in the repository.