### PR TITLE
Docs/what is krkn punctuation-issue #77

### DIFF
--- a/content/en/docs/krkn/_index.md
+++ b/content/en/docs/krkn/_index.md
@@ -35,7 +35,7 @@ Fail test if certain metrics aren't met at the end of the run
 ### Signaling
 In CI runs or any external job it is useful to stop Krkn once a certain test or state gets reached. We created a way to signal to Krkn to pause the chaos or stop it completely using a signal posted to a port of your choice.
 
-For example if we have a test run loading the cluster running and Krkn separately running; we want to be able to know when to start/stop the Krkn run based on when the test run completes or gets to a certain loaded state.
+For example, if we have a test run loading the cluster running and Krkn separately running, we want to be able to know when to start/stop the Krkn run based on when the test run completes or when it gets to a certain loaded state
 
 More detailed information on enabling and leveraging this feature can be found [here](signal.md).
 


### PR DESCRIPTION
## Documentation Update
**Related Feature:** 

branch name: punctuation-issue

**Changes:** 

Before:
“For example if we have a test run loading the cluster running and Krkn separately running; we want to be able to know when to start/stop the Krkn run based on when the test run completes or gets to a certain loaded state.”

After:
“For example, if we have a test run loading the cluster running and Krkn separately running, we want to be able to know when to start/stop the Krkn run based on when the test run completes or when it gets to a certain loaded state”

Closed #77 