### PR TITLE
Pod network image

### DIFF
--- a/content/en/docs/scenarios/network-chaos-scenario/network-chaos-scenario-krkn-hub.md
+++ b/content/en/docs/scenarios/network-chaos-scenario/network-chaos-scenario-krkn-hub.md
@@ -51,6 +51,7 @@ See list of variables that apply to all scenarios [here](/docs/scenarios/all-sce
 Parameter               | Description                                                           | Default
 ----------------------- | -----------------------------------------------------------------     | ------------------------------------ |
 DURATION                | Duration in seconds - during with network chaos will be applied.         | 300                                  |
+IMAGE | Image used to disrupt network on a pod  |  quay.io/krkn-chaos/krkn:tools | 
 NODE_NAME               | Node name to inject faults in case of targeting a specific node; Can set multiple node names separated by a comma      | ""                                   |
 LABEL_SELECTOR          | When NODE_NAME is not specified, a node with matching label_selector is selected for running.          | node-role.kubernetes.io/master       |
 INSTANCE_COUNT          | Targeted instance count matching the label selector                   | 1                                   |
@@ -64,6 +65,7 @@ EGRESS          | Dictonary of values to set  network latency(latency: 50ms), pa
 Parameter               | Description                                                           | Default
 ----------------------- | -----------------------------------------------------------------     | ------------------------------------ |
 DURATION                | Duration in seconds - during with network chaos will be applied.         | 300                                  |
+IMAGE | Image used to disrupt network on a pod  |  quay.io/krkn-chaos/krkn:tools | 
 TARGET_NODE_AND_INTERFACE               |  # Dictionary with key as node name(s) and value as a list of its interfaces to test. For example: {ip-10-0-216-2.us-west-2.compute.internal: [ens5]}      | ""                                   |
 LABEL_SELECTOR          | When NODE_NAME is not specified, a node with matching label_selector is selected for running.          | node-role.kubernetes.io/master       |
 INSTANCE_COUNT          | Targeted instance count matching the label selector                   | 1                                   |
@@ -71,9 +73,15 @@ EXECUTION          |  Used to specify whether you want to apply filters on inter
 NETWORK_PARAMS     | latency, loss and bandwidth are the three supported network parameters to alter for the chaos test. For example: {latency: 50ms, loss: '0.02'} | "" |
 WAIT_DURATION           | Ensure that it is at least about twice of test_duration               | 300                                   |
 
+{{% alert title="Note" %}} For disconnected clusters, be sure to also mirror the helper image of quay.io/krkn-chaos/krkn:tools and set the mirrored image path properly  {{% /alert %}}
+
+
+
 
 {{% alert title="Note" %}} In case of using custom metrics profile or alerts profile when `CAPTURE_METRICS` or `ENABLE_ALERTS` is enabled, mount the metrics profile from the host on which the container is run using podman/docker under `/home/krkn/kraken/config/metrics-aggregated.yaml` and `/home/krkn/kraken/config/alerts`.{{% /alert %}}
  For example:
 ```bash
 $ podman run --name=<container_name> --net=host --env-host=true -v <path-to-custom-metrics-profile>:/home/krkn/kraken/config/metrics-aggregated.yaml -v <path-to-custom-alerts-profile>:/home/krkn/kraken/config/alerts -v <path-to-kube-config>:/home/krkn/.kube/config:Z -d containers.krkn-chaos.dev/krkn-chaos/krkn-hub:network-chaos
 ```
+
+

--- a/content/en/docs/scenarios/network-chaos-scenario/network-chaos-scenario-krkn.md
+++ b/content/en/docs/scenarios/network-chaos-scenario/network-chaos-scenario-krkn.md
@@ -18,6 +18,7 @@ network_chaos:                                    # Scenario to create an outage
     latency: 500ms
     loss: 50%                                    # percentage
     bandwidth: 10mbit
+  image: quay.io/krkn-chaos/krkn:tools
 ```
 
 ##### Sample scenario config for ingress traffic shaping (using a plugin)
@@ -39,6 +40,7 @@ network_chaos:                                    # Scenario to create an outage
         bandwidth: 10mbit
     wait_duration: 120
     test_duration: 60
+    image: quay.io/krkn-chaos/krkn:tools
 ```
 
 Note: For ingress traffic shaping, ensure that your node doesn't have any [IFB](https://wiki.linuxfoundation.org/networking/ifb) interfaces already present. The scenario relies on creating IFBs to do the shaping, and they are deleted at the end of the scenario.

--- a/content/en/docs/scenarios/network-chaos-scenario/network-chaos-scenario-krknctl.md
+++ b/content/en/docs/scenarios/network-chaos-scenario/network-chaos-scenario-krknctl.md
@@ -16,6 +16,7 @@ Scenario specific parameters:
 | Parameter      | Description    | Type      |  Default | 
 | ----------------------- | ----------------------    | ----------------  | ------------------------------------ |
 ~-~-traffic-type | Selects the network chaos scenario type can be ingress or egress | enum |   ingress|egress
+~-~-image | Image used to disrupt network on a pod  | string |  quay.io/krkn-chaos/krkn:tools | 
 ~-~-duration| Duration in seconds - during with network chaos will be applied. | number| 300 | 
 ~-~-label-selector| When NODE_NAME is not specified, a node with matching label_selector is selected for running. | string| node-role.kubernetes.io/master |
 ~-~-execution parallel|serial: Execute each of the egress option as a single scenario(parallel) or as separate scenario(serial). | enum| parallel| ~-~-instance-count| Targeted instance count matching the label selector. | number| 1| 

--- a/content/en/docs/scenarios/pod-network-scenario/pod-network-chaos-krkn-hub.md
+++ b/content/en/docs/scenarios/pod-network-scenario/pod-network-chaos-krkn-hub.md
@@ -49,6 +49,7 @@ See list of variables that apply to all scenarios [here](/docs/scenarios/all-sce
 Parameter               | Description                                                           | Default
 ----------------------- | -----------------------------------------------------------------     | ------------------------------------ |
 NAMESPACE               | Required - Namespace of the pod to which filter need to be applied    | ""                                     |
+IMAGE               | Image used to disrupt network on a pod   | "quay.io/krkn-chaos/krkn:tools"                                     |
 LABEL_SELECTOR          | Label of the pod(s) to target                                         | ""                                   | 
 POD_NAME                | When label_selector is not specified, pod matching the name will be selected for the chaos scenario | "" |
 EXCLUDE_LABEL           | Pods matching this label will be excluded from the chaos even if they match other criteria | "" |
@@ -58,6 +59,9 @@ INGRESS_PORTS           | Ingress ports to block ( needs to be a list ) | [] i.e
 EGRESS_PORTS            | Egress ports to block ( needs to be a list ) | [] i.e all ports |
 WAIT_DURATION           | Ensure that it is at least about twice of test_duration | 300 |
 TEST_DURATION           | Duration of the test run | 120 |
+
+{{% alert title="Note" %}} For disconnected clusters, be sure to also mirror the helper image of quay.io/krkn-chaos/krkn:tools and set the mirrored image path properly  {{% /alert %}}
+
 
 
 {{% alert title="Note" %}} In case of using custom metrics profile or alerts profile when `CAPTURE_METRICS` or `ENABLE_ALERTS` is enabled, mount the metrics profile from the host on which the container is run using podman/docker under `/home/krkn/kraken/config/metrics-aggregated.yaml` and `/home/krkn/kraken/config/alerts`.{{% /alert %}}

--- a/content/en/docs/scenarios/pod-network-scenario/pod-network-chaos-krknctl.md
+++ b/content/en/docs/scenarios/pod-network-scenario/pod-network-chaos-krknctl.md
@@ -16,6 +16,7 @@ Scenario specific parameters:
 | Parameter      | Description    | Type      |  Default | 
 | ----------------------- | ----------------------    | ----------------  | ------------------------------------ | 
 ~-~-namespace | Namespace of the pod to which filter need to be applied  | string |
+~-~-image | Image used to disrupt network on a pod  | string |  quay.io/krkn-chaos/krkn:tools | 
 ~-~-label-selector | When pod_name is not specified, pod matching the label will be selected for the chaos scenario  | string |
 ~-~-pod-name | When label_selector is not specified, pod matching the name will be selected for the chaos scenario  | string | 
 ~-~-instance-count | Targeted instance count matching the label selector  | number |  1 |

--- a/content/en/docs/scenarios/pod-network-scenario/pod-network-scenarios-krkn.md
+++ b/content/en/docs/scenarios/pod-network-scenario/pod-network-scenarios-krkn.md
@@ -15,7 +15,10 @@ weight: 1
         - 8443                     # Blocks 8443, Default [], i.e. all ports.
     label_selector: 'component=ui' # Blocks access to openshift console
     exclude_label: 'critical=true' # Optional - Pods matching this label will be excluded from the chaos
+    image: quay.io/krkn-chaos/krkn:tools
 ```
+
+
 ### Pod Network shaping
 Scenario to introduce network latency, packet loss, and bandwidth restriction in the Pod's network interface. The purpose of this scenario is to observe faults caused by random variations in the network.
 
@@ -28,6 +31,7 @@ Scenario to introduce network latency, packet loss, and bandwidth restriction in
     exclude_label: 'critical=true' # Optional - Pods matching this label will be excluded from the chaos
     network_params:
         latency: 500ms             # Add 500ms latency to egress traffic from the pod.
+    image: quay.io/krkn-chaos/krkn:tools
 ```
 ##### Sample scenario config for ingress traffic shaping (using plugin)
 ```yaml
@@ -38,6 +42,7 @@ Scenario to introduce network latency, packet loss, and bandwidth restriction in
     exclude_label: 'critical=true' # Optional - Pods matching this label will be excluded from the chaos
     network_params:
         latency: 500ms             # Add 500ms latency to egress traffic from the pod.
+    image: quay.io/krkn-chaos/krkn:tools
 ```
 
 ##### Steps


### PR DESCRIPTION
## Documentation Update
**Related Feature:** 

Please include the branch name where you have made changes or added new features/scenario that we need on the website (e.g., `krkn/new_scenario`) in the title of this PR.

**Changes:** 

Adding tools image option for pod network and network scenarios for disconnected clusters to be able to set their own image 

Related PRs 
https://github.com/krkn-chaos/krkn/pull/883
https://github.com/krkn-chaos/krkn-hub/pull/286