### PR TITLE
pod-ingress and egress network shaping porting to network-chaos-ng

### DIFF
--- a/content/en/docs/scenarios/network-chaos-ng-scenarios/_index.md
+++ b/content/en/docs/scenarios/network-chaos-ng-scenarios/_index.md
@@ -2,7 +2,7 @@
 type: "docs/scenarios"
 title: Network Chaos NG Scenarios
 description: 
-date: 2017-01-04
+date: 2025-08-18
 weight: 3
 ---
 
@@ -10,5 +10,7 @@ This scenario introduce a new infrastructure to refactor and port the current im
 
 ### Available Scenarios
 #### Network Chaos NG scenarios:
-- [Pod Network Filter](/docs/scenarios/network-chaos-ng-scenarios/pod-network-filter/_index.md)
 - [Node Network Filter](/docs/scenarios/network-chaos-ng-scenarios/node-network-filter/_index.md)
+- [Pod Network Filter](/docs/scenarios/network-chaos-ng-scenarios/pod-network-filter/_index.md)
+- [Pod Ingress Network Shaping](/docs/scenarios/network-chaos-ng-scenarios/pod-ingress-shaping/_index.md)
+- [Pod Egress Network Shaping](/docs/scenarios/network-chaos-ng-scenarios/pod-egress-shaping/_index.md)

--- a/content/en/docs/scenarios/network-chaos-ng-scenarios/pod-egress-shaping/_index.md
+++ b/content/en/docs/scenarios/network-chaos-ng-scenarios/pod-egress-shaping/_index.md
@@ -1,0 +1,7 @@
+---
+title: Pod Egress Network Shaping
+description: 
+date: 2017-01-04
+---
+
+Scenario to introduce network latency, packet loss, and bandwidth restriction in the Pod’s Egress network interface. The purpose of this scenario is to observe faults caused by random variations in the network.

--- a/content/en/docs/scenarios/network-chaos-ng-scenarios/pod-egress-shaping/pod-egress-shaping-krkn-hub.md
+++ b/content/en/docs/scenarios/network-chaos-ng-scenarios/pod-egress-shaping/pod-egress-shaping-krkn-hub.md
@@ -1,0 +1,76 @@
+---
+title: Pod Network Egress Network Shaping using krkn-hub
+description: >
+date: 2025-08-18
+weight: 2
+---
+This scenario runs network chaos at the pod level on a Kubernetes/OpenShift cluster.
+
+#### Run
+
+If enabling [Cerberus](/docs/cerberus/) to monitor the cluster and pass/fail the scenario post chaos, refer [docs](/docs/cerberus/). Make sure to start it before injecting the chaos and set `CERBERUS_ENABLED` environment variable for the chaos injection container to autoconnect.
+
+```bash
+$ podman run --name=<container_name> --net=host --env-host=true -v <path-to-kube-config>:/home/krkn/.kube/config:Z -d containers.krkn-chaos.dev/krkn-chaos/krkn-hub:pod-egress-shaping
+$ podman logs -f <container_name or container_id> # Streams Kraken logs
+$ podman inspect <container-name or container-id> --format "{{.State.ExitCode}}" # Outputs exit code which can considered as pass/fail for the scenario
+```
+{{% alert title="Note" %}} --env-host: This option is not available with the remote Podman client, including Mac and Windows (excluding WSL2) machines. 
+Without the --env-host option you'll have to set each enviornment variable on the podman command line like  `-e <VARIABLE>=<value>`
+{{% /alert %}}
+
+
+```bash
+$ docker run $(./get_docker_params.sh) --name=<container_name> --net=host -v <path-to-kube-config>:/home/krkn/.kube/config:Z -d containers.krkn-chaos.dev/krkn-chaos/krkn-hub:pod-egress-shaping
+OR 
+$ docker run -e <VARIABLE>=<value> --name=<container_name> --net=host -v <path-to-kube-config>:/home/krkn/.kube/config:Z -d containers.krkn-chaos.dev/krkn-chaos/krkn-hub:pod-egress-shaping
+
+$ docker logs -f <container_name or container_id> # Streams Kraken logs
+$ docker inspect <container-name or container-id> --format "{{.State.ExitCode}}" # Outputs exit code which can considered as pass/fail for the scenario
+```
+
+{{% alert title="Tip" %}} Because the container runs with a non-root user, ensure the kube config is globally readable before mounting it in the container. You can achieve this with the following commands:
+```kubectl config view --flatten > ~/kubeconfig && chmod 444 ~/kubeconfig && docker run $(./get_docker_params.sh) --name=<container_name> --net=host -v ~kubeconfig:/home/krkn/.kube/config:Z -d containers.krkn-chaos.dev/krkn-chaos/krkn-hub:<scenario>``` {{% /alert %}}
+#### Supported parameters
+
+The following environment variables can be set on the host running the container to tweak the scenario/faults being injected:
+
+Example if --env-host is used:
+```
+export <parameter_name>=<value>
+```
+OR on the command line like example: 
+
+```
+-e <VARIABLE>=<value> 
+```
+See list of variables that apply to all scenarios [here](/docs/scenarios/all-scenario-env.md) that can be used/set in addition to these scenario specific variables
+
+
+| Parameter               | Description                                                           | Default
+----------------------- | -----------------------------------------------------------------     | ------------------------------------ |
+| IMAGE         | The scenario workload container image | quay.io/krkn-chaos/krkn:tools | 
+| TOTAL_CHAOS_DURATION | Duration in seconds - during with network chaos will be applied. | 60 |
+| POD_SELECTOR  | Label of the pod(s) to target | "" |
+| EXECUTION            | sets the execution mode of the scenario on multiple pods, can be parallel or serial                                              | "parallel"                        |
+| NAMESPACE               | Required - Namespace of the pod to which filter need to be applied    | ""                                     |
+| INSTANCE_COUNT          | Number of pods to perform action/select that match the label selector | 1 |
+| POD_NAME                | When label_selector is not specified, pod matching the name will be selected for the chaos scenario | "" |
+| SERVICE_ACCOUNT | The service account that the workload will run with. This is especially useful for privileged workloads, as it can be configured to bypass cluster security restrictions.| "" |
+| TAINTS | A list of comma sepaerated taints that the node might have that will be transformed on workload tolerations | "" |
+| LATENCY | Injects IP packet latency on the pod interface,  value is a string eg. 50ms| "" |
+| LOSS | Injects a percentage of IP packet loss on the pod interface, value is a string eg. 90% | "" |
+| BANDWIDTH | Injects a bandwidth restriction on the pod interface, value is a string eg. 1mbps | "" |
+| NETWORK_SHAPING_EXECUTION | sets the execution mode for the three network disruptions available can be serial or parallel | parallel |
+
+
+
+{{% alert title="Note" %}} For disconnected clusters, be sure to also mirror the helper image of quay.io/krkn-chaos/krkn:tools and set the mirrored image path properly  {{% /alert %}}
+
+
+
+{{% alert title="Note" %}} In case of using custom metrics profile or alerts profile when `CAPTURE_METRICS` or `ENABLE_ALERTS` is enabled, mount the metrics profile from the host on which the container is run using podman/docker under `/home/krkn/kraken/config/metrics-aggregated.yaml` and `/home/krkn/kraken/config/alerts`.{{% /alert %}}
+ For example:
+```bash
+$ podman run --name=<container_name> --net=host --env-host=true -v <path-to-custom-metrics-profile>:/home/krkn/kraken/config/metrics-aggregated.yaml -v <path-to-custom-alerts-profile>:/home/krkn/kraken/config/alerts -v <path-to-kube-config>:/home/krkn/.kube/config:Z -d containers.krkn-chaos.dev/krkn-chaos/krkn-hub:pod-egress-shaping
+```

--- a/content/en/docs/scenarios/network-chaos-ng-scenarios/pod-egress-shaping/pod-egress-shaping-krkn.md
+++ b/content/en/docs/scenarios/network-chaos-ng-scenarios/pod-egress-shaping/pod-egress-shaping-krkn.md
@@ -1,0 +1,47 @@
+---
+title: Pod Network Egress Network Shaping using Krkn 
+description: 
+date: 2025-08-18
+weight: 1
+---
+##### Sample scenario config for egress traffic shaping
+```yaml
+- id: pod_egress_shaping
+  image: docker.io/fedora/tools       # scenario workload image
+  wait_duration: <time_duration>      # Default is 300. Ensure that it is at least about twice of test_duration
+  test_duration: <time_duration>      # Default is 120
+  label_selector: <label_selector>    # When pod_name is not specified, pod with matching label_selector is selected for chaos scenario
+  execution: <serial/parallel>        # used to specify wheter you want to apply filters on multiple targets
+  namespace: <namespace>              # Required - Namespace of the pod to which traffic shaping need to be applied
+  instance_count: <number>            # Number of pods to perform action/select that match the label selector
+  target: <pod name>                # When label_selector is not specified, pod matching the name will be selected for the chaos scenario
+  service_account: ""
+  taints: [ ] # example ["node-role.kubernetes.io/master:NoSchedule"]
+
+  # latency, loss and bandwidth are the three supported network parameters to alter for the chaos test
+  latency: <time>                 # Value is a string. For example : 50ms
+  loss: <fraction>                # Loss is a fraction between 0 and 1. It has to be enclosed in quotes to treat it as a string. For example, '0.02%' (not 0.02%)
+  bandwidth: <rate>               # Value is a string. For example: 100mbit
+  network_shaping_execution: <serial/parallel> # Used to specify whether you want to apply filters on interfaces one at a time or all at once. Default is 'parallel'
+```
+
+
+
+##### Steps
+ - Pick the pods to introduce the network anomaly either from label_selector or target.
+ - Identify the pod interface name on the node.
+ - Set traffic shaping config on pod's interface using tc and netem.
+ - Wait for the duration time.
+ - Remove traffic shaping config on pod's interface.
+ - Remove the job that spawned the pod.
+
+### How to Use Plugin Name
+Add the plugin name to the list of chaos_scenarios section in the config/config.yaml file
+```yaml
+kraken:
+    kubeconfig_path: ~/.kube/config                     # Path to kubeconfig
+    .. 
+    chaos_scenarios:
+        - network_chaos_ng_scenarios:
+            - scenarios/<scenario_name>.yaml
+  ```

--- a/content/en/docs/scenarios/network-chaos-ng-scenarios/pod-egress-shaping/pod-egress-shaping-krknctl.md
+++ b/content/en/docs/scenarios/network-chaos-ng-scenarios/pod-egress-shaping/pod-egress-shaping-krknctl.md
@@ -1,0 +1,36 @@
+---
+title: Pod Network Egress Network Shaping using krknctl
+description: 
+date: 2017-01-04
+weight: 3
+---
+
+```bash
+krknctl run pod-egress-shaping (optional: --<parameter>:<value> )
+```
+
+Can also set any global variable listed [here](../all-scenario-env-krknctl.md)
+
+
+Scenario specific parameters: 
+| Parameter      | Description    | Type      |  Default | 
+| ----------------------- | ----------------------    | ----------------  | ------------------------------------ | 
+| ~-~-image |The scenario workload container image | quay.io/krkn-chaos/krkn:tools | 
+| ~-~-total-chaos-duration | Duration of the test run  | number |  60 |
+| ~-~-pod-selector | When pod_name is not specified, pod matching the label will be selected for the chaos scenario  | string | "" |
+| ~-~-execution |Sets the execution mode of the scenario on multiple pods, can be parallel or serial | parallel | 
+| ~-~-namespace | Namespace of the pod to which filter need to be applied  | string | default |
+| ~-~-instance-count | Targeted instance count matching the label selector  | number |  1 |
+| ~-~-pod-name | When label_selector is not specified, pod matching the name will be selected for the chaos scenario  | string | "" |
+| ~-~-service-account | The service account that the workload will run with. This is especially useful for privileged workloads, as it can be configured to bypass cluster security restrictions.| "" |
+| ~-~-taints | A list of comma sepaerated taints that the node might have that will be transformed on workload tolerations | "" |
+| ~-~-latency | Injects IP packet latency on the pod interface,  value is a string eg. 50ms| "" |
+| ~-~-loss | Injects a percentage of IP packet loss on the pod interface, value is a string eg. 90% | "" |
+| ~-~-bandwidth | Injects a bandwidth restriction on the pod interface, value is a string eg. 1mbps | "" |
+| ~-~-network-shaping-execution | sets the execution mode for the three network disruptions available can be serial or parallel | parallel |
+
+
+To see all available scenario options 
+```bash
+krknctl run pod-network-chaos --help 
+```

--- a/content/en/docs/scenarios/network-chaos-ng-scenarios/pod-ingress-shaping/_index.md
+++ b/content/en/docs/scenarios/network-chaos-ng-scenarios/pod-ingress-shaping/_index.md
@@ -1,0 +1,8 @@
+---
+title: Pod Ingress Network Shaping
+description: 
+date: 2017-01-04
+---
+
+Scenario to introduce network latency, packet loss, and bandwidth restriction in the Pod’s Ingress network interface. The purpose of this scenario is to observe faults caused by random variations in the network.
+

--- a/content/en/docs/scenarios/network-chaos-ng-scenarios/pod-ingress-shaping/pod-ingress-shaping-krkn.md
+++ b/content/en/docs/scenarios/network-chaos-ng-scenarios/pod-ingress-shaping/pod-ingress-shaping-krkn.md
@@ -1,0 +1,48 @@
+---
+title: Pod Network Ingress Network Shaping using Krkn 
+description: 
+date: 2025-08-18
+weight: 1
+---
+##### Sample scenario config for ingress traffic shaping
+```yaml
+- id: pod_ingress_shaping
+  image: docker.io/fedora/tools       # scenario workload image
+  wait_duration: <time_duration>      # Default is 300. Ensure that it is at least about twice of test_duration
+  test_duration: <time_duration>      # Default is 120
+  label_selector: <label_selector>    # When pod_name is not specified, pod with matching label_selector is selected for chaos scenario
+  execution: <serial/parallel>        # used to specify wheter you want to apply filters on multiple targets
+  namespace: <namespace>              # Required - Namespace of the pod to which traffic shaping need to be applied
+  instance_count: <number>            # Number of pods to perform action/select that match the label selector
+  target: <pod name>                # When label_selector is not specified, pod matching the name will be selected for the chaos scenario
+  service_account: ""
+  taints: [ ] # example ["node-role.kubernetes.io/master:NoSchedule"]
+
+  # latency, loss and bandwidth are the three supported network parameters to alter for the chaos test
+  latency: <time>                 # Value is a string. For example : 50ms
+  loss: <fraction>                # Loss is a fraction between 0 and 1. It has to be enclosed in quotes to treat it as a string. For example, '0.02%' (not 0.02%)
+  bandwidth: <rate>               # Value is a string. For example: 100mbit
+  network_shaping_execution: <serial/parallel> # Used to specify whether you want to apply filters on interfaces one at a time or all at once. Default is 'parallel'
+```
+
+Note: For ingress traffic shaping, ensure that your node doesn't have any [IFB](https://wiki.linuxfoundation.org/networking/ifb) interfaces already present. The scenario relies on creating IFBs to do the shaping, and they are deleted at the end of the scenario.
+
+
+##### Steps
+ - Pick the pods to introduce the network anomaly either from label_selector or target.
+ - Identify the pod interface name on the node.
+ - Set traffic shaping config on pod's interface using tc and netem.
+ - Wait for the duration time.
+ - Remove traffic shaping config on pod's interface.
+ - Remove the job that spawned the pod.
+
+### How to Use Plugin Name
+Add the plugin name to the list of chaos_scenarios section in the config/config.yaml file
+```yaml
+kraken:
+    kubeconfig_path: ~/.kube/config                     # Path to kubeconfig
+    .. 
+    chaos_scenarios:
+        - network_chaos_ng_scenarios:
+            - scenarios/<scenario_name>.yaml
+  ```

--- a/content/en/docs/scenarios/network-chaos-ng-scenarios/pod-ingress-shaping/pod-ingress-shaping-krknctl.md
+++ b/content/en/docs/scenarios/network-chaos-ng-scenarios/pod-ingress-shaping/pod-ingress-shaping-krknctl.md
@@ -1,0 +1,36 @@
+---
+title: Pod Network Ingress Network Shaping using krknctl
+description: 
+date: 2017-01-04
+weight: 3
+---
+
+```bash
+krknctl run pod-ingress-shaping (optional: --<parameter>:<value> )
+```
+
+Can also set any global variable listed [here](../all-scenario-env-krknctl.md)
+
+
+Scenario specific parameters: 
+| Parameter      | Description    | Type      |  Default | 
+| ----------------------- | ----------------------    | ----------------  | ------------------------------------ | 
+| ~-~-image |The scenario workload container image | quay.io/krkn-chaos/krkn:tools | 
+| ~-~-total-chaos-duration | Duration of the test run  | number |  60 |
+| ~-~-pod-selector | When pod_name is not specified, pod matching the label will be selected for the chaos scenario  | string | "" |
+| ~-~-execution |Sets the execution mode of the scenario on multiple pods, can be parallel or serial | parallel | 
+| ~-~-namespace | Namespace of the pod to which filter need to be applied  | string | default |
+| ~-~-instance-count | Targeted instance count matching the label selector  | number |  1 |
+| ~-~-pod-name | When label_selector is not specified, pod matching the name will be selected for the chaos scenario  | string | "" |
+| ~-~-service-account | The service account that the workload will run with. This is especially useful for privileged workloads, as it can be configured to bypass cluster security restrictions.| "" |
+| ~-~-taints | A list of comma sepaerated taints that the node might have that will be transformed on workload tolerations | "" |
+| ~-~-latency | Injects IP packet latency on the pod interface,  value is a string eg. 50ms| "" |
+| ~-~-loss | Injects a percentage of IP packet loss on the pod interface, value is a string eg. 90% | "" |
+| ~-~-bandwidth | Injects a bandwidth restriction on the pod interface, value is a string eg. 1mbps | "" |
+| ~-~-network-shaping-execution | sets the execution mode for the three network disruptions available can be serial or parallel | parallel |
+
+
+To see all available scenario options 
+```bash
+krknctl run pod-network-chaos --help 
+```

--- a/content/en/docs/scenarios/network-chaos-scenario/_index.md
+++ b/content/en/docs/scenarios/network-chaos-scenario/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Network Chaos Scenario
 description: 
-date: 2017-01-04
+date: 2025-08-18
 weight: 3
 ---
 


### PR DESCRIPTION
## Documentation Update
Adds the documentation to the porting of the pod ingress and egress network shaping to the new Network Chaos NG infrastructure.

Please include the branch name where you have made changes or added new features/scenario that we need on the website (e.g., `krkn/new_scenario`) in the title of this PR.

**Changes:** 

Describe the documentation updates made for the feature.
