### PR TITLE
Fix krknctl link in installation docs

### DIFF
--- a/content/en/docs/installation/_index.md
+++ b/content/en/docs/installation/_index.md
@@ -12,7 +12,7 @@ This is a placeholder page that shows you how to use this template site.
 {{% /pageinfo %}} -->
 
 The following ways are supported to run Krkn:
-- Krkn CLI (recommended) - [krknctl](../krknctl/installation.md)
+- Krkn CLI (recommended) - [krknctl](../installation/krknctl/)
 - Standalone python program through Git - See specific documentation for [krkn](krkn.md)
 - Containerized version using either Podman or Docker as the runtime via [Krkn-hub](krkn-hub.md)
 - Kubernetes or OpenShift deployment ( unsupported )


### PR DESCRIPTION
## Documentation Update
Fixed incorrect link path for krknctl installation documentation in the installation index page.

Please include the branch name where you have made changes or added new features/scenario that we need on the website (e.g., `krkn/new_scenario`) in the title of this PR. -> fix/krknctl-installation-link

**Changes:** 

Describe the documentation updates made for the feature.
- Updated krknctl link from `../krknctl/installation.md` to `../installation/krknctl/` in `content/en/docs/installation/_index.md`
- This ensures the link points to the correct installation directory structure
