### PR TITLE
Adding disconneted env details for kube checks

### DIFF
--- a/content/en/docs/krkn/virt-checks.md
+++ b/content/en/docs/krkn/virt-checks.md
@@ -9,15 +9,23 @@ weight: 2
 Virt checks provide real-time visibility into the impact of chaos scenarios on VMI ssh connectivity and performance.
 Virt checks are configured in the ```config.yaml``` [here](config.md#virt-checks)
 
-The system periodically checks the VMI's in the provided namespace based on the defined interval and records the results in Telemetry. The telemetry data includes:
+The system periodically checks the VMI's in the provided namespace based on the defined interval and records the results in Telemetry. The checks will run continuously from the very beginning of krkn until all scenarios are done and wait durations are complete. The telemetry data includes:
 
 - Success status ```True``` when the VMI is up and running and can form an ssh connection
 - Failure response ```False``` if the VMI experiences downtime or errors.
+- The VMI Name
+- The VMI Namespace
+- The VMI Ip Address and a New IP Address if the VMI is deleted
+- The time of the start and end of the specific status 
+- The duration the VMI had the specific status
+- The node the VMI is running on 
+
 
 This helps users quickly identify VMI issues and take necessary actions.
 
-### Additional Installation of VirtCtl 
-It is required to have virtctl or an ssh connection via a bastion host to be able to run this option. We don't recommend using the `krew` installation type
+### Additional Installation of VirtCtl (If running using Krkn)
+It is required to have virtctl or an ssh connection via a bastion host to be able to run this option. We don't recommend using the `krew` installation type. 
+This is only required if you are running locally with python Krkn version, the virtctl command will be automatically installed in the krkn-hub and krknctl images 
 
 See virtctl installer guide from [KubeVirt](https://kubevirt.io/user-guide/user_workloads/virtctl_client_tool/)
 ```bash
@@ -37,10 +45,41 @@ kubevirt_checks:                                      # Utilizing virt check end
     name: "^windows-vm-.$"                            # Regex Name style of VMI's to watch, optional, if left blank will find all names in namespace
     only_failures: False                              # Boolean of whether to show all VMI's failures and successful ssh connection (False), or only failure status' (True) 
     disconnected: False                               # Boolean of how to try to connect to the VMIs; if True will use the ip_address to try ssh from within a node, if false will use the name and uses virtctl to try to connect  
+    ssh_node: ""                                            # If set, will be a backup way to ssh to a node. Will want to set to a node that isn't targeted in chaos
 ```
+
+##### Disconnected Environment
+The disconnected variable set in the config bypasses the kube-apiserver and SSH's directly to the worker nodes to test SSH connection to the VM's IP address.
+
+When using `disconnected: true`, you must configure SSH authentication to the worker nodes. This requires passing your SSH private key to the container.
+
+**Configuration:**
+```yaml
+disconnected: True                               # Boolean of how to try to connect to the VMIs; if True will use the ip_address to try ssh from within a node, if false will use the name and uses virtctl to try to connect
+```
+
+**SSH Key Setup for krkn-hub or krknctl:**
+
+You need to mount your SSH private and/or public key into the container to enable SSH connection to the worker nodes. Pass the `id_rsa` variable with the path to your SSH keys:
+
+```bash
+# Example with krknctl
+krknctl run --config config.yaml -e id_rsa=/path/to/your/id_rsa
+
+# Example with krkn-hub
+podman run --name=<container_name> --net=host \
+  -v /path/to/your/id_rsa:/home/krkn/.ssh/id_rsa:Z \. # do not change path on right of colon
+  -v /path/to/your/id_rsa.pub:/home/krkn/.ssh/id_rsa.pub:Z \. # do not change path on right of colon
+  -v /path/to/config.yaml:/root/kraken/config/config.yaml:Z \
+  -d quay.io/krkn-chaos/krkn-hub:<scenario_type>
+```
+
+**Note:** Ensure your SSH key has appropriate permissions (`chmod 644 id_rsa`) and matches the key authorized on your worker nodes.
 
 #### Sample virt check telemetry
 Notice here that the vm with name windows-vm-1 had a false status (not able to form an ssh connection), for the first 37 seconds (the first item in the list). And at the end of the run the vm was able to for the ssh connection and reports true status for 41 seconds. While the vm with name windows-vm-0 has a true status the whole length of the chaos run (~88 seconds).
+
+When 
 ```
 "virt_checks": [
       {
@@ -51,7 +90,8 @@ Notice here that the vm with name windows-vm-1 had a false status (not able to f
           "status": false,
           "start_timestamp": "2025-07-22T13:41:53.461951",
           "end_timestamp": "2025-07-22T13:42:30.696498",
-          "duration": 37.234547
+          "duration": 37.234547,
+          "new_ip_address": "0.0.0.2",
       },
       {
           "node_name": "000-000",
@@ -61,17 +101,19 @@ Notice here that the vm with name windows-vm-1 had a false status (not able to f
           "status": true,
           "start_timestamp": "2025-07-22T13:41:49.346861",
           "end_timestamp": "2025-07-22T13:43:17.949613",
-          "duration": 88.602752
+          "duration": 88.602752,
+          "new_ip_address": ""
       },
       {
           "node_name": "000-000",
           "namespace": "runner",
           "vm_name": "windows-vm-1",
-          "ip_address": "0.0.0.0",
+          "ip_address": "0.0.0.2",
           "status": true,
           "start_timestamp": "2025-07-22T13:42:36.260780",
           "end_timestamp": "2025-07-22T13:43:17.949613",
-          "duration": 41.688833
+          "duration": 41.688833,
+          "new_ip_address": ""
       }
   ],
 

--- a/content/en/docs/scenarios/all-scenario-env-krknctl.md
+++ b/content/en/docs/scenarios/all-scenario-env-krknctl.md
@@ -67,6 +67,7 @@ example:
 | ~-~-kubevirt-name| KubeVirt regex names to watch | string |  | 
 | ~-~-kubevirt-only-failures | KubeVirt checks only report if failure occurs | string |  |  | false |
 | ~-~-kubevirt-disconnected| KubeVirt checks in disconnected mode, bypassing the clusters Api | string |  | false |
+| ~-~-kubevirt-ssh-node | KubeVirt back up node to ssh into when checking vmi ip address status | string | | false |
 | ~-~-krkn-debug | Enables debug mode for Krkn  | enum | True/False | False| 
 
 {{% alert title="Note" %}} For setting the TELEMETRY_ARCHIVE_SIZE,the higher the number of archive files will be produced and uploaded (and processed by backup_thread simultaneously| .For unstable/slow connection is better to keep this value low increasing the number of backup_threads, in this way, on upload failure, the retry will happen only on the failed chunk without affecting the whole upload.{{% /alert %}}

--- a/content/en/docs/scenarios/all-scenario-env.md
+++ b/content/en/docs/scenarios/all-scenario-env.md
@@ -42,7 +42,8 @@ KUBE_VIRT_CHECK_INTERVAL | Interval at which to test kubevirt connections | 2 |
 KUBE_VIRT_NAMESPACE | Namespace to find VMIs in and watch | _blank_ | 
 KUBE_VIRT_NAME | Regex style name to match VMIs to watch | _blank_ | 
 KUBE_VIRT_FAILURES | If value is True exits will only report when ssh connections fail to vmi, values can be True/False |  _blank_ | 
-KUBE_VIRT_DISCONNECTED | Use disconnected check by passing cluster API, can be True/False | False 
+KUBE_VIRT_DISCONNECTED | Use disconnected check by passing cluster API, can be True/False | False |
+KUBE_VIRT_SSH_NODE |  If set, will be a backup way to ssh to a node. Will want to set to a node that isn't targeted in chaos |_blank_ | 
 CHECK_CRITICAL_ALERTS | When enabled will check prometheus for critical alerts firing post chaos | False |
 TELEMETRY_ENABLED | Enable/disables the telemetry collection feature | False |
 TELEMETRY_API_URL | telemetry service endpoint | https://ulnmf9xv7j.execute-api.us-west-2.amazonaws.com/production |


### PR DESCRIPTION
## Documentation Update
**Related Feature:** 
https://github.com/krkn-chaos/krkn/pull/932

Please include the branch name where you have made changes or added new features/scenario that we need on the website (e.g., `krkn/new_scenario`) in the title of this PR.

**Changes:** 

Adding details explaining needing to pass ssh keys to container for krkn-hub and krknctl to properly ssh into nodes to check VMI status/connection

