### PR TITLE
Docs : aws-s3-replication-scenario

### DIFF
--- a/content/en/docs/scenarios/_index.md
+++ b/content/en/docs/scenarios/_index.md
@@ -26,7 +26,8 @@ table th:nth-of-type(3) {
 | **Scenario**   | **Plugin Type**   |  **Description** |
 | ------------------------------------------- | ------------------------------------------- | ------------------------------------------------------------------ |
 | [Application outages](docs/scenarios/application-outage/_index.md) | application_outages_scenarios | Isolates application Ingress/Egress traffic to observe the impact on dependent applications and recovery/initialization timing  |    
-| [Aurora Disruption](docs/scenarios/aurora-disruption/_index.md) | network_chaos_ng_scenarios | Blocks a pod's outgoing MySQL and PostgreSQL traffic, effectively preventing it from connecting to any AWS Aurora SQL engine |            
+| [Aurora Disruption](docs/scenarios/aurora-disruption/_index.md) | network_chaos_ng_scenarios | Blocks a pod's outgoing MySQL and PostgreSQL traffic, effectively preventing it from connecting to any AWS Aurora SQL engine |
+| [AWS S3 Replication](docs/scenarios/aws-s3-replication/_index.md) | aws_s3_replication_scenarios | Temporarily pauses S3 bucket replication to test application resilience when replication is unavailable or experiencing lag |            
 | [Container failures](docs/scenarios/container-scenario/_index.md) | container_scenarios | Injects container failures based on the provided kill signal | 
 | [DNS outages](docs/scenarios/dns-outage/_index.md) | network_chaos_ng_scenarios | Blocks all outgoing DNS traffic from a specific pod, effectively preventing it from resolving any hostnames or service names. |    
 | [EFS Disruption](docs/scenarios/efs-disruption/_index.md) | network_chaos_ng_scenarios | Creates an outgoing firewall rule blocking connections to AWS EFS, leading to a temporary failure of any EFS volumes mounted on those affected nodes.|    

--- a/content/en/docs/scenarios/aws-s3-replication/_index.md
+++ b/content/en/docs/scenarios/aws-s3-replication/_index.md
@@ -1,0 +1,64 @@
+---
+title: AWS S3 Replication Scenarios
+description: 
+date: 2017-01-04
+weight: 3
+---
+
+<krkn-hub-scenario id="aws-s3-replication-scenarios">
+
+This scenario temporarily pauses S3 bucket replication to test application resilience when replication is unavailable or experiencing lag. The target S3 bucket must have replication already configured.
+
+</krkn-hub-scenario>
+
+## How It Works
+
+1. **Save Configuration**: Retrieves and saves the current S3 replication configuration
+2. **Pause Replication**: Disables all replication rules by setting their status to `Disabled`
+3. **Chaos Period**: Waits for the specified duration while replication is paused
+4. **Restore Replication**: Re-enables replication by restoring the original configuration
+
+## Prerequisites
+
+### AWS S3 Replication Setup
+
+The target S3 bucket **must have replication already configured**. This scenario does not create replication configurations; it only pauses and restores existing ones.
+
+To set up S3 replication:
+1. Enable versioning on both source and destination buckets
+2. Create an IAM role for S3 replication
+3. Configure replication rules in the source bucket
+
+See [AWS S3 Replication Documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/replication.html) for details.
+
+### AWS Credentials
+
+Ensure AWS credentials are configured via one of these methods:
+- Environment variables (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_DEFAULT_REGION`)
+- AWS credentials file (`~/.aws/credentials`)
+- IAM role (if running on EC2, ECS, or Lambda)
+
+## Required IAM Permissions
+
+The IAM user or role running Krkn must have these permissions on the source bucket:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "KrknS3ReplicationChaos",
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetReplicationConfiguration",
+        "s3:PutReplicationConfiguration"
+      ],
+      "Resource": [
+        "arn:aws:s3:::your-source-bucket-name"
+      ]
+    }
+  ]
+}
+```
+
+{{% alert title="Note" %}}These permissions are only needed on the **source bucket** (where replication originates), not on destination buckets.{{% /alert %}}

--- a/content/en/docs/scenarios/aws-s3-replication/aws-s3-replication-krkn.md
+++ b/content/en/docs/scenarios/aws-s3-replication/aws-s3-replication-krkn.md
@@ -1,0 +1,69 @@
+---
+title: AWS S3 Replication Scenarios using Krkn
+description: 
+date: 2017-01-04
+weight: 1
+---
+
+This scenario temporarily pauses S3 bucket replication to test application resilience when replication is unavailable or experiencing lag.
+
+##### Scenario config
+
+```yaml
+aws_s3_replication_scenarios:
+  bucket_name: "my-source-bucket"  # Required: Source bucket with replication
+  duration: 300                     # Required: Pause duration in seconds
+  region: "us-east-1"              # Optional: AWS region
+```
+
+### Configuration Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `bucket_name` | string | Yes | - | Name of the S3 source bucket with replication configured |
+| `duration` | integer | Yes | - | Duration to pause replication (in seconds) |
+| `region` | string | No | Default AWS region | AWS region where the bucket is located |
+
+### Example Scenarios
+
+#### Short Pause (5 minutes)
+```yaml
+aws_s3_replication_scenarios:
+  bucket_name: "production-data"
+  duration: 300
+  region: "us-east-1"
+```
+
+#### Extended Pause (30 minutes)
+```yaml
+aws_s3_replication_scenarios:
+  bucket_name: "backup-bucket"
+  duration: 1800
+  region: "us-west-2"
+```
+
+#### Multi-Region Failover Test
+```yaml
+aws_s3_replication_scenarios:
+  bucket_name: "global-assets-bucket"
+  duration: 900
+  region: "ap-southeast-1"
+```
+
+### How to Use Plugin Name
+
+Add the plugin name to the list of chaos_scenarios section in the config/config.yaml file
+
+```yaml
+kraken:
+    kubeconfig_path: ~/.kube/config
+    chaos_scenarios:
+        - aws_s3_replication_scenarios:
+            - scenarios/s3_replication.yaml
+```
+
+### Run
+
+```bash
+python run_kraken.py --config config/config.yaml
+```


### PR DESCRIPTION
## Documentation Update
**Related Feature:** AWS S3 Replication Chaos Scenario

Branch: `Docs/aws-s3-replication-scenario`

**Changes:**

Added documentation for the AWS S3 replication chaos scenario including:
- Scenario overview and configuration
- Usage instructions with krkn
- Example YAML configuration

**Closes issue :**
  #190 
