### PR TITLE
Fix typo: clsuterr -> cluster

### DIFF
--- a/content/en/docs/krkn/_index.md
+++ b/content/en/docs/krkn/_index.md
@@ -73,7 +73,7 @@ Health checks provide real-time visibility into the impact of chaos scenarios on
 
 
 ### Telemetry
-We gather some basic details of the clsuter configuration and scenarios ran as part of a `telemetry` set of data that is printed off at the end of each krkn run. You can also opt in to the telemetry being stored in AWS S3 bucket or elasticsearch for long term storage. Find more details and configuration specifics [here](telemetry.md)
+We gather some basic details of the cluster configuration and scenarios ran as part of a `telemetry` set of data that is printed off at the end of each krkn run. You can also opt in to the telemetry being stored in AWS S3 bucket or elasticsearch for long term storage. Find more details and configuration specifics [here](telemetry.md)
 
 
 ### OCM / ACM integration


### PR DESCRIPTION
### **User description**
Fixes #199


Fixes a typo on line 76 where "clsuter" was misspelled as "cluster".

Changes:
- Line 76: "clsuter" → "cluster"


___

### **PR Type**
Bug fix


___

### **Description**
- Fix typo in documentation: "clsuter" → "cluster"


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Documentation File"] -- "Fix typo: clsuter to cluster" --> B["Corrected Text"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>_index.md</strong><dd><code>Fix typo in telemetry documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

content/en/docs/krkn/_index.md

<ul><li>Fixed typo on line 76: changed "clsuter" to "cluster" in the Telemetry <br>section<br> <li> Improves documentation accuracy and readability</ul>


</details>


  </td>
  <td><a href="https://github.com/krkn-chaos/website/pull/200/files#diff-970697af8634b69f40aaace52895c4b2c331c599b495783152c5665bc0227503">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

