### PR TITLE
ui: refactor hero to side-by-side layout

### DIFF
--- a/assets/scss/_custom_hero.scss
+++ b/assets/scss/_custom_hero.scss
@@ -47,9 +47,6 @@
 // -----------------------------------------------------------------------------
 // Hero content container
 // -----------------------------------------------------------------------------
-// -----------------------------------------------------------------------------
-// Hero content container
-// -----------------------------------------------------------------------------
 .hero-content {
   position: relative;
   z-index: 1;
@@ -57,7 +54,15 @@
   width: 100%;
   max-width: 100%;
   margin: 0 auto;
-  padding: 0 8rem;
+  padding: 0 1.5rem;
+
+  @media (min-width: 768px) {
+    padding: 0 4rem;
+  }
+
+  @media (min-width: 1024px) {
+    padding: 0 8rem;
+  }
 }
 
 // Layout Grid (Desktop: Side-by-Side)
@@ -110,6 +115,10 @@
     width: 100%;
     height: auto;
     margin: 0;
+  }
+
+  @media (max-width: 1023px) {
+    margin-top: 1.5rem;
   }
 
   @media (max-width: 600px) {
@@ -436,13 +445,17 @@
 // Title with gradient
 // -----------------------------------------------------------------------------
 .hero-title {
-  font-size: clamp(2.5rem, 6vw, 4.5rem); // Slightly adjusted for side-by-side
+  font-size: clamp(2.25rem, 7vw, 4.5rem); // Smaller minimum for mobile
   font-weight: 800;
   font-family: 'Satoshi', sans-serif;
-  line-height: 1.1;
+  line-height: 1.05;
   margin-bottom: 1rem;
   color: var(--krkn-text);
   letter-spacing: -0.02em;
+
+  @media (max-width: 480px) {
+    font-size: 2.5rem; // Explicit fallback for very small screens
+  }
 }
 
 // Accent span within hero title -- red gradient for emphasis
@@ -540,6 +553,12 @@
 
   @media (min-width: 1024px) {
     justify-content: flex-start;
+  }
+
+  @media (max-width: 375px) {
+    flex-direction: column;
+    align-items: center;
+    gap: 0.75rem;
   }
 }
 

--- a/assets/scss/_custom_navbar.scss
+++ b/assets/scss/_custom_navbar.scss
@@ -31,6 +31,13 @@
     backdrop-filter: blur(20px);
     -webkit-backdrop-filter: blur(20px);
   }
+
+  &.krkn-navbar--drawer-open {
+    background: var(--krkn-surface);
+    backdrop-filter: none !important;
+    -webkit-backdrop-filter: none !important;
+    transition: background-color 0s linear;
+  }
 }
 
 // -----------------------------------------------------------------------------
@@ -59,13 +66,12 @@
   color: var(--krkn-text);
   text-decoration: none;
   transition: transform 0.35s cubic-bezier(0.34, 1.56, 0.64, 1),
-              filter 0.35s ease;
+    filter 0.35s ease;
 
   &:hover {
     color: var(--krkn-text);
     transform: scale(1.08);
-    filter: drop-shadow(0 0 8px rgba(236, 28, 36, 0.45))
-            drop-shadow(0 0 20px rgba(236, 28, 36, 0.15));
+    filter: drop-shadow(0 0 8px rgba(236, 28, 36, 0.45)) drop-shadow(0 0 20px rgba(236, 28, 36, 0.15));
   }
 
   &:active {
@@ -213,7 +219,7 @@
     opacity: 0.55;
   }
 
-  span:empty + svg,
+  span:empty+svg,
   span:empty {
     display: none;
   }
@@ -256,7 +262,7 @@ button.krkn-navbar__search {
   justify-content: center;
   width: 3rem;
   height: 3rem;
-  color: var(--krkn-text-muted);
+  color: var(--krkn-text);
   background: transparent;
   border: none;
   border-radius: 0.5rem;
@@ -273,17 +279,37 @@ button.krkn-navbar__search {
     background-color: var(--krkn-nav-hover-bg);
     transform: rotate(25deg) scale(1.15);
   }
+
+  @media (max-width: 991.98px) {
+    color: var(--krkn-text);
+    background-color: var(--krkn-elevated);
+    border-radius: 0.5rem;
+
+    &:hover {
+      background-color: var(--krkn-nav-hover-bg);
+    }
+  }
 }
 
 // Sun/moon icon visibility based on active theme
 // Dark mode: show sun (to switch to light)
 // Light mode: show moon (to switch to dark)
-.krkn-navbar__icon--moon { display: none; }
-.krkn-navbar__icon--sun  { display: block; }
+.krkn-navbar__icon--moon {
+  display: none;
+}
+
+.krkn-navbar__icon--sun {
+  display: block;
+}
 
 [data-theme="light"] {
-  .krkn-navbar__icon--moon { display: block; }
-  .krkn-navbar__icon--sun  { display: none; }
+  .krkn-navbar__icon--moon {
+    display: block;
+  }
+
+  .krkn-navbar__icon--sun {
+    display: none;
+  }
 }
 
 .krkn-navbar__icon {
@@ -297,14 +323,20 @@ button.krkn-navbar__search {
   display: flex;
   flex-direction: column;
   justify-content: center;
-  gap: 5px;
-  width: 2.5rem;
-  height: 2.5rem;
-  padding: 0.5rem;
+  align-items: flex-end;
+  gap: 6px;
+  width: 3rem;
+  height: 3rem;
+  padding: 0.75rem;
   background: transparent;
   border: none;
   cursor: pointer;
   color: var(--krkn-text);
+  transition: opacity 0.2s;
+
+  &:hover {
+    opacity: 0.8;
+  }
 
   @media (min-width: 992px) {
     display: none;
@@ -313,23 +345,26 @@ button.krkn-navbar__search {
 
 .krkn-navbar__hamburger-line {
   display: block;
-  width: 100%;
+  width: 24px;
   height: 2px;
   background: currentColor;
-  border-radius: 1px;
-  transition: transform 0.3s ease, opacity 0.3s ease;
+  border-radius: 4px;
+  transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1), opacity 0.3s ease, width 0.3s ease;
 }
 
-.krkn-navbar__hamburger--active .krkn-navbar__hamburger-line:nth-child(1) {
-  transform: translateY(7px) rotate(45deg);
-}
+.krkn-navbar__hamburger--active {
+  .krkn-navbar__hamburger-line:nth-child(1) {
+    transform: translateY(7px) rotate(45deg);
+  }
 
-.krkn-navbar__hamburger--active .krkn-navbar__hamburger-line:nth-child(2) {
-  opacity: 0;
-}
+  .krkn-navbar__hamburger-line:nth-child(2) {
+    opacity: 0;
+    transform: translateX(-10px);
+  }
 
-.krkn-navbar__hamburger--active .krkn-navbar__hamburger-line:nth-child(3) {
-  transform: translateY(-7px) rotate(-45deg);
+  .krkn-navbar__hamburger-line:nth-child(3) {
+    transform: translateY(-7px) rotate(-45deg);
+  }
 }
 
 // -----------------------------------------------------------------------------
@@ -360,7 +395,7 @@ button.krkn-navbar__search {
 .krkn-navbar__drawer-backdrop {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.5);
+  background: rgba(0, 0, 0, 0.65);
   opacity: 0;
   transition: opacity 0.3s ease;
 }
@@ -376,6 +411,9 @@ button.krkn-navbar__search {
   bottom: 0;
   width: 100%;
   background: var(--krkn-surface);
+  isolation: isolate;
+  backdrop-filter: none !important;
+  -webkit-backdrop-filter: none !important;
   border-left: 1px solid var(--krkn-border-subtle);
   padding: 4rem 1.5rem 1.5rem;
   display: flex;
@@ -413,6 +451,54 @@ button.krkn-navbar__search {
 
   &.krkn-navbar__drawer-link--active {
     color: var(--krkn-primary);
+  }
+}
+
+.krkn-navbar__drawer-theme-toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  width: 100%;
+  padding: 0.75rem 1rem;
+  background: var(--krkn-elevated);
+  border: 1px solid var(--krkn-border-subtle);
+  border-radius: 0.5rem;
+  color: var(--krkn-text);
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 0.9375rem;
+  font-weight: 500;
+  text-align: left;
+  transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+
+  svg {
+    width: 20px;
+    height: 20px;
+    flex-shrink: 0;
+  }
+
+  &:hover {
+    background-color: var(--krkn-border-prominent);
+    border-color: var(--krkn-border-prominent);
+    color: var(--krkn-text);
+  }
+}
+
+.krkn-navbar__drawer-theme-label--dark {
+  display: inline;
+}
+
+.krkn-navbar__drawer-theme-label--light {
+  display: none;
+}
+
+[data-theme="light"] {
+  .krkn-navbar__drawer-theme-label--dark {
+    display: none;
+  }
+
+  .krkn-navbar__drawer-theme-label--light {
+    display: inline;
   }
 }
 
@@ -620,7 +706,7 @@ button.krkn-navbar__search {
   padding: 1rem 1.25rem;
   border-bottom: 1px solid var(--krkn-border-subtle);
 
-  > svg {
+  >svg {
     flex-shrink: 0;
     color: var(--krkn-text-muted);
   }
@@ -708,7 +794,8 @@ button.krkn-navbar__search {
       }
     }
 
-    small, .text-body-secondary {
+    small,
+    .text-body-secondary {
       color: var(--krkn-text-muted) !important;
     }
   }

--- a/assets/scss/_custom_sections.scss
+++ b/assets/scss/_custom_sections.scss
@@ -141,9 +141,11 @@ svg.feature-card__icon {
   &::-webkit-scrollbar {
     height: 6px;
   }
+
   &::-webkit-scrollbar-track {
     background: transparent;
   }
+
   &::-webkit-scrollbar-thumb {
     background: var(--krkn-border-prominent);
     border-radius: 3px;
@@ -220,6 +222,11 @@ svg.scenario-card__icon {
   padding: 6rem 2rem;
   text-align: center;
   background: var(--krkn-bg);
+  overflow-x: hidden;
+
+  @media (max-width: 600px) {
+    padding: 3rem 1.25rem;
+  }
 }
 
 .cta-section__title {
@@ -227,6 +234,10 @@ svg.scenario-card__icon {
   font-weight: 700;
   color: var(--krkn-text);
   margin-bottom: 1rem;
+
+  @media (max-width: 600px) {
+    font-size: 1.5rem;
+  }
 }
 
 .cta-section__subtitle {
@@ -389,12 +400,22 @@ svg.scenario-card__icon {
 }
 
 // Theme-dependent footer CNCF logo
-.krkn-footer__cncf-light { display: none; }
-.krkn-footer__cncf-dark  { display: inline-block; }
+.krkn-footer__cncf-light {
+  display: none;
+}
+
+.krkn-footer__cncf-dark {
+  display: inline-block;
+}
 
 [data-theme="light"] {
-  .krkn-footer__cncf-light { display: inline-block; }
-  .krkn-footer__cncf-dark  { display: none; }
+  .krkn-footer__cncf-light {
+    display: inline-block;
+  }
+
+  .krkn-footer__cncf-dark {
+    display: none;
+  }
 }
 
 .krkn-footer__copyright {

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -31,8 +31,8 @@
   --krkn-code-bg: #0F172A;
   --krkn-shadow: rgba(0, 0, 0, 0.3);
   --krkn-card-hover-glow: rgba(236, 28, 36, 0.15);
-  --krkn-glass-bg: rgba(10, 11, 16, 0.65);
-  --krkn-glass-bg-solid: rgba(10, 11, 16, 0.95);
+  --krkn-glass-bg: rgba(10, 11, 16, 0.88);
+  --krkn-glass-bg-solid: rgba(10, 11, 16, 0.97);
   --krkn-nav-hover-bg: rgba(255, 255, 255, 0.05);
   --krkn-logo-filter: none;
   --krkn-cncf-logo: url('/img/cncf-white.svg');
@@ -57,8 +57,8 @@
   --krkn-code-bg: #DDDCD8;
   --krkn-shadow: rgba(0, 0, 0, 0.06);
   --krkn-card-hover-glow: rgba(220, 38, 38, 0.06);
-  --krkn-glass-bg: rgba(244, 243, 239, 0.85);
-  --krkn-glass-bg-solid: rgba(244, 243, 239, 0.97);
+  --krkn-glass-bg: rgba(244, 243, 239, 0.95);
+  --krkn-glass-bg-solid: rgba(244, 243, 239, 0.99);
   --krkn-nav-hover-bg: rgba(0, 0, 0, 0.05);
   --krkn-logo-filter: none;
   --krkn-cncf-logo: url('/img/cncf-color.png');
@@ -179,10 +179,15 @@ html {
 // Must override Docsy's `.td-default main section { padding: 4rem }`.
 // Using !important to beat the higher-specificity Docsy selector.
 section.hero-section {
-  padding-top: 10rem !important;
-  padding-bottom: 3rem !important;
+  padding-top: 8rem !important; // Slightly less top padding on mobile
+  padding-bottom: 2rem !important;
   padding-left: 0 !important;
   padding-right: 0 !important;
+
+  @media (min-width: 1024px) {
+    padding-top: 10rem !important;
+    padding-bottom: 3rem !important;
+  }
 }
 
 // Force all Docsy page wrappers to use theme colors

--- a/layouts/_partials/navbar.html
+++ b/layouts/_partials/navbar.html
@@ -97,6 +97,18 @@
           <a href="{{ `/community/` | relLangURL }}" class="krkn-navbar__drawer-link{{ if eq .Section `community` }} krkn-navbar__drawer-link--active{{ end }}">Community</a>
         {{ end }}
       </div>
+      {{/* Theme toggle row inside drawer */}}
+      <button type="button" class="krkn-navbar__drawer-theme-toggle" id="krkn-theme-toggle-mobile" aria-label="Toggle light/dark theme">
+        {{/* Sun icon (shown in dark mode) */}}
+        <svg class="krkn-navbar__icon krkn-navbar__icon--sun" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
+        {{/* Moon icon (shown in light mode) */}}
+        <svg class="krkn-navbar__icon krkn-navbar__icon--moon" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z"/></svg>
+        <span class="krkn-navbar__drawer-theme-text">
+          <span class="krkn-navbar__drawer-theme-label--dark">Switch to Light</span>
+          <span class="krkn-navbar__drawer-theme-label--light">Switch to Dark</span>
+        </span>
+      </button>
+
       <a href="https://github.com/krkn-chaos/" class="krkn-navbar__drawer-github" target="_blank" rel="noopener noreferrer">
         <svg class="krkn-navbar__icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
         GitHub
@@ -114,7 +126,6 @@
   var drawer = document.getElementById('krkn-nav-drawer');
   var backdrop = document.getElementById('krkn-drawer-backdrop');
   var searchTrigger = document.getElementById('krkn-search-trigger');
-  var searchWrap = document.getElementById('krkn-search-wrap');
 
   var SCROLL_THRESHOLD = 50;
   var isHome = navbar && navbar.classList.contains('krkn-navbar--solid') === false;
@@ -132,6 +143,7 @@
   // Toggle mobile drawer
   function openDrawer() {
     if (drawer) drawer.classList.add('krkn-navbar__drawer--open');
+    if (navbar) navbar.classList.add('krkn-navbar--drawer-open');
     if (hamburger) {
       hamburger.classList.add('krkn-navbar__hamburger--active');
       hamburger.setAttribute('aria-expanded', 'true');
@@ -141,6 +153,7 @@
 
   function closeDrawer() {
     if (drawer) drawer.classList.remove('krkn-navbar__drawer--open');
+    if (navbar) navbar.classList.remove('krkn-navbar--drawer-open');
     if (hamburger) {
       hamburger.classList.remove('krkn-navbar__hamburger--active');
       hamburger.setAttribute('aria-expanded', 'false');
@@ -279,18 +292,17 @@
 
   // ---- Theme toggle ----
   var themeToggle = document.getElementById('krkn-theme-toggle');
+  var themeToggleMobile = document.getElementById('krkn-theme-toggle-mobile');
 
   function getPreferredTheme() {
     var stored = localStorage.getItem('krkn-theme');
     if (stored) return stored;
-    // Default to dark
     return 'dark';
   }
 
   function setTheme(theme) {
     document.documentElement.setAttribute('data-theme', theme);
     localStorage.setItem('krkn-theme', theme);
-    // Update toggle aria-label
     if (themeToggle) {
       themeToggle.setAttribute('aria-label',
         theme === 'dark' ? 'Switch to light theme' : 'Switch to dark theme'
@@ -301,11 +313,12 @@
   // Apply stored theme immediately
   setTheme(getPreferredTheme());
 
-  if (themeToggle) {
-    themeToggle.addEventListener('click', function() {
-      var current = document.documentElement.getAttribute('data-theme') || 'dark';
-      setTheme(current === 'dark' ? 'light' : 'dark');
-    });
+  function onThemeToggleClick() {
+    var current = document.documentElement.getAttribute('data-theme') || 'dark';
+    setTheme(current === 'dark' ? 'light' : 'dark');
   }
+
+  if (themeToggle) themeToggle.addEventListener('click', onThemeToggleClick);
+  if (themeToggleMobile) themeToggleMobile.addEventListener('click', onThemeToggleClick);
 })();
 </script>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -6,6 +6,17 @@ Design: Apple-inspired dark theme, cinematic, generous whitespace.
 */}}
 {{ define "main" }}
 <style>
+  .krkn-home {
+    overflow-x: hidden;
+    width: 100%;
+  }
+
+  .krkn-home *,
+  .krkn-home *::before,
+  .krkn-home *::after {
+    box-sizing: border-box;
+  }
+
   /* Homepage-specific overrides (not in SCSS because they're page-specific) */
   .krkn-home .section-surface .section-title,
   .krkn-home .section-dark .section-title {
@@ -27,6 +38,31 @@ Design: Apple-inspired dark theme, cinematic, generous whitespace.
     max-width: none;
   }
 
+  @media (max-width: 768px) {
+
+    .krkn-home .section-dark,
+    .krkn-home .section-surface,
+    .krkn-home .section-elevated {
+      padding: 3rem 0;
+    }
+
+    .krkn-home .section-dark>.container,
+    .krkn-home .section-surface>.container,
+    .krkn-home .section-elevated>.container {
+      padding-left: 1.25rem;
+      padding-right: 1.25rem;
+    }
+
+    .krkn-home .section-title {
+      font-size: 1.75rem;
+    }
+
+    .krkn-home .section-subtitle {
+      font-size: 0.95rem;
+      padding: 0 0.5rem;
+    }
+  }
+
   /* About grid layout */
   .about-grid {
     display: grid;
@@ -38,6 +74,44 @@ Design: Apple-inspired dark theme, cinematic, generous whitespace.
   @media (max-width: 900px) {
     .about-grid {
       grid-template-columns: 1fr;
+      text-align: center;
+    }
+
+    /* Force center alignment for titles/subtitles/buttons on mobile */
+    .krkn-home .about-grid .section-title {
+      text-align: center !important;
+    }
+
+    .krkn-home .about-grid .section-subtitle {
+      text-align: center !important;
+      margin-left: auto;
+      margin-right: auto;
+      max-width: 100% !important;
+    }
+
+    .about-grid .btn-outline-krkn,
+    .about-grid .btn-primary-krkn,
+    .about-grid .btn {
+      display: inline-flex;
+      margin: 0 auto;
+    }
+
+    .about-visual {
+      max-width: 100%;
+      overflow: hidden;
+    }
+
+    .about-visual .code-block {
+      max-width: 100%;
+    }
+
+    .about-visual .code-block pre {
+      overflow-x: auto;
+      -webkit-overflow-scrolling: touch;
+    }
+
+    .about-visual .code-block code {
+      font-size: 0.78rem;
     }
   }
 
@@ -48,6 +122,7 @@ Design: Apple-inspired dark theme, cinematic, generous whitespace.
     border: 1px solid rgba(255, 255, 255, 0.08) !important;
     overflow: hidden;
     box-shadow: 0 2px 12px rgba(0, 0, 0, 0.12);
+    max-width: 100%;
   }
 
   .code-block__header {
@@ -57,6 +132,52 @@ Design: Apple-inspired dark theme, cinematic, generous whitespace.
     padding: 0.75rem 1rem;
     background: #161B22 !important;
     border-bottom: 1px solid rgba(255, 255, 255, 0.06) !important;
+  }
+
+  [data-theme="light"] .code-block,
+  [data-theme="light"] .step-card__code,
+  [data-theme="light"] .krkn-ai-terminal {
+    background: #EAEAEF !important;
+    border: 1px solid #C7C7CC !important;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08) !important;
+  }
+
+  [data-theme="light"] .code-block__header,
+  [data-theme="light"] .krkn-ai-terminal__bar {
+    background: #DFDFE6 !important;
+    border-bottom: 1px solid #C7C7CC !important;
+  }
+
+  [data-theme="light"] .code-block__title,
+  [data-theme="light"] .krkn-ai-terminal__title {
+    color: #55555A !important;
+  }
+
+  [data-theme="light"] .code-block code,
+  [data-theme="light"] .krkn-ai-terminal__body,
+  [data-theme="light"] .step-card__code {
+    color: #1C1C1E !important;
+    -webkit-text-fill-color: #1C1C1E !important;
+  }
+
+  [data-theme="light"] .code-block code .check,
+  [data-theme="light"] .t-ok,
+  [data-theme="light"] .c-ok,
+  [data-theme="light"] .step-card__code .c-ok {
+    color: #15803d !important;
+    -webkit-text-fill-color: #15803d !important;
+  }
+
+  [data-theme="light"] .t-flag,
+  [data-theme="light"] .c-flag,
+  [data-theme="light"] .step-card__code .c-flag {
+    color: #1d4ed8 !important;
+  }
+
+  [data-theme="light"] .c-prompt,
+  [data-theme="light"] .t-prompt,
+  [data-theme="light"] .step-card__code .c-prompt {
+    color: #4b5563 !important;
   }
 
   .code-block__dot {
@@ -129,7 +250,7 @@ Design: Apple-inspired dark theme, cinematic, generous whitespace.
   @media (max-width: 1200px) {
     .steps-grid {
       max-width: 100%;
-      padding: 0 1rem;
+      padding: 0 1.5rem;
     }
   }
 
@@ -137,13 +258,19 @@ Design: Apple-inspired dark theme, cinematic, generous whitespace.
     .steps-grid {
       grid-template-columns: repeat(2, 1fr);
       max-width: 700px;
+      gap: 1.5rem;
     }
   }
 
   @media (max-width: 550px) {
     .steps-grid {
       grid-template-columns: 1fr;
-      max-width: 400px;
+      max-width: 100%;
+      padding: 0;
+    }
+
+    .step-card {
+      padding: 1.5rem 1.25rem;
     }
   }
 
@@ -211,6 +338,7 @@ Design: Apple-inspired dark theme, cinematic, generous whitespace.
     line-height: 1.5;
     overflow-x: auto;
     white-space: pre;
+    max-width: 100%;
   }
 
   .step-card__code .c-prompt {
@@ -244,6 +372,24 @@ Design: Apple-inspired dark theme, cinematic, generous whitespace.
       grid-template-columns: 1fr;
       gap: 2rem;
     }
+
+    .krkn-ai-content {
+      text-align: center;
+    }
+
+    .krkn-ai-desc {
+      max-width: 100%;
+      margin-left: auto;
+      margin-right: auto;
+    }
+
+    .krkn-ai-features {
+      text-align: left;
+    }
+
+    .krkn-ai-content .hero-cta {
+      justify-content: center !important;
+    }
   }
 
   @media (max-width: 600px) {
@@ -255,9 +401,18 @@ Design: Apple-inspired dark theme, cinematic, generous whitespace.
       font-size: 0.9375rem;
     }
 
+    .krkn-ai-features li {
+      font-size: 0.875rem;
+      line-height: 1.55;
+    }
+
+    .krkn-ai-features li strong {
+      display: inline;
+    }
+
     .krkn-ai-terminal__body {
-      font-size: 0.6rem !important;
-      padding: 0.875rem 1rem !important;
+      font-size: 0.55rem !important;
+      padding: 0.75rem 0.75rem !important;
     }
   }
 
@@ -326,9 +481,16 @@ Design: Apple-inspired dark theme, cinematic, generous whitespace.
     line-height: 1.5;
   }
 
+  .krkn-ai-features li span {
+    min-width: 0;
+    overflow-wrap: break-word;
+    word-break: break-word;
+  }
+
   .krkn-ai-features li svg {
     width: 20px;
     height: 20px;
+    min-width: 20px;
     color: var(--krkn-primary);
     flex-shrink: 0;
     margin-top: 2px;
@@ -336,6 +498,8 @@ Design: Apple-inspired dark theme, cinematic, generous whitespace.
 
   .krkn-ai-visual {
     position: relative;
+    max-width: 100%;
+    overflow: hidden;
   }
 
   .krkn-ai-terminal {
@@ -344,6 +508,7 @@ Design: Apple-inspired dark theme, cinematic, generous whitespace.
     border-radius: 0.75rem;
     overflow: hidden;
     box-shadow: 0 4px 24px rgba(0, 0, 0, 0.2);
+    max-width: 100%;
   }
 
   .krkn-ai-terminal__bar {
@@ -388,6 +553,7 @@ Design: Apple-inspired dark theme, cinematic, generous whitespace.
     color: #E6EDF3;
     overflow-x: auto;
     white-space: pre;
+    max-width: 100%;
   }
 
   .krkn-ai-terminal__body .t-prompt {
@@ -463,7 +629,6 @@ Design: Apple-inspired dark theme, cinematic, generous whitespace.
     }
   }
 
-  /* ── Scenario Categories ── */
   .scenario-categories {
     display: grid;
     grid-template-columns: repeat(3, 1fr);
@@ -582,6 +747,22 @@ Design: Apple-inspired dark theme, cinematic, generous whitespace.
   }
 
   @media (max-width: 600px) {
+    .cta-section {
+      padding: 3rem 1.25rem !important;
+    }
+
+    .cta-code {
+      max-width: 100%;
+    }
+
+    .cta-code .code-block pre {
+      padding: 1rem;
+    }
+
+    .cta-code .code-block code {
+      font-size: 0.7rem;
+    }
+
     .scenario-categories {
       grid-template-columns: 1fr;
     }
@@ -609,7 +790,8 @@ Design: Apple-inspired dark theme, cinematic, generous whitespace.
     }
 
     .krkn-ai-terminal__body {
-      font-size: 0.55rem !important;
+      font-size: 0.5rem !important;
+      padding: 0.625rem 0.5rem !important;
     }
 
     .step-card h3 {
@@ -627,7 +809,23 @@ Design: Apple-inspired dark theme, cinematic, generous whitespace.
 
     .steps-grid {
       max-width: 100%;
-      padding: 0 0.5rem;
+      padding: 0;
+    }
+
+    .cta-code .code-block code {
+      font-size: 0.6rem;
+    }
+
+    .hero-cta {
+      flex-direction: column;
+      align-items: center;
+      gap: 0.75rem;
+    }
+
+    .hero-cta .btn-primary-krkn,
+    .hero-cta .btn-outline-krkn {
+      width: 100%;
+      justify-content: center;
     }
   }
 </style>
@@ -895,10 +1093,9 @@ $ krknctl run pod-scenarios --kubeconfig ~/.kube/config
           <h3>Configure</h3>
           <p>Point to your kubeconfig and optionally connect Cerberus for live health monitoring.</p>
           <div class="step-card__code"><span class="c-prompt">$</span> krknctl list available
-            <span class="c-muted">pod-scenarios container-scenarios
-              node-scenarios network-chaos
-              zone-outages time-scenarios ...</span>
-          </div>
+<span class="c-muted">  pod-scenarios  container-scenarios
+  node-scenarios   network-chaos
+  zone-outages     time-scenarios ...</span></div>
         </div>
 
         <div class="step-card reveal" data-delay="250">
@@ -1130,7 +1327,7 @@ $ krknctl run pod-scenarios --kubeconfig ~/.kube/config
                 weakest points</span>
             </li>
           </ul>
-          <div class="hero-cta" style="justify-content:flex-start">
+          <div class="hero-cta">
             <a href="/docs/krkn_ai/" class="btn-primary-krkn">
               Explore Krkn AI
               <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none"

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -1,7 +1,7 @@
 {{/*
-  Krkn Custom Navbar
-  Apple-inspired: clean, minimal, transparent over hero, solid dark on scroll.
-  Overrides Docsy default when placed at layouts/partials/navbar.html.
+Krkn Custom Navbar
+Apple-inspired: clean, minimal, transparent over hero, solid dark on scroll.
+Overrides Docsy default when placed at layouts/partials/navbar.html.
 */}}
 <nav id="krkn-navbar" class="td-navbar krkn-navbar{{ if not .IsHome }} krkn-navbar--solid{{ end }}">
   <div class="krkn-navbar__inner">
@@ -13,15 +13,20 @@
     {{/* Center nav links (desktop only) */}}
     <div class="krkn-navbar__links">
       {{ range .Site.Menus.main }}
-        {{ if and (ne (lower .Name) "github") (ne (lower .Name) "github ") }}
-          <a href="{{ .URL }}" class="krkn-navbar__link{{ if or ($.IsMenuCurrent `main` .) ($.HasMenuCurrent `main` .) }} krkn-navbar__link--active{{ end }}"{{ if hasPrefix .URL "http" }} target="_blank" rel="noopener noreferrer"{{ end }}>{{ .Name }}</a>
-        {{ end }}
+      {{ if and (ne (lower .Name) "github") (ne (lower .Name) "github ") }}
+      <a href="{{ .URL }}"
+        class="krkn-navbar__link{{ if or ($.IsMenuCurrent `main` .) ($.HasMenuCurrent `main` .) }} krkn-navbar__link--active{{ end }}"
+        {{ if hasPrefix .URL "http" }} target="_blank" rel="noopener noreferrer" {{ end }}>{{ .Name }}</a>
+      {{ end }}
       {{ end }}
       {{/* Fallback if menu is empty - hardcode known links */}}
       {{ if not .Site.Menus.main }}
-        <a href="{{ `/docs/` | relLangURL }}" class="krkn-navbar__link{{ if eq .Section `docs` }} krkn-navbar__link--active{{ end }}">Docs</a>
-        <a href="{{ `/blog/` | relLangURL }}" class="krkn-navbar__link{{ if eq .Section `blog` }} krkn-navbar__link--active{{ end }}">Blog</a>
-        <a href="{{ `/community/` | relLangURL }}" class="krkn-navbar__link{{ if eq .Section `community` }} krkn-navbar__link--active{{ end }}">Community</a>
+      <a href="{{ `/docs/` | relLangURL }}"
+        class="krkn-navbar__link{{ if eq .Section `docs` }} krkn-navbar__link--active{{ end }}">Docs</a>
+      <a href="{{ `/blog/` | relLangURL }}"
+        class="krkn-navbar__link{{ if eq .Section `blog` }} krkn-navbar__link--active{{ end }}">Blog</a>
+      <a href="{{ `/community/` | relLangURL }}"
+        class="krkn-navbar__link{{ if eq .Section `community` }} krkn-navbar__link--active{{ end }}">Community</a>
       {{ end }}
     </div>
 
@@ -29,51 +34,94 @@
     <div class="krkn-navbar__actions">
       {{/* Search trigger + inline Docsy/Lunr search */}}
       {{ if .Site.Params.offlineSearch }}
-        <button type="button" class="krkn-navbar__search" id="krkn-search-trigger" aria-label="Search" aria-expanded="false">
-          <svg class="krkn-navbar__icon" xmlns="http://www.w3.org/2000/svg" width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.35-4.35"/></svg>
-        </button>
-        {{/* Search overlay — contains the real Docsy offline search input */}}
-        <div class="krkn-search-overlay" id="krkn-search-overlay" aria-hidden="true">
-          <div class="krkn-search-overlay__backdrop" id="krkn-search-backdrop"></div>
-          <div class="krkn-search-overlay__panel">
-            <div class="krkn-search-overlay__header">
-              <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.35-4.35"/></svg>
-              {{ partial "search-input.html" . }}
-              <button type="button" class="krkn-search-overlay__close" id="krkn-search-close" aria-label="Close search">
-                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
-              </button>
-            </div>
-            <div class="krkn-search-overlay__hint">Press Enter to search &middot; Esc to close</div>
+      <button type="button" class="krkn-navbar__search" id="krkn-search-trigger" aria-label="Search"
+        aria-expanded="false">
+        <svg class="krkn-navbar__icon" xmlns="http://www.w3.org/2000/svg" width="26" height="26" viewBox="0 0 24 24"
+          fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <circle cx="11" cy="11" r="8" />
+          <path d="m21 21-4.35-4.35" />
+        </svg>
+      </button>
+      {{/* Search overlay — contains the real Docsy offline search input */}}
+      <div class="krkn-search-overlay" id="krkn-search-overlay" aria-hidden="true">
+        <div class="krkn-search-overlay__backdrop" id="krkn-search-backdrop"></div>
+        <div class="krkn-search-overlay__panel">
+          <div class="krkn-search-overlay__header">
+            <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none"
+              stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <circle cx="11" cy="11" r="8" />
+              <path d="m21 21-4.35-4.35" />
+            </svg>
+            {{ partial "search-input.html" . }}
+            <button type="button" class="krkn-search-overlay__close" id="krkn-search-close" aria-label="Close search">
+              <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none"
+                stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <line x1="18" y1="6" x2="6" y2="18" />
+                <line x1="6" y1="6" x2="18" y2="18" />
+              </svg>
+            </button>
           </div>
+          <div class="krkn-search-overlay__hint">Press Enter to search &middot; Esc to close</div>
         </div>
+      </div>
       {{ end }}
 
       {{/* Theme toggle */}}
-      <button type="button" class="krkn-navbar__theme-toggle" id="krkn-theme-toggle" aria-label="Toggle light/dark theme">
+      <button type="button" class="krkn-navbar__theme-toggle" id="krkn-theme-toggle"
+        aria-label="Toggle light/dark theme">
         {{/* Sun icon (shown in dark mode) */}}
-        <svg class="krkn-navbar__icon krkn-navbar__icon--sun" xmlns="http://www.w3.org/2000/svg" width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
+        <svg class="krkn-navbar__icon krkn-navbar__icon--sun" xmlns="http://www.w3.org/2000/svg" width="26" height="26"
+          viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+          stroke-linejoin="round">
+          <circle cx="12" cy="12" r="5" />
+          <line x1="12" y1="1" x2="12" y2="3" />
+          <line x1="12" y1="21" x2="12" y2="23" />
+          <line x1="4.22" y1="4.22" x2="5.64" y2="5.64" />
+          <line x1="18.36" y1="18.36" x2="19.78" y2="19.78" />
+          <line x1="1" y1="12" x2="3" y2="12" />
+          <line x1="21" y1="12" x2="23" y2="12" />
+          <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" />
+          <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
+        </svg>
         {{/* Moon icon (shown in light mode) */}}
-        <svg class="krkn-navbar__icon krkn-navbar__icon--moon" xmlns="http://www.w3.org/2000/svg" width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z"/></svg>
+        <svg class="krkn-navbar__icon krkn-navbar__icon--moon" xmlns="http://www.w3.org/2000/svg" width="26" height="26"
+          viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+          stroke-linejoin="round">
+          <path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z" />
+        </svg>
       </button>
 
       {{/* GitHub widget — icon + version, stars, forks */}}
-      <a href="https://github.com/krkn-chaos/krkn" class="krkn-navbar__github-widget" target="_blank" rel="noopener noreferrer" aria-label="GitHub">
-        <svg class="krkn-navbar__icon" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
+      <a href="https://github.com/krkn-chaos/krkn" class="krkn-navbar__github-widget" target="_blank"
+        rel="noopener noreferrer" aria-label="GitHub">
+        <svg class="krkn-navbar__icon" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24"
+          fill="currentColor">
+          <path
+            d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
+        </svg>
         <span class="krkn-navbar__gh-meta">
           <span class="krkn-navbar__gh-version" id="gh-version"></span>
           <span class="krkn-navbar__gh-stat" id="gh-stars">
-            <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="currentColor"><path d="M12 .587l3.668 7.568 8.332 1.151-6.064 5.828 1.48 8.279-7.416-3.967-7.417 3.967 1.481-8.279-6.064-5.828 8.332-1.151z"/></svg>
+            <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="currentColor">
+              <path
+                d="M12 .587l3.668 7.568 8.332 1.151-6.064 5.828 1.48 8.279-7.416-3.967-7.417 3.967 1.481-8.279-6.064-5.828 8.332-1.151z" />
+            </svg>
             <span id="gh-stars-count"></span>
           </span>
           <span class="krkn-navbar__gh-stat" id="gh-forks">
-            <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="currentColor"><path d="M21 3c0-1.657-1.343-3-3-3s-3 1.343-3 3c0 1.323.861 2.443 2.05 2.84-.131 2.078-1.081 3.156-4.05 3.66-1.978.336-3.478 1.098-4.5 2.063V6.84A3.001 3.001 0 0 0 6 0C4.343 0 3 1.343 3 3c0 1.323.861 2.443 2.05 2.84L5 21.16A3.001 3.001 0 0 0 6 27c1.657 0 3-1.343 3-3 0-1.323-.861-2.443-2.05-2.84l.05-4.478c.979 1.503 2.972 2.607 5.55 2.168 4.078-.693 5.393-3.028 5.5-6.01A3.001 3.001 0 0 0 21 3z" transform="scale(0.889)"/></svg>
+            <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="currentColor">
+              <path
+                d="M21 3c0-1.657-1.343-3-3-3s-3 1.343-3 3c0 1.323.861 2.443 2.05 2.84-.131 2.078-1.081 3.156-4.05 3.66-1.978.336-3.478 1.098-4.5 2.063V6.84A3.001 3.001 0 0 0 6 0C4.343 0 3 1.343 3 3c0 1.323.861 2.443 2.05 2.84L5 21.16A3.001 3.001 0 0 0 6 27c1.657 0 3-1.343 3-3 0-1.323-.861-2.443-2.05-2.84l.05-4.478c.979 1.503 2.972 2.607 5.55 2.168 4.078-.693 5.393-3.028 5.5-6.01A3.001 3.001 0 0 0 21 3z"
+                transform="scale(0.889)" />
+            </svg>
             <span id="gh-forks-count"></span>
           </span>
         </span>
       </a>
 
       {{/* Mobile hamburger */}}
-      <button class="krkn-navbar__hamburger" id="krkn-hamburger" aria-label="Toggle menu" aria-expanded="false" aria-controls="krkn-nav-drawer">
+      <button class="krkn-navbar__hamburger" id="krkn-hamburger" aria-label="Toggle menu" aria-expanded="false"
+        aria-controls="krkn-nav-drawer">
         <span class="krkn-navbar__hamburger-line"></span>
         <span class="krkn-navbar__hamburger-line"></span>
         <span class="krkn-navbar__hamburger-line"></span>
@@ -87,18 +135,40 @@
     <div class="krkn-navbar__drawer-content">
       <div class="krkn-navbar__drawer-links">
         {{ range .Site.Menus.main }}
-          {{ if and (ne (lower .Name) "github") (ne (lower .Name) "github ") }}
-            <a href="{{ .URL }}" class="krkn-navbar__drawer-link{{ if or ($.IsMenuCurrent `main` .) ($.HasMenuCurrent `main` .) }} krkn-navbar__drawer-link--active{{ end }}"{{ if hasPrefix .URL "http" }} target="_blank" rel="noopener noreferrer"{{ end }}>{{ .Name }}</a>
-          {{ end }}
+        {{ if and (ne (lower .Name) "github") (ne (lower .Name) "github ") }}
+        <a href="{{ .URL }}"
+          class="krkn-navbar__drawer-link{{ if or ($.IsMenuCurrent `main` .) ($.HasMenuCurrent `main` .) }} krkn-navbar__drawer-link--active{{ end }}"
+          {{ if hasPrefix .URL "http" }} target="_blank" rel="noopener noreferrer" {{ end }}>{{ .Name }}</a>
+        {{ end }}
         {{ end }}
         {{ if not .Site.Menus.main }}
-          <a href="{{ `/docs/` | relLangURL }}" class="krkn-navbar__drawer-link{{ if eq .Section `docs` }} krkn-navbar__drawer-link--active{{ end }}">Docs</a>
-          <a href="{{ `/blog/` | relLangURL }}" class="krkn-navbar__drawer-link{{ if eq .Section `blog` }} krkn-navbar__drawer-link--active{{ end }}">Blog</a>
-          <a href="{{ `/community/` | relLangURL }}" class="krkn-navbar__drawer-link{{ if eq .Section `community` }} krkn-navbar__drawer-link--active{{ end }}">Community</a>
+        <a href="{{ `/docs/` | relLangURL }}"
+          class="krkn-navbar__drawer-link{{ if eq .Section `docs` }} krkn-navbar__drawer-link--active{{ end }}">Docs</a>
+        <a href="{{ `/blog/` | relLangURL }}"
+          class="krkn-navbar__drawer-link{{ if eq .Section `blog` }} krkn-navbar__drawer-link--active{{ end }}">Blog</a>
+        <a href="{{ `/community/` | relLangURL }}"
+          class="krkn-navbar__drawer-link{{ if eq .Section `community` }} krkn-navbar__drawer-link--active{{ end }}">Community</a>
         {{ end }}
       </div>
-      <a href="https://github.com/krkn-chaos/" class="krkn-navbar__drawer-github" target="_blank" rel="noopener noreferrer">
-        <svg class="krkn-navbar__icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
+      {{/* Theme toggle row inside drawer */}}
+      <button type="button" class="krkn-navbar__drawer-theme-toggle" id="krkn-theme-toggle-mobile" aria-label="Toggle light/dark theme">
+        {{/* Sun icon (shown in dark mode) */}}
+        <svg class="krkn-navbar__icon krkn-navbar__icon--sun" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
+        {{/* Moon icon (shown in light mode) */}}
+        <svg class="krkn-navbar__icon krkn-navbar__icon--moon" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z"/></svg>
+        <span class="krkn-navbar__drawer-theme-text">
+          <span class="krkn-navbar__drawer-theme-label--dark">Switch to Light</span>
+          <span class="krkn-navbar__drawer-theme-label--light">Switch to Dark</span>
+        </span>
+      </button>
+
+      <a href="https://github.com/krkn-chaos/" class="krkn-navbar__drawer-github" target="_blank"
+        rel="noopener noreferrer">
+        <svg class="krkn-navbar__icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"
+          fill="currentColor">
+          <path
+            d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
+        </svg>
         GitHub
       </a>
     </div>
@@ -106,206 +176,210 @@
 </nav>
 
 <script>
-(function() {
-  'use strict';
+  (function () {
+    'use strict';
 
-  var navbar = document.getElementById('krkn-navbar');
-  var hamburger = document.getElementById('krkn-hamburger');
-  var drawer = document.getElementById('krkn-nav-drawer');
-  var backdrop = document.getElementById('krkn-drawer-backdrop');
-  var searchTrigger = document.getElementById('krkn-search-trigger');
-  var searchWrap = document.getElementById('krkn-search-wrap');
+    var navbar = document.getElementById('krkn-navbar');
+    var hamburger = document.getElementById('krkn-hamburger');
+    var drawer = document.getElementById('krkn-nav-drawer');
+    var backdrop = document.getElementById('krkn-drawer-backdrop');
+    var searchTrigger = document.getElementById('krkn-search-trigger');
+    var searchWrap = document.getElementById('krkn-search-wrap');
 
-  var SCROLL_THRESHOLD = 50;
-  var isHome = navbar && navbar.classList.contains('krkn-navbar--solid') === false;
+    var SCROLL_THRESHOLD = 50;
+    var isHome = navbar && navbar.classList.contains('krkn-navbar--solid') === false;
 
-  // Add .scrolled class when user scrolls past threshold (hero page only)
-  function onScroll() {
-    if (!navbar) return;
-    if (isHome && window.scrollY > SCROLL_THRESHOLD) {
-      navbar.classList.add('scrolled');
-    } else if (isHome && window.scrollY <= SCROLL_THRESHOLD) {
-      navbar.classList.remove('scrolled');
+    // Add .scrolled class when user scrolls past threshold (hero page only)
+    function onScroll() {
+      if (!navbar) return;
+      if (isHome && window.scrollY > SCROLL_THRESHOLD) {
+        navbar.classList.add('scrolled');
+      } else if (isHome && window.scrollY <= SCROLL_THRESHOLD) {
+        navbar.classList.remove('scrolled');
+      }
     }
-  }
 
-  // Toggle mobile drawer
-  function openDrawer() {
-    if (drawer) drawer.classList.add('krkn-navbar__drawer--open');
-    if (hamburger) {
-      hamburger.classList.add('krkn-navbar__hamburger--active');
-      hamburger.setAttribute('aria-expanded', 'true');
+    // Toggle mobile drawer
+    function openDrawer() {
+      if (drawer) drawer.classList.add('krkn-navbar__drawer--open');
+      if (navbar) navbar.classList.add('krkn-navbar--drawer-open');
+      if (hamburger) {
+        hamburger.classList.add('krkn-navbar__hamburger--active');
+        hamburger.setAttribute('aria-expanded', 'true');
+      }
+      document.body.style.overflow = 'hidden';
     }
-    document.body.style.overflow = 'hidden';
-  }
 
-  function closeDrawer() {
-    if (drawer) drawer.classList.remove('krkn-navbar__drawer--open');
-    if (hamburger) {
-      hamburger.classList.remove('krkn-navbar__hamburger--active');
-      hamburger.setAttribute('aria-expanded', 'false');
+    function closeDrawer() {
+      if (drawer) drawer.classList.remove('krkn-navbar__drawer--open');
+      if (navbar) navbar.classList.remove('krkn-navbar--drawer-open');
+      if (hamburger) {
+        hamburger.classList.remove('krkn-navbar__hamburger--active');
+        hamburger.setAttribute('aria-expanded', 'false');
+      }
+      document.body.style.overflow = '';
     }
-    document.body.style.overflow = '';
-  }
 
-  function toggleDrawer() {
-    if (drawer && drawer.classList.contains('krkn-navbar__drawer--open')) {
-      closeDrawer();
-    } else {
-      openDrawer();
-    }
-  }
-
-  if (hamburger) hamburger.addEventListener('click', toggleDrawer);
-  if (backdrop) backdrop.addEventListener('click', closeDrawer);
-
-  // Close drawer on nav link click (mobile)
-  var drawerLinks = drawer && drawer.querySelectorAll('.krkn-navbar__drawer-link');
-  if (drawerLinks) {
-    drawerLinks.forEach(function(link) {
-      link.addEventListener('click', closeDrawer);
-    });
-  }
-
-  // Close drawer or search on escape
-  document.addEventListener('keydown', function(e) {
-    if (e.key === 'Escape') {
-      if (searchOverlay && searchOverlay.classList.contains('krkn-search-overlay--open')) {
-        closeSearch();
-      } else if (drawer && drawer.classList.contains('krkn-navbar__drawer--open')) {
+    function toggleDrawer() {
+      if (drawer && drawer.classList.contains('krkn-navbar__drawer--open')) {
         closeDrawer();
-      }
-    }
-  });
-
-  // Search overlay
-  var searchOverlay = document.getElementById('krkn-search-overlay');
-  var searchBackdrop = document.getElementById('krkn-search-backdrop');
-  var searchClose = document.getElementById('krkn-search-close');
-  var searchInput = searchOverlay ? searchOverlay.querySelector('input[type="search"], .td-search__input, .td-search input') : null;
-
-  function openSearch() {
-    if (!searchOverlay) return;
-    searchOverlay.classList.add('krkn-search-overlay--open');
-    searchOverlay.setAttribute('aria-hidden', 'false');
-    if (searchTrigger) searchTrigger.setAttribute('aria-expanded', 'true');
-    document.body.style.overflow = 'hidden';
-    // Focus input after CSS transition
-    setTimeout(function() { if (searchInput) searchInput.focus(); }, 120);
-  }
-
-  function closeSearch() {
-    if (!searchOverlay) return;
-    searchOverlay.classList.remove('krkn-search-overlay--open');
-    searchOverlay.setAttribute('aria-hidden', 'true');
-    if (searchTrigger) searchTrigger.setAttribute('aria-expanded', 'false');
-    document.body.style.overflow = '';
-    // Clear results popover
-    if (searchInput) {
-      searchInput.value = '';
-      // Trigger change to clear Lunr popover
-      var evt = new Event('change', { bubbles: true });
-      searchInput.dispatchEvent(evt);
-    }
-  }
-
-  if (searchTrigger) searchTrigger.addEventListener('click', openSearch);
-  if (searchBackdrop) searchBackdrop.addEventListener('click', closeSearch);
-  if (searchClose) searchClose.addEventListener('click', closeSearch);
-
-  // Ctrl/Cmd + K shortcut to open search
-  document.addEventListener('keydown', function(e) {
-    if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
-      e.preventDefault();
-      if (searchOverlay && searchOverlay.classList.contains('krkn-search-overlay--open')) {
-        closeSearch();
       } else {
-        openSearch();
-      }
-    }
-  });
-
-  // Initial state and scroll listener
-  onScroll();
-  window.addEventListener('scroll', onScroll, { passive: true });
-
-  // ---- GitHub stats ----
-  (function fetchGitHubStats() {
-    var repo = 'krkn-chaos/krkn';
-    var cacheKey = 'krkn-gh-stats';
-    var cacheTTL = 3600000; // 1 hour
-
-    function render(data) {
-      var versionEl = document.getElementById('gh-version');
-      var starsEl = document.getElementById('gh-stars-count');
-      var forksEl = document.getElementById('gh-forks-count');
-      if (versionEl && data.version) versionEl.textContent = data.version;
-      if (starsEl && data.stars != null) starsEl.textContent = data.stars >= 1000 ? (data.stars / 1000).toFixed(1) + 'k' : data.stars;
-      if (forksEl && data.forks != null) forksEl.textContent = data.forks >= 1000 ? (data.forks / 1000).toFixed(1) + 'k' : data.forks;
-    }
-
-    // Try cache first
-    try {
-      var cached = JSON.parse(localStorage.getItem(cacheKey));
-      if (cached && Date.now() - cached.ts < cacheTTL) {
-        render(cached.data);
-        return;
-      }
-    } catch(e) {}
-
-    // Fetch repo info (stars, forks) and latest release (version) in parallel
-    var data = {};
-    var done = 0;
-    function check() {
-      done++;
-      if (done >= 2) {
-        render(data);
-        try { localStorage.setItem(cacheKey, JSON.stringify({ ts: Date.now(), data: data })); } catch(e) {}
+        openDrawer();
       }
     }
 
-    fetch('https://api.github.com/repos/' + repo)
-      .then(function(r) { return r.json(); })
-      .then(function(j) { data.stars = j.stargazers_count; data.forks = j.forks_count; })
-      .catch(function() {})
-      .finally(check);
+    if (hamburger) hamburger.addEventListener('click', toggleDrawer);
+    if (backdrop) backdrop.addEventListener('click', closeDrawer);
 
-    fetch('https://api.github.com/repos/' + repo + '/releases/latest')
-      .then(function(r) { return r.json(); })
-      .then(function(j) { if (j.tag_name) data.version = j.tag_name; })
-      .catch(function() {})
-      .finally(check);
-  })();
-
-  // ---- Theme toggle ----
-  var themeToggle = document.getElementById('krkn-theme-toggle');
-
-  function getPreferredTheme() {
-    var stored = localStorage.getItem('krkn-theme');
-    if (stored) return stored;
-    // Default to dark
-    return 'dark';
-  }
-
-  function setTheme(theme) {
-    document.documentElement.setAttribute('data-theme', theme);
-    localStorage.setItem('krkn-theme', theme);
-    // Update toggle aria-label
-    if (themeToggle) {
-      themeToggle.setAttribute('aria-label',
-        theme === 'dark' ? 'Switch to light theme' : 'Switch to dark theme'
-      );
+    // Close drawer on nav link click (mobile)
+    var drawerLinks = drawer && drawer.querySelectorAll('.krkn-navbar__drawer-link');
+    if (drawerLinks) {
+      drawerLinks.forEach(function (link) {
+        link.addEventListener('click', closeDrawer);
+      });
     }
-  }
 
-  // Apply stored theme immediately
-  setTheme(getPreferredTheme());
+    // Close drawer or search on escape
+    document.addEventListener('keydown', function (e) {
+      if (e.key === 'Escape') {
+        if (searchOverlay && searchOverlay.classList.contains('krkn-search-overlay--open')) {
+          closeSearch();
+        } else if (drawer && drawer.classList.contains('krkn-navbar__drawer--open')) {
+          closeDrawer();
+        }
+      }
+    });
 
-  if (themeToggle) {
-    themeToggle.addEventListener('click', function() {
+    // Search overlay
+    var searchOverlay = document.getElementById('krkn-search-overlay');
+    var searchBackdrop = document.getElementById('krkn-search-backdrop');
+    var searchClose = document.getElementById('krkn-search-close');
+    var searchInput = searchOverlay ? searchOverlay.querySelector('input[type="search"], .td-search__input, .td-search input') : null;
+
+    function openSearch() {
+      if (!searchOverlay) return;
+      searchOverlay.classList.add('krkn-search-overlay--open');
+      searchOverlay.setAttribute('aria-hidden', 'false');
+      if (searchTrigger) searchTrigger.setAttribute('aria-expanded', 'true');
+      document.body.style.overflow = 'hidden';
+      // Focus input after CSS transition
+      setTimeout(function () { if (searchInput) searchInput.focus(); }, 120);
+    }
+
+    function closeSearch() {
+      if (!searchOverlay) return;
+      searchOverlay.classList.remove('krkn-search-overlay--open');
+      searchOverlay.setAttribute('aria-hidden', 'true');
+      if (searchTrigger) searchTrigger.setAttribute('aria-expanded', 'false');
+      document.body.style.overflow = '';
+      // Clear results popover
+      if (searchInput) {
+        searchInput.value = '';
+        // Trigger change to clear Lunr popover
+        var evt = new Event('change', { bubbles: true });
+        searchInput.dispatchEvent(evt);
+      }
+    }
+
+    if (searchTrigger) searchTrigger.addEventListener('click', openSearch);
+    if (searchBackdrop) searchBackdrop.addEventListener('click', closeSearch);
+    if (searchClose) searchClose.addEventListener('click', closeSearch);
+
+    // Ctrl/Cmd + K shortcut to open search
+    document.addEventListener('keydown', function (e) {
+      if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+        e.preventDefault();
+        if (searchOverlay && searchOverlay.classList.contains('krkn-search-overlay--open')) {
+          closeSearch();
+        } else {
+          openSearch();
+        }
+      }
+    });
+
+    // Initial state and scroll listener
+    onScroll();
+    window.addEventListener('scroll', onScroll, { passive: true });
+
+    // ---- GitHub stats ----
+    (function fetchGitHubStats() {
+      var repo = 'krkn-chaos/krkn';
+      var cacheKey = 'krkn-gh-stats';
+      var cacheTTL = 3600000; // 1 hour
+
+      function render(data) {
+        var versionEl = document.getElementById('gh-version');
+        var starsEl = document.getElementById('gh-stars-count');
+        var forksEl = document.getElementById('gh-forks-count');
+        if (versionEl && data.version) versionEl.textContent = data.version;
+        if (starsEl && data.stars != null) starsEl.textContent = data.stars >= 1000 ? (data.stars / 1000).toFixed(1) + 'k' : data.stars;
+        if (forksEl && data.forks != null) forksEl.textContent = data.forks >= 1000 ? (data.forks / 1000).toFixed(1) + 'k' : data.forks;
+      }
+
+      // Try cache first
+      try {
+        var cached = JSON.parse(localStorage.getItem(cacheKey));
+        if (cached && Date.now() - cached.ts < cacheTTL) {
+          render(cached.data);
+          return;
+        }
+      } catch (e) { }
+
+      // Fetch repo info (stars, forks) and latest release (version) in parallel
+      var data = {};
+      var done = 0;
+      function check() {
+        done++;
+        if (done >= 2) {
+          render(data);
+          try { localStorage.setItem(cacheKey, JSON.stringify({ ts: Date.now(), data: data })); } catch (e) { }
+        }
+      }
+
+      fetch('https://api.github.com/repos/' + repo)
+        .then(function (r) { return r.json(); })
+        .then(function (j) { data.stars = j.stargazers_count; data.forks = j.forks_count; })
+        .catch(function () { })
+        .finally(check);
+
+      fetch('https://api.github.com/repos/' + repo + '/releases/latest')
+        .then(function (r) { return r.json(); })
+        .then(function (j) { if (j.tag_name) data.version = j.tag_name; })
+        .catch(function () { })
+        .finally(check);
+    })();
+
+    // ---- Theme toggle ----
+    var themeToggle = document.getElementById('krkn-theme-toggle');
+    var themeToggleMobile = document.getElementById('krkn-theme-toggle-mobile');
+
+    function getPreferredTheme() {
+      var stored = localStorage.getItem('krkn-theme');
+      if (stored) return stored;
+      // Default to dark
+      return 'dark';
+    }
+
+    function setTheme(theme) {
+      document.documentElement.setAttribute('data-theme', theme);
+      localStorage.setItem('krkn-theme', theme);
+      // Update toggle aria-label
+      if (themeToggle) {
+        themeToggle.setAttribute('aria-label',
+          theme === 'dark' ? 'Switch to light theme' : 'Switch to dark theme'
+        );
+      }
+    }
+
+    // Apply stored theme immediately
+    setTheme(getPreferredTheme());
+
+    function onThemeToggleClick() {
       var current = document.documentElement.getAttribute('data-theme') || 'dark';
       setTheme(current === 'dark' ? 'light' : 'dark');
-    });
-  }
-})();
+    }
+
+    if (themeToggle) themeToggle.addEventListener('click', onThemeToggleClick);
+    if (themeToggleMobile) themeToggleMobile.addEventListener('click', onThemeToggleClick);
+  })();
 </script>


### PR DESCRIPTION
closes #214 
Refactors the hero section to use a side-by-side layout on desktop for better visual balance. Retains the stacked layout on mobile devices to ensure responsiveness and readability.
Before :
<img width="1919" height="973" alt="image" src="https://github.com/user-attachments/assets/a90c6c57-b3e2-41b6-b693-7fc88cdc8d27" />
<img width="1916" height="923" alt="image" src="https://github.com/user-attachments/assets/e9cf27ce-f194-4bcb-8583-5b9192566059" />

After :
<img width="1919" height="972" alt="image" src="https://github.com/user-attachments/assets/a873359c-465d-411d-9fb2-56c9350f366c" />
