### PR TITLE
docs: add Zone Outage (GCP) to supported rollback scenarios

### DIFF
--- a/content/en/docs/rollback-scenarios/_index.md
+++ b/content/en/docs/rollback-scenarios/_index.md
@@ -44,6 +44,7 @@ Krkn supports rollback for the following scenarios.
 - [PVC Scenarios](../scenarios/pvc-scenario/_index.md)
 - [Service Hijacking](../scenarios/service-hijacking-scenario/_index.md)
 - [Syn Flood ](../scenarios/syn-flood-scenario/_index.md)
+- [Zone Outage (GCP)](../scenarios/zone-outage-scenarios/_index.md)
 
 ## Rollback Command
 


### PR DESCRIPTION
## Documentation Update
**Related Feature:** krkn-chaos/krkn#1200 (feat/gcp-zone-outage-rollback)

**Changes:** 
Added Zone Outage (GCP) to the supported rollback scenarios list in rollback-scenarios/_index.md