### PR TITLE
docs: clarify Node Network Filter krknctl parameters (#250)

### DIFF
--- a/content/en/docs/scenarios/network-chaos-ng-scenarios/network-chaos-ng-scenario-api.md
+++ b/content/en/docs/scenarios/network-chaos-ng-scenarios/network-chaos-ng-scenario-api.md
@@ -27,4 +27,5 @@ Is the base class that contains the common parameters shared by all the Network 
 - `instance_count` if greater than 0 picks `instance_count` elements from the targets selected by the filters randomly
 - `execution` if more than one target are selected by the selector the scenario can target the resources both in `serial` or `parallel`.
 - `namespace` the namespace were the scenario workloads will be deployed
+- `service_account` optional service account for the scenario workload (empty string uses the cluster default)
 - `taints` : List of taints for which tolerations need to created. Example: ["node-role.kubernetes.io/master:NoSchedule"]

--- a/content/en/docs/scenarios/network-chaos-ng-scenarios/node-network-filter/_tab-krkn-hub.md
+++ b/content/en/docs/scenarios/network-chaos-ng-scenarios/node-network-filter/_tab-krkn-hub.md
@@ -44,6 +44,7 @@ See list of variables that apply to all scenarios [here](/docs/scenarios/all-sce
 | PORTS                        | a list of comma separated port numbers (eg 8080 or 8080,8081,8082) to filter for both outgoing and incoming traffic | "" |
 | PROTOCOLS                    | a list of comma separated protocols to filter (tcp, udp or both) |
 | TAINTS               | List of taints for which tolerations need to created. Example: ["node-role.kubernetes.io/master:NoSchedule"] | [] |
+| SERVICE_ACCOUNT             | optional service account for the Node Network Filter workload | "" |
 
 
 **NOTE** In case of using custom metrics profile or alerts profile when `CAPTURE_METRICS` or `ENABLE_ALERTS` is enabled, mount the metrics profile from the host on which the container is run using podman/docker under `/home/krkn/kraken/config/metrics-aggregated.yaml` and `/home/krkn/kraken/config/alerts`. For example:

--- a/content/en/docs/scenarios/network-chaos-ng-scenarios/node-network-filter/_tab-krkn.md
+++ b/content/en/docs/scenarios/network-chaos-ng-scenarios/node-network-filter/_tab-krkn.md
@@ -21,17 +21,19 @@ Example scenario file: [node-network-filter.yml](https://github.com/krkn-chaos/s
   ports:
     - 2049
   taints: []
+  service_account: ""
 ```
 
 for the common module settings please refer to the [documentation](/docs/scenarios/network-chaos-ng-scenarios/network-chaos-ng-scenario-api/#basenetworkchaosconfig-base-module-configuration).
 
-- `ingress`: filters the incoming traffic on one or more ports. If set one or more network interfaces must be specified
-- `egress` : filters the outgoing traffic on one or more ports.
-- `target`: the node name (if label_selector not set)
-- `interfaces`: a list of network interfaces where the incoming traffic will be filtered
-- `ports`: the list of ports that will be filtered
-- `protocols`: the ip protocols to filter (tcp and udp)
-- `taints` : List of taints for which tolerations need to created. Example: ["node-role.kubernetes.io/master:NoSchedule"]
+- `ingress`: filters incoming traffic on one or more ports
+- `egress`: filters outgoing traffic on one or more ports
+- `target`: the node name (if `label_selector` is not set)
+- `interfaces`: network interfaces used for **outgoing** traffic when `egress` is enabled (same semantics as krknctl and krkn-hub)
+- `ports`: ports that incoming and/or outgoing filtering applies to (depending on `ingress` / `egress`)
+- `protocols`: the IP protocols to filter (`tcp` and `udp`)
+- `taints`: list of taints for which tolerations are created. Example: `["node-role.kubernetes.io/master:NoSchedule"]`
+- `service_account`: optional service account for the scenario workload (empty string uses the default)
 
 ### Usage
 

--- a/content/en/docs/scenarios/network-chaos-ng-scenarios/node-network-filter/_tab-krknctl.md
+++ b/content/en/docs/scenarios/network-chaos-ng-scenarios/node-network-filter/_tab-krknctl.md
@@ -6,6 +6,8 @@ Can also set any global variable listed [here](../../all-scenario-env-krknctl.md
 
 ### Node Network Filter Parameters
 
+krknctl marks `--ingress` and `--egress` as required flags (you should pass both). **Values:** at least one of `--ingress` or `--egress` must be `true`; both may be `true` to filter incoming and outgoing traffic.
+
 | Argument          | Type    | Description                                                                 | Required | Default Value                       |
 | :---------------- | :------ | :-------------------------------------------------------------------------- | :------- | :---------------------------------- |
 | `--chaos-duration`| number  | Chaos duration in seconds                                                   | false    | 60                                  |
@@ -14,14 +16,14 @@ Can also set any global variable listed [here](../../all-scenario-env-krknctl.md
 | `--namespace`     | string  | Namespace where the scenario container is deployed                          | false    | default                             |
 | `--instance-count`| number  | Number of nodes to target when using node-selector                          | false    | 1                                   |
 | `--execution`     | enum    | Execution mode: `parallel` or `serial`                                      | false    | parallel                            |
-| `--ingress`       | boolean | Filter incoming traffic (at least one of ingress/egress must be true)       | true     |                                     |
-| `--egress`        | boolean | Filter outgoing traffic (at least one of ingress/egress must be true)       | true     |                                     |
-| `--interfaces`    | string  | Network interfaces to filter traffic (comma-separated, auto-detected if empty) | false    |                                     |
+| `--ingress`       | boolean | Filter incoming traffic (`true` / `false`)                                | true     |                                     |
+| `--egress`        | boolean | Filter outgoing traffic (`true` / `false`)                                  | true     |                                     |
+| `--interfaces`    | string  | Network interfaces for **outgoing** traffic (comma-separated, e.g. `eth0,eth1`). Optional; empty uses workload defaults | false    |                                     |
 | `--ports`         | string  | Network ports to filter traffic (comma-separated, e.g., `8080,8081,8082`)   | true     |                                     |
 | `--image`         | string  | The network chaos injection workload container image                        | false    | quay.io/krkn-chaos/krkn-network-chaos:latest |
 | `--protocols`     | string  | Network protocols to filter: `tcp`, `udp`, or `tcp,udp`                     | false    | tcp                                 |
-| `--taints`        | string  | Comma-separated tolerations for the workload (e.g., `key=value:NoSchedule`) | false    |                                     |
-| `--service-account`| string | Service account for the workload                                            | false    |                                     |
+| `--taints`        | string  | Comma-separated **taints** (tolerations are derived for the workload). Same notation as elsewhere in Network Chaos NG docs, e.g. `node-role.kubernetes.io/master:NoSchedule` | false    |                                     |
+| `--service-account`| string | Service account for the workload (optional)                                 | false    |                                     |
 
 ### Parameter Format Details
 
@@ -40,18 +42,19 @@ Can also set any global variable listed [here](../../all-scenario-env-krknctl.md
 - Default: `tcp`
 
 **Interface Format:**
+- Applies to **egress** (outgoing) filtering, matching the scenario image metadata
 - Single interface: `eth0`
 - Multiple interfaces: `eth0,eth1,eth2` (comma-separated, no spaces)
-- If empty, the scenario auto-detects the default network interface
+- May be left empty when not needed for your egress rules
 
 **Taints Format:**
-- Standard Kubernetes toleration format
-- Example: `key=value:NoSchedule,key2=value2:NoExecute`
+- Comma-separated Kubernetes **taints**; the workload gets matching tolerations
+- Examples: `node-role.kubernetes.io/master:NoSchedule` or `key=value:NoSchedule` when the taint includes a value
 
 ### Usage Notes
 
 - **Node targeting:** This scenario targets nodes (not pods) and creates iptables rules on the target node(s) to filter network traffic
-- **Ingress/Egress:** At least one of `--ingress` or `--egress` must be set to `true`. Both can be `true` to filter both incoming and outgoing traffic
+- **Ingress/Egress:** Pass both flags; at least one must be `true`. Both may be `true` to filter incoming and outgoing traffic
 - **Execution modes:**
   - `parallel`: Applies network filtering to all selected nodes simultaneously
   - `serial`: Applies network filtering to nodes one at a time


### PR DESCRIPTION
## Documentation Update
**Related Feature:** 
NA

**Changes:** 

Updates the Node Network Filter **Krknctl** tab: correct parameter table (node targeting, execution modes), documented formats for ports/protocols/interfaces/taints, ingress/egress rules, and runnable example commands.

