### PR TITLE
Fix typos, grammar errors, and stray characters in scenario docs (#288)

### DIFF
--- a/content/en/docs/krknctl/usage.md
+++ b/content/en/docs/krknctl/usage.md
@@ -281,7 +281,7 @@ If you're using krknctl in a disconnected environment, you can mirror the desire
 |--private-registry-scenarios | KRKNCTL_PRIVATE_REGISTRY_SCENARIOS |  private registry krkn scenarios image repository |
 |--private-registry-skip-tls | KRKNCTL_PRIVATE_REGISTRY_SKIP_TLS | skips tls verification on private registry |
 |--private-registry-token |  KRKNCTL_PRIVATE_REGISTRY_TOKEN |      private registry identity token for token based authentication|
-|-private-registry-username |  KRKNCTL_PRIVATE_REGISTRY_USERNAME |   private registry username for basic authentication |
+|--private-registry-username |  KRKNCTL_PRIVATE_REGISTRY_USERNAME |   private registry username for basic authentication |
 
 
 {{% alert title="Note" %}}

--- a/content/en/docs/scenarios/application-outage/_tab-krkn-hub.md
+++ b/content/en/docs/scenarios/application-outage/_tab-krkn-hub.md
@@ -54,7 +54,8 @@ chmod 444 ~/kubeconfig && \
 docker run $(./get_docker_params.sh) \
   --name=<container_name> \
   --net=host \
-  -v ~kubeconfig:/home/krkn/.kube/config:Z \
+  --pull=always \
+  -v ~/kubeconfig:/home/krkn/.kube/config:Z \
   -d containers.krkn-chaos.dev/krkn-chaos/krkn-hub:<scenario>
 ```
 {{% /alert %}}

--- a/content/en/docs/scenarios/container-scenario/_tab-krkn-hub.md
+++ b/content/en/docs/scenarios/container-scenario/_tab-krkn-hub.md
@@ -61,7 +61,7 @@ Parameter               | Description                                           
 NAMESPACE               | Targeted namespace in the cluster                                     | openshift-etcd                       |
 LABEL_SELECTOR          | Label of the container(s) to target                                   | k8s-app=etcd                         | 
 EXCLUDE_LABEL            | Pods to exclude after getting list of pods from LABEL_SELECTOR to target. For example "app=foo"                                | No default                           |
-DISRUPTION_COUNT        | Number of container to disrupt                                        | 1                                    |
+DISRUPTION_COUNT        | Number of containers to disrupt                                        | 1                                    |
 CONTAINER_NAME          | Name of the container to disrupt                                      | etcd                                 |
 ACTION                  | kill signal to run. For example 1 ( hang up ) or 9                    | 1                                    |
 EXPECTED_RECOVERY_TIME  | Time to wait before checking if all containers that were affected recover properly | 60                      |

--- a/content/en/docs/scenarios/container-scenario/_tab-krknctl.md
+++ b/content/en/docs/scenarios/container-scenario/_tab-krknctl.md
@@ -12,7 +12,7 @@ Scenario specific parameters:
 `--namespace` | Targeted namespace in the cluster | string | openshift-etcd | 
 `--label-selector` | Label of the container(s) to target | string | k8s-app=etcd | 
 `--exclude-selector` | Pods to exclude from targeting. For example "{app: foo}"  | string | "" | 
-`--disruption-count` | Number of container to disrupt | number | 1 | 
+`--disruption-count` | Number of containers to disrupt | number | 1 | 
 `--container-name` | Name of the container to disrupt | string | etcd | 
 `--action` | kill signal to run. For example 1 ( hang up ) or 9 | string | 1 | 
 `--expected-recovery-time` | Time to wait before checking if all containers that were affected recover properly | number | 60 | 

--- a/content/en/docs/scenarios/hog-scenarios/_index.md
+++ b/content/en/docs/scenarios/hog-scenarios/_index.md
@@ -30,7 +30,7 @@ These scenarios involve deploying one or more workloads in the cluster. Based on
 | `image` | string  | the container image of the stress workload  (quay.io/krkn-chaos/krkn-hog)  |
 | `namespace` | string   | the namespace where the stress workload will be deployed   |
 | `node-selector` | string (Optional) | defines the node selector for choosing target nodes. If not specified, one schedulable node in the cluster will be chosen at random. If multiple nodes match the selector, all of them will be subjected to stress. If number-of-nodes is specified, that many nodes will be randomly selected from those identified by the selector. |
-|`taints`| list (Optional) default [] | list of taints for which tolerations need to created. Example: ["node-role.kubernetes.io/master:NoSchedule"]|
+|`taints`| list (Optional) default [] | list of taints for which tolerations need to be created. Example: ["node-role.kubernetes.io/master:NoSchedule"]|
 | `number-of-nodes` | number (Optional) | restricts the number of selected nodes by the selector|
 
 ### Available Scenarios

--- a/content/en/docs/scenarios/hog-scenarios/cpu-hog-scenario/_tab-krkn-hub.md
+++ b/content/en/docs/scenarios/hog-scenarios/cpu-hog-scenario/_tab-krkn-hub.md
@@ -65,7 +65,7 @@ See list of variables that apply to all scenarios [here](/docs/scenarios/all-sce
 | NODE_CPU_PERCENTAGE  | Percentage of total cpu to be consumed                  | 50                                   |
 | NAMESPACE            | Namespace where the scenario container will be deployed | default |
 | NODE_SELECTOR        | Defines the node selector for choosing target nodes. If not specified, one schedulable node in the cluster will be chosen at random. If multiple nodes match the selector, all of them will be subjected to stress. If number-of-nodes is specified, that many nodes will be randomly selected from those identified by the selector.                                     | "" |                             |
-| TAINTS               | List of taints for which tolerations need to created. Example: ["node-role.kubernetes.io/master:NoSchedule"] | [] |
+| TAINTS               | List of taints for which tolerations need to be created. Example: ["node-role.kubernetes.io/master:NoSchedule"] | [] |
 | NUMBER_OF_NODES      | Restricts the number of selected nodes by the selector                                     | "" |                             |
 | IMAGE                | The container image of the stress workload|quay.io/krkn-chaos/krkn-hog||
 

--- a/content/en/docs/scenarios/hog-scenarios/cpu-hog-scenario/_tab-krknctl.md
+++ b/content/en/docs/scenarios/hog-scenarios/cpu-hog-scenario/_tab-krknctl.md
@@ -13,7 +13,7 @@ Can also set any global variable listed [here](../../all-scenario-env-krknctl.md
 `--cpu-percentage` | Percentage of total cpu to be consumed | number |  50 | 
 `--namespace` | Namespace where the scenario container will be deployed | string |  default | 
 `--node-selector` | Node selector where the scenario containers will be scheduled in the format "<selector>=<value>". NOTE:  Will be instantiated a container per each node selected with the same scenario options. If left empty a random node will be selected | string | 
-`--taints` | List of taints for which tolerations need to created. For example ["node-role.kubernetes.io/master:NoSchedule"]" | string | [] |
+`--taints` | List of taints for which tolerations need to be created. For example ["node-role.kubernetes.io/master:NoSchedule"]" | string | [] |
 `--number-of-nodes` | restricts the number of selected nodes by the selector | number | 
 `--image` | The hog container image. Can be changed if the hog image is mirrored on a private repository | string |  quay.io/krkn-chaos/krkn-hog | 
 

--- a/content/en/docs/scenarios/hog-scenarios/io-hog-scenario/_tab-krkn-hub.md
+++ b/content/en/docs/scenarios/hog-scenarios/io-hog-scenario/_tab-krkn-hub.md
@@ -65,7 +65,7 @@ See list of variables that apply to all scenarios [here](/docs/scenarios/all-sce
 | IO_WRITE_BYTES      | string writes N bytes for each hdd process. The size can be expressed as % of free space on the file system or in units of Bytes, KBytes, MBytes and GBytes using the suffix b, k, m or g   | 10m |
 | NAMESPACE            | Namespace where the scenario container will be deployed   | default |
 | NODE_SELECTOR        | defines the node selector for choosing target nodes. If not specified, one schedulable node in the cluster will be chosen at random. If multiple nodes match the selector, all of them will be subjected to stress. If number-of-nodes is specified, that many nodes will be randomly selected from those identified by the selector. | "" |     |
-| TAINTS               | List of taints for which tolerations need to created. Example: ["node-role.kubernetes.io/master:NoSchedule"] | [] |
+| TAINTS               | List of taints for which tolerations need to be created. Example: ["node-role.kubernetes.io/master:NoSchedule"] | [] |
 | NODE_MOUNT_PATH        | the local path in the node that will be mounted in the pod and that will be filled by the scenario              | "" |   |
 | NUMBER_OF_NODES      | restricts the number of selected nodes by the selector     | "" |                             |
 | IMAGE                | the container image of the stress workload      |quay.io/krkn-chaos/krkn-hog||

--- a/content/en/docs/scenarios/hog-scenarios/io-hog-scenario/_tab-krknctl.md
+++ b/content/en/docs/scenarios/hog-scenarios/io-hog-scenario/_tab-krknctl.md
@@ -9,13 +9,13 @@ Can also set any global variable listed [here](../../all-scenario-env-krknctl.md
 | Parameter      | Description    | Type      |  Default | 
 | ----------------------- | ----------------------    | ----------------  | ------------------------------------ |
 `--chaos-duration` |Set chaos duration (in sec) as desired | number | 60 | 
-`--oo-block-size` |sSze of each write in bytes. Size can be from 1 byte to 4 Megabytes (allowed suffix are b,k,m) | string | 1m | 
+`--oo-block-size` |Size of each write in bytes. Size can be from 1 byte to 4 Megabytes (allowed suffix are b,k,m) | string | 1m | 
 `--io-workers` |Number of stressor instances | number | 5 | 
 `--io-write-bytes` |string writes N bytes for each hdd process. The size can be expressed as % of free space on the file system or in units of Bytes, KBytes, MBytes and GBytes using the suffix b, k, m or g | string | 10m | 
 `--node-mount-path` |the path in the node that will be mounted in the pod and where the io hog will be executed. NOTE: be sure that kubelet has the rights to write in that node path | string | /root | 
 `--namespace` |Namespace where the scenario container will be deployed | string | default | 
 `--node-selector` |Node selector where the scenario containers will be scheduled in the format "<selector>=<value>". NOTE:  Will be instantiated a container per each node selected with the same scenario options. If left empty a random node will be selected | string | 
-`--taints` | List of taints for which tolerations need to created. For example ["node-role.kubernetes.io/master:NoSchedule"]" | string | [] |
+`--taints` | List of taints for which tolerations need to be created. For example ["node-role.kubernetes.io/master:NoSchedule"]" | string | [] |
 `--number-of-nodes` |restricts the number of selected nodes by the selector | number |
 `--image` |The hog container image. Can be changed if the hog image is mirrored on a private repository | string | quay.io/krkn-chaos/krkn-hog | 
 

--- a/content/en/docs/scenarios/hog-scenarios/memory-hog-scenario/_tab-krkn-hub.md
+++ b/content/en/docs/scenarios/hog-scenarios/memory-hog-scenario/_tab-krkn-hub.md
@@ -64,7 +64,7 @@ See list of variables that apply to all scenarios [here](/docs/scenarios/all-sce
 | NUMBER_OF_WORKERS             | Total number of workers (stress-ng threads)   | 1    |
 | NAMESPACE                     | Namespace where the scenario container will be deployed | default |
 | NODE_SELECTOR                 | defines the node selector for choosing target nodes. If not specified, one schedulable node in the cluster will be chosen at random. If multiple nodes match the selector, all of them will be subjected to stress. If number-of-nodes is specified, that many nodes will be randomly selected from those identified by the selector.                                     | "" |                             |
-| TAINTS               | List of taints for which tolerations need to created. Example: ["node-role.kubernetes.io/master:NoSchedule"] | [] |
+| TAINTS               | List of taints for which tolerations need to be created. Example: ["node-role.kubernetes.io/master:NoSchedule"] | [] |
 | NUMBER_OF_NODES               | restricts the number of selected nodes by the selector                                     | "" |                             |
 | IMAGE                         | the container image of the stress workload|quay.io/krkn-chaos/krkn-hog||                          
 

--- a/content/en/docs/scenarios/hog-scenarios/memory-hog-scenario/_tab-krknctl.md
+++ b/content/en/docs/scenarios/hog-scenarios/memory-hog-scenario/_tab-krknctl.md
@@ -13,7 +13,7 @@ Can also set any global variable listed [here](../../all-scenario-env-krknctl.md
 `--memory-consumption` | percentage (expressed with the suffix %) or amount (expressed with the suffix b, k, m or g) of memory to be consumed by the scenario |string|  90%|
 `--namespace` |Namespace where the scenario container will be deployed | string | default | 
 `--node-selector` |Node selector where the scenario containers will be scheduled in the format "<selector>=<value>". NOTE:  Will be instantiated a container per each node selected with the same scenario options. If left empty a random node will be selected | string | 
-`--taints` | List of taints for which tolerations need to created. For example ["node-role.kubernetes.io/master:NoSchedule"]" | string | [] |
+`--taints` | List of taints for which tolerations need to be created. For example ["node-role.kubernetes.io/master:NoSchedule"]" | string | [] |
 `--number-of-nodes` |restricts the number of selected nodes by the selector | number |
 `--image` |The hog container image. Can be changed if the hog image is mirrored on a private repository | string | quay.memory/krkn-chaos/krkn-hog | 
 

--- a/content/en/docs/scenarios/network-chaos-ng-scenarios/network-chaos-ng-scenario-api.md
+++ b/content/en/docs/scenarios/network-chaos-ng-scenarios/network-chaos-ng-scenario-api.md
@@ -28,4 +28,4 @@ Is the base class that contains the common parameters shared by all the Network 
 - `execution` if more than one target are selected by the selector the scenario can target the resources both in `serial` or `parallel`.
 - `namespace` the namespace were the scenario workloads will be deployed
 - `service_account` optional service account for the scenario workload (empty string uses the cluster default)
-- `taints` : List of taints for which tolerations need to created. Example: ["node-role.kubernetes.io/master:NoSchedule"]
+- `taints` : List of taints for which tolerations need to be created. Example: ["node-role.kubernetes.io/master:NoSchedule"]

--- a/content/en/docs/scenarios/network-chaos-ng-scenarios/node-network-filter/_tab-krkn-hub.md
+++ b/content/en/docs/scenarios/network-chaos-ng-scenarios/node-network-filter/_tab-krkn-hub.md
@@ -43,7 +43,7 @@ See list of variables that apply to all scenarios [here](/docs/scenarios/all-sce
 | INTERFACES                   | a list of comma separated names of network interfaces (eg. eth0 or eth0,eth1,eth2) to filter for outgoing traffic | "" |
 | PORTS                        | a list of comma separated port numbers (eg 8080 or 8080,8081,8082) to filter for both outgoing and incoming traffic | "" |
 | PROTOCOLS                    | a list of comma separated protocols to filter (tcp, udp or both) |
-| TAINTS               | List of taints for which tolerations need to created. Example: ["node-role.kubernetes.io/master:NoSchedule"] | [] |
+| TAINTS               | List of taints for which tolerations need to be created. Example: ["node-role.kubernetes.io/master:NoSchedule"] | [] |
 | SERVICE_ACCOUNT             | optional service account for the Node Network Filter workload | "" |
 
 

--- a/content/en/docs/scenarios/network-chaos-ng-scenarios/pod-network-filter/_tab-krkn-hub.md
+++ b/content/en/docs/scenarios/network-chaos-ng-scenarios/pod-network-filter/_tab-krkn-hub.md
@@ -44,7 +44,7 @@ See list of variables that apply to all scenarios [here](/docs/scenarios/all-sce
 | INTERFACES           | a list of comma separated names of network interfaces (eg. eth0 or eth0,eth1,eth2) to filter for outgoing traffic                | ""                                |
 | PORTS                | a list of comma separated port numbers (eg 8080 or 8080,8081,8082) to filter for both outgoing and incoming traffic              | ""                                |
 | PROTOCOLS            | a list of comma separated network protocols  (tcp, udp or both of them e.g. tcp,udp)                                             | "tcp"                             |
-| TAINTS               | List of taints for which tolerations need to created. Example: ["node-role.kubernetes.io/master:NoSchedule"] | [] |
+| TAINTS               | List of taints for which tolerations need to be created. Example: ["node-role.kubernetes.io/master:NoSchedule"] | [] |
 
 
 **NOTE** In case of using custom metrics profile or alerts profile when `CAPTURE_METRICS` or `ENABLE_ALERTS` is enabled, mount the metrics profile from the host on which the container is run using podman/docker under `/home/krkn/kraken/config/metrics-aggregated.yaml` and `/home/krkn/kraken/config/alerts`. For example:

--- a/content/en/docs/scenarios/network-chaos-ng-scenarios/pod-network-filter/_tab-krkn.md
+++ b/content/en/docs/scenarios/network-chaos-ng-scenarios/pod-network-filter/_tab-krkn.md
@@ -32,7 +32,7 @@ for the common module settings please refer to the [documentation](../network-ch
 - `interfaces`: a list of network interfaces where the incoming traffic will be filtered
 - `ports`: the list of ports that will be filtered
 - `protocols`: the ip protocols to filter (tcp and udp)
-- `taints` : List of taints for which tolerations need to created. Example: ["node-role.kubernetes.io/master:NoSchedule"]
+- `taints` : List of taints for which tolerations need to be created. Example: ["node-role.kubernetes.io/master:NoSchedule"]
 
 ### Usage
 

--- a/content/en/docs/scenarios/network-chaos-ng-scenarios/pod-network-filter/_tab-krknctl.md
+++ b/content/en/docs/scenarios/network-chaos-ng-scenarios/pod-network-filter/_tab-krknctl.md
@@ -20,4 +20,4 @@ Can also set any global variable listed [here](../../all-scenario-env-krknctl.md
 | `--ports`         | string  | Network ports to filter traffic (if more than one separated by comma)       | true     |                                     |
 | `--image`         | string  | The network chaos injection workload container image                        | false    | quay.io/krkn-chaos/krkn-network-chaos:latest |
 | `--protocols`     | string  | The network protocols that will be filtered                                 | false    | tcp                                 |
-| `--taints`| String | List of taints for which tolerations need to created | false ||
+| `--taints`| String | List of taints for which tolerations need to be created | false ||

--- a/content/en/docs/scenarios/network-chaos-scenario/_tab-krknctl.md
+++ b/content/en/docs/scenarios/network-chaos-scenario/_tab-krknctl.md
@@ -18,7 +18,7 @@ Scenario specific parameters:
 `--node-name` | Node name to inject faults in case of targeting a specific node; Can set multiple node names separated by a comma | string | 
 `--interfaces` | List of interface on which to apply the network restriction. eg. | [eth0,eth1,eth2] | string| | | 
 `--egress` | Dictonary of values to set network latency(latency: 50ms), packet loss(loss: 0.02), bandwidth restriction(bandwidth: 100mbit) eg. {bandwidth: 100mbit} | string| "{bandwidth: 100mbit}" | 
-`--target-node-interface` | Dictionary with key as node name(s) and value as a list of its interfaces to test. For example: {ip-10-0-216-2.us-west-2.compute.internal: ens5]} | string | 
+`--target-node-interface` | Dictionary with key as node name(s) and value as a list of its interfaces to test. For example: {ip-10-0-216-2.us-west-2.compute.internal: ens5] | string | 
 `--network-params` | latency, loss and bandwidth are the three supported network parameters to alter for the chaos test. For example: {latency: 50ms, loss: 0.02} | string | 
 `--wait-duration` | Ensure that it is at least about twice of test_duration | number| 300| 
 

--- a/content/en/docs/scenarios/node-scenarios/_tab-krkn-hub.md
+++ b/content/en/docs/scenarios/node-scenarios/_tab-krkn-hub.md
@@ -36,7 +36,7 @@ $ docker inspect <container-name or container-id> \
 ```
 {{% alert title="Tip" %}} Because the container runs with a non-root user, ensure the kube config is globally readable before mounting it in the container. You can achieve this with the following commands:
 ```bash
-kubectl config view --flatten > ~/kubeconfig && chmod 444 ~/kubeconfig && docker run $(./get_docker_params.sh) --name=<container_name> --net=host -v ~kubeconfig:/home/krkn/.kube/config:Z -d containers.krkn-chaos.dev/krkn-chaos/krkn-hub:<scenario>
+kubectl config view --flatten > ~/kubeconfig && chmod 444 ~/kubeconfig && docker run $(./get_docker_params.sh) --name=<container_name> --net=host -v ~/kubeconfig:/home/krkn/.kube/config:Z -d containers.krkn-chaos.dev/krkn-chaos/krkn-hub:<scenario>
 ```
 
 {{% /alert %}}

--- a/content/en/docs/scenarios/node-scenarios/_tab-krknctl.md
+++ b/content/en/docs/scenarios/node-scenarios/_tab-krknctl.md
@@ -19,9 +19,9 @@ Scenario specific parameters:  (be sure to scroll to right)
 `--kube-check` | Connecting to the kubernetes api to check the node status, set to False for SNO | enum | true | 
 `--timeout` | Duration to wait for completion of node scenario injection | number | 180| 
 `--duration` | Duration to wait for completion of node scenario injection | number | 120 | 
-`--vsphere-ip` | VSpere IP Address | string | 
-`--vsphere-username` | VSpere IP Address | string (secret)| 
-`--vsphere-password` | VSpere password | string (secret)| 
+`--vsphere-ip` | vSphere IP address | string | 
+`--vsphere-username` | vSphere IP address | string (secret)| 
+`--vsphere-password` | vSphere password | string (secret)| 
 `--aws-access-key-id` | AWS Access Key Id | string (secret)| 
 `--aws-secret-access-key` | AWS Secret Access Key | string (secret)| 
 `--aws-default-region` | AWS default region | string | 

--- a/content/en/docs/scenarios/pod-scenario/_tab-krkn-hub.md
+++ b/content/en/docs/scenarios/pod-scenario/_tab-krkn-hub.md
@@ -41,7 +41,7 @@ $ docker inspect <container-name or container-id> \
   --format "{{.State.ExitCode}}" # Outputs exit code which can considered as pass/fail for the scenario
 ```
 {{% alert title="Tip" %}} Because the container runs with a non-root user, ensure the kube config is globally readable before mounting it in the container. You can achieve this with the following commands:
-```kubectl config view --flatten > ~/kubeconfig && chmod 444 ~/kubeconfig && docker run $(./get_docker_params.sh) --name=<container_name> --net=host --pull=always -v ~kubeconfig:/home/krkn/.kube/config:Z -d containers.krkn-chaos.dev/krkn-chaos/krkn-hub:<scenario>``` {{% /alert %}}
+```kubectl config view --flatten > ~/kubeconfig && chmod 444 ~/kubeconfig && docker run $(./get_docker_params.sh) --name=<container_name> --net=host --pull=always -v ~/kubeconfig:/home/krkn/.kube/config:Z -d containers.krkn-chaos.dev/krkn-chaos/krkn-hub:<scenario>``` {{% /alert %}}
 
 #### Supported parameters
 

--- a/content/en/docs/scenarios/power-outage-scenarios/_tab-krknctl.md
+++ b/content/en/docs/scenarios/power-outage-scenarios/_tab-krknctl.md
@@ -12,9 +12,9 @@ Scenario specific parameters:
 `--cloud-type` | Cloud platform on top of which cluster is running, supported platforms - aws, azure, gcp, vmware, ibmcloud, bm | enum | aws | 
 `--timeout` | Duration to wait for completion of node scenario injection | number | 180| 
 `--shutdown-duration` | Duration to wait for completion of node scenario injection | number | 1200 | 
-`--vsphere-ip` | VSpere IP Address | string | 
-`--vsphere-username` | VSpere IP Address | string (secret)| 
-`--vsphere-password` | VSpere password | string (secret)| 
+`--vsphere-ip` | vSphere IP address | string | 
+`--vsphere-username` | vSphere IP address | string (secret)| 
+`--vsphere-password` | vSphere password | string (secret)| 
 `--aws-access-key-id` | AWS Access Key Id | string (secret)| 
 `--aws-secret-access-key` | AWS Secret Access Key | string (secret)| 
 `--aws-default-region` | AWS default region | string | 

--- a/content/en/docs/scenarios/syn-flood-scenario/_tab-krknctl.md
+++ b/content/en/docs/scenarios/syn-flood-scenario/_tab-krknctl.md
@@ -1,6 +1,6 @@
 
 ```bash
-krknctl run syn-flood (optional: --<parameter>:<value> ) |
+krknctl run syn-flood (optional: --<parameter>:<value> )
 ```
 
 Can also set any global variable listed [here](../all-scenario-env-krknctl.md) 

--- a/content/en/docs/scenarios/time-scenarios/_tab-krknctl.md
+++ b/content/en/docs/scenarios/time-scenarios/_tab-krknctl.md
@@ -1,6 +1,6 @@
 
 ```bash
-krknctl run time-scenarios  (optional: --<parameter>:<value> ) |
+krknctl run time-scenarios  (optional: --<parameter>:<value> )
 ```
 
 Can also set any global variable listed [here](../all-scenario-env-krknctl.md) 


### PR DESCRIPTION
## Summary
- Fix `VSpere` → `vSphere` typos in node-scenarios and power-outage krknctl tabs
- Fix `sSze` → `Size` in io-hog-scenario krknctl tab
- Fix `Number of container` → `Number of containers` in container-scenario (krknctl + hub tabs)
- Fix `need to created` → `need to be created` across 12 files
- Remove trailing `|` in syn-flood and time-scenarios krknctl tabs
- Remove trailing `}` in network-chaos-scenario krknctl tab
- Fix volume mount typo `~kubeconfig` → `~/kubeconfig` in 3 hub tab tip blocks
- Fix single-dash `--private-registry-username` in krknctl/usage.md
- Add missing `--pull=always` to application-outage hub tab tip block

Closes #288

## Test plan
- [ ] Verify all fixed files render correctly on the site
- [ ] Check dark and light themes
- [ ] No new typos introduced