### PR TITLE
Fix wrong flag names, image references, and scenario identifiers (#290)

### DIFF
--- a/content/en/docs/scenarios/application-outage/_tab-krknctl.md
+++ b/content/en/docs/scenarios/application-outage/_tab-krknctl.md
@@ -12,7 +12,7 @@ Scenario specific parameters:
 `--namespace` | Namespace to target - all application routes will go inaccessible if pod selector is empty | string | True |
 `--chaos-duration` | Set chaos duration (in sec) as desired  | number | False | 600 | 
 `--pod-selector` | Pods to target. For example "{app: foo}"  | string | False | | 
-`--exclude-label` | Pods to exclude after using pod-selector to target. For example "{app: foo}"  | string | False | | 
+`--exclude-selector` | Pods to exclude after using pod-selector to target. For example "{app: foo}"  | string | False | | 
 `--block-traffic-type` | It can be [Ingress] or [Egress] or [Ingress, Egress] | string | False | "[Ingress, Egress]" | 
 
 To see all available scenario options 

--- a/content/en/docs/scenarios/hog-scenarios/io-hog-scenario/_tab-krknctl.md
+++ b/content/en/docs/scenarios/hog-scenarios/io-hog-scenario/_tab-krknctl.md
@@ -9,7 +9,7 @@ Can also set any global variable listed [here](../../all-scenario-env-krknctl.md
 | Parameter      | Description    | Type      |  Default | 
 | ----------------------- | ----------------------    | ----------------  | ------------------------------------ |
 `--chaos-duration` |Set chaos duration (in sec) as desired | number | 60 | 
-`--oo-block-size` |Size of each write in bytes. Size can be from 1 byte to 4 Megabytes (allowed suffix are b,k,m) | string | 1m | 
+`--io-block-size` |Size of each write in bytes. Size can be from 1 byte to 4 Megabytes (allowed suffix are b,k,m) | string | 1m | 
 `--io-workers` |Number of stressor instances | number | 5 | 
 `--io-write-bytes` |string writes N bytes for each hdd process. The size can be expressed as % of free space on the file system or in units of Bytes, KBytes, MBytes and GBytes using the suffix b, k, m or g | string | 10m | 
 `--node-mount-path` |the path in the node that will be mounted in the pod and where the io hog will be executed. NOTE: be sure that kubelet has the rights to write in that node path | string | /root | 

--- a/content/en/docs/scenarios/network-chaos-ng-scenarios/pod-network-filter/_tab-krkn-hub.md
+++ b/content/en/docs/scenarios/network-chaos-ng-scenarios/pod-network-filter/_tab-krkn-hub.md
@@ -49,5 +49,5 @@ See list of variables that apply to all scenarios [here](/docs/scenarios/all-sce
 
 **NOTE** In case of using custom metrics profile or alerts profile when `CAPTURE_METRICS` or `ENABLE_ALERTS` is enabled, mount the metrics profile from the host on which the container is run using podman/docker under `/home/krkn/kraken/config/metrics-aggregated.yaml` and `/home/krkn/kraken/config/alerts`. For example:
 ```bash
-$ podman run --name=<container_name> --net=host --pull=always --env-host=true -v <path-to-custom-metrics-profile>:/home/krkn/kraken/config/metrics-aggregated.yaml -v <path-to-custom-alerts-profile>:/home/krkn/kraken/config/alerts -v <path-to-kube-config>:/home/krkn/.kube/config:Z -d quay.io/krkn-chaos/krkn-hub:pod-network-traffic
+$ podman run --name=<container_name> --net=host --pull=always --env-host=true -v <path-to-custom-metrics-profile>:/home/krkn/kraken/config/metrics-aggregated.yaml -v <path-to-custom-alerts-profile>:/home/krkn/kraken/config/alerts -v <path-to-kube-config>:/home/krkn/.kube/config:Z -d quay.io/krkn-chaos/krkn-hub:pod-network-filter
 ```

--- a/content/en/docs/scenarios/power-outage-scenarios/_tab-krkn-hub.md
+++ b/content/en/docs/scenarios/power-outage-scenarios/_tab-krkn-hub.md
@@ -104,7 +104,7 @@ $ podman run \
   -v <path-to-custom-metrics-profile>:/home/krkn/kraken/config/metrics-aggregated.yaml \
   -v <path-to-custom-alerts-profile>:/home/krkn/kraken/config/alerts \
   -v <path-to-kube-config>:/home/krkn/.kube/config:Z \
-  -d containers.krkn-chaos.dev/krkn-chaos/krkn-hub:container-scenarios
+  -d containers.krkn-chaos.dev/krkn-chaos/krkn-hub:power-outages
 ```
 
 

--- a/content/en/docs/scenarios/pvc-scenario/_index.md
+++ b/content/en/docs/scenarios/pvc-scenario/_index.md
@@ -4,7 +4,7 @@ description:
 date: 2017-01-04
 weight: 3
 ---
-<krkn-hub-scenario id="power-outages">
+<krkn-hub-scenario id="pvc-scenarios">
 Scenario to fill up a given PersistenVolumeClaim by creating a temp file on the PVC from a pod associated with it. The purpose of this scenario is to fill up a volume to understand faults caused by the application using this volume.
 </krkn-hub-scenario>
 


### PR DESCRIPTION
## Summary
- Fix `--oo-block-size` → `--io-block-size` in io-hog krknctl tab
- Fix `--exclude-label` → `--exclude-selector` in application-outage krknctl tab
- Fix wrong container image `krkn-hub:pod-network-traffic` → `krkn-hub:pod-network-filter`
- Fix wrong container image `krkn-hub:container-scenarios` → `krkn-hub:power-outages`
- Fix PVC scenario ID `power-outages` → `pvc-scenarios`

Closes #290

## Test plan
- [ ] Verify corrected flags match krkn-hub krknctl-input.json
- [ ] Verify corrected images exist in container registry
- [ ] Pages render correctly in both themes