### PR TITLE
fix copy-pasted wrong descriptions across scenario tabs (#294)

### DIFF
--- a/content/en/docs/scenarios/container-scenario/_tab-krkn-hub.md
+++ b/content/en/docs/scenarios/container-scenario/_tab-krkn-hub.md
@@ -66,7 +66,6 @@ CONTAINER_NAME          | Name of the container to disrupt                      
 ACTION                  | kill signal to run. For example 1 ( hang up ) or 9                    | 1                                    |
 EXPECTED_RECOVERY_TIME  | Time to wait before checking if all containers that were affected recover properly | 60                      |
 
-{{% alert title="Note" %}} Set NAMESPACE environment variable to `openshift-.*` to pick and disrupt pods randomly in openshift system namespaces, the DAEMON_MODE can also be enabled to disrupt the pods every x seconds in the background to check the reliability.{{% /alert %}}
 
 {{% alert title="Note" %}} In case of using custom metrics profile or alerts profile when `CAPTURE_METRICS` or `ENABLE_ALERTS` is enabled, mount the metrics profile from the host on which the container is run using podman/docker under `/home/krkn/kraken/config/metrics-aggregated.yaml` and `/home/krkn/kraken/config/alerts`.{{% /alert %}}
  For example:

--- a/content/en/docs/scenarios/power-outage-scenarios/_tab-krknctl.md
+++ b/content/en/docs/scenarios/power-outage-scenarios/_tab-krknctl.md
@@ -10,8 +10,8 @@ Scenario specific parameters:
 | Parameter      | Description    | Type      |  Default | 
 | ----------------------- | ----------------------    | ----------------  | ------------------------------------ | 
 `--cloud-type` | Cloud platform on top of which cluster is running, supported platforms - aws, azure, gcp, vmware, ibmcloud, bm | enum | aws | 
-`--timeout` | Duration to wait for completion of node scenario injection | number | 180| 
-`--shutdown-duration` | Duration to wait for completion of node scenario injection | number | 1200 | 
+`--timeout` | Time in seconds to wait for each node to be stopped or running after the cluster comes back | number | 180| 
+`--shutdown-duration` | Duration in seconds to shut down the cluster | number | 1200 | 
 `--vsphere-ip` | vSphere IP address | string | 
 `--vsphere-username` | vSphere IP address | string (secret)| 
 `--vsphere-password` | vSphere password | string (secret)| 


### PR DESCRIPTION
## Summary
- Fix 4 copy-pasted "Duration to wait for completion of node scenario injection" descriptions in PVC, KubeVirt, and power-outage krknctl tabs with correct krkn-hub source text
- Fix `--vm-name` description in KubeVirt tab from node-scenario text to "Name of the VM to delete"
- Remove copy-pasted pod-scenario note about `openshift-.*` and `DAEMON_MODE` from container hub tab (container env.sh doesn't support either)

## Test plan
- [ ] Verify PVC `--duration` description matches [krkn-hub source](https://github.com/krkn-chaos/krkn-hub/blob/main/pvc-scenario/krknctl-input.json#L38-L45)
- [ ] Verify KubeVirt `--timeout` and `--vm-name` descriptions match [krkn-hub source](https://github.com/krkn-chaos/krkn-hub/blob/main/kubevirt-outage/krknctl-input.json)
- [ ] Verify power-outage `--timeout` and `--shutdown-duration` descriptions match [krkn-hub source](https://github.com/krkn-chaos/krkn-hub/blob/main/power-outages/krknctl-input.json)
- [ ] Verify container hub tab no longer has the `openshift-.*` / `DAEMON_MODE` note
- [ ] Pages render correctly in both dark and light themes

Closes #294