### PR TITLE
fix network-chaos loss format to match canonical examples (#296)

### DIFF
--- a/content/en/docs/scenarios/network-chaos-scenario/_tab-krkn.md
+++ b/content/en/docs/scenarios/network-chaos-scenario/_tab-krkn.md
@@ -14,7 +14,7 @@ network_chaos:                                    # Scenario to create an outage
   execution: serial                               # Default: serial. Options: serial, parallel. Execute each of the egress options as a single scenario(parallel) or as separate scenario(serial).
   egress:
     latency: 500ms
-    loss: 0.02                                   # percentage (e.g. 0.02 = 0.02% packet loss)
+    loss: 2                                      # 2% packet loss (value is a percentage, e.g. 50 = 50%)
     bandwidth: 10mbit
   image: quay.io/krkn-chaos/krkn:tools
 ```
@@ -34,7 +34,7 @@ network_chaos:                                    # Scenario to create an outage
     execution_type: parallel                        # Execute each of the ingress options as a single scenario(parallel) or as separate scenario(serial).
     network_params:
         latency: 500ms
-        loss: '0.02'
+        loss: '2'                               # 2% packet loss (value is a percentage, must be quoted)
         bandwidth: 10mbit
     wait_duration: 120
     test_duration: 60

--- a/content/en/docs/scenarios/network-chaos-scenario/_tab-krkn.md
+++ b/content/en/docs/scenarios/network-chaos-scenario/_tab-krkn.md
@@ -14,7 +14,7 @@ network_chaos:                                    # Scenario to create an outage
   execution: serial                               # Default: serial. Options: serial, parallel. Execute each of the egress options as a single scenario(parallel) or as separate scenario(serial).
   egress:
     latency: 500ms
-    loss: 50%                                    # percentage
+    loss: 0.02                                   # percentage (e.g. 0.02 = 0.02% packet loss)
     bandwidth: 10mbit
   image: quay.io/krkn-chaos/krkn:tools
 ```
@@ -34,7 +34,7 @@ network_chaos:                                    # Scenario to create an outage
     execution_type: parallel                        # Execute each of the ingress options as a single scenario(parallel) or as separate scenario(serial).
     network_params:
         latency: 500ms
-        loss: '50%'
+        loss: '0.02'
         bandwidth: 10mbit
     wait_duration: 120
     test_duration: 60


### PR DESCRIPTION
## Summary
- Fix egress example `loss: 50%` → `loss: 0.02` to match [canonical krkn example](https://github.com/krkn-chaos/krkn/blob/main/scenarios/openshift/network_chaos.yaml#L11)
- Fix ingress example `loss: '50%'` → `loss: '0.02'` to match [canonical krkn guidance](https://github.com/krkn-chaos/krkn/blob/main/scenarios/openshift/network_chaos_ingress.yml#L13)

## Test plan
- [ ] Verify egress YAML example uses `loss: 0.02` without `%`
- [ ] Verify ingress YAML example uses `loss: '0.02'`
- [ ] Page renders correctly in both dark and light themes

Closes #296