### PR TITLE
add Required column to krknctl parameter tables (#298)

### DIFF
--- a/content/en/docs/scenarios/container-scenario/_tab-krknctl.md
+++ b/content/en/docs/scenarios/container-scenario/_tab-krknctl.md
@@ -7,15 +7,15 @@ Can also set any global variable listed [here](../all-scenario-env-krknctl.md)
 
 
 Scenario specific parameters: 
-| Parameter      | Description    | Type      |  Default | 
-| ----------------------- | ----------------------    | ----------------  | ------------------------------------ |
-`--namespace` | Targeted namespace in the cluster | string | openshift-etcd | 
-`--label-selector` | Label of the container(s) to target | string | k8s-app=etcd | 
-`--exclude-selector` | Pods to exclude from targeting. For example "{app: foo}"  | string | "" | 
-`--disruption-count` | Number of containers to disrupt | number | 1 | 
-`--container-name` | Name of the container to disrupt | string | etcd | 
-`--action` | kill signal to run. For example 1 ( hang up ) or 9 | string | 1 | 
-`--expected-recovery-time` | Time to wait before checking if all containers that were affected recover properly | number | 60 | 
+| Parameter      | Description    | Type      | Required |  Default | 
+| ----------------------- | ----------------------    | ----------------  | :------: | ------------------------------------ |
+`--namespace` | Targeted namespace in the cluster | string | No | openshift-etcd | 
+`--label-selector` | Label of the container(s) to target | string | No | k8s-app=etcd | 
+`--exclude-selector` | Pods to exclude from targeting. For example "{app: foo}"  | string | No | "" | 
+`--disruption-count` | Number of containers to disrupt | number | No | 1 | 
+`--container-name` | Name of the container to disrupt | string | No | etcd | 
+`--action` | kill signal to run. For example 1 ( hang up ) or 9 | string | No | 1 | 
+`--expected-recovery-time` | Time to wait before checking if all containers that were affected recover properly | number | No | 60 | 
 
 
 #### Behavior Notes

--- a/content/en/docs/scenarios/hog-scenarios/cpu-hog-scenario/_tab-krknctl.md
+++ b/content/en/docs/scenarios/hog-scenarios/cpu-hog-scenario/_tab-krknctl.md
@@ -6,16 +6,16 @@ krknctl run node-cpu-hog [--<parameter> <value>]
 
 Can also set any global variable listed [here](../../all-scenario-env-krknctl.md)
 
-| Parameter      | Description    | Type      |  Default | 
-| ----------------------- | ----------------------    | ----------------  | ------------------------------------ |
-`--chaos-duration` | Set chaos duration (in secs) as desired | number |  60 | 
-`--cores` | Number of cores (workers) of node CPU to be consumed | number | 
-`--cpu-percentage` | Percentage of total cpu to be consumed | number |  50 | 
-`--namespace` | Namespace where the scenario container will be deployed | string |  default | 
-`--node-selector` | Node selector where the scenario containers will be scheduled in the format "<selector>=<value>". NOTE:  Will be instantiated a container per each node selected with the same scenario options. If left empty a random node will be selected | string | 
-`--taints` | List of taints for which tolerations need to be created. For example ["node-role.kubernetes.io/master:NoSchedule"]" | string | [] |
-`--number-of-nodes` | restricts the number of selected nodes by the selector | number | 
-`--image` | The hog container image. Can be changed if the hog image is mirrored on a private repository | string |  quay.io/krkn-chaos/krkn-hog | 
+| Parameter      | Description    | Type      | Required |  Default | 
+| ----------------------- | ----------------------    | ----------------  | :------: | ------------------------------------ |
+`--chaos-duration` | Set chaos duration (in secs) as desired | number | No |  60 | 
+`--cores` | Number of cores (workers) of node CPU to be consumed | number | No | 
+`--cpu-percentage` | Percentage of total cpu to be consumed | number | No |  50 | 
+`--namespace` | Namespace where the scenario container will be deployed | string | No |  default | 
+`--node-selector` | Node selector where the scenario containers will be scheduled in the format "<selector>=<value>". NOTE:  Will be instantiated a container per each node selected with the same scenario options. If left empty a random node will be selected | string | No | 
+`--taints` | List of taints for which tolerations need to be created. For example ["node-role.kubernetes.io/master:NoSchedule"]" | string | No | [] |
+`--number-of-nodes` | restricts the number of selected nodes by the selector | number | No | 
+`--image` | The hog container image. Can be changed if the hog image is mirrored on a private repository | string | No |  quay.io/krkn-chaos/krkn-hog | 
 
 
 

--- a/content/en/docs/scenarios/hog-scenarios/io-hog-scenario/_tab-krknctl.md
+++ b/content/en/docs/scenarios/hog-scenarios/io-hog-scenario/_tab-krknctl.md
@@ -6,18 +6,18 @@ krknctl run node-io-hog [--<parameter> <value>]
 
 Can also set any global variable listed [here](../../all-scenario-env-krknctl.md )
 
-| Parameter      | Description    | Type      |  Default | 
-| ----------------------- | ----------------------    | ----------------  | ------------------------------------ |
-`--chaos-duration` |Set chaos duration (in sec) as desired | number | 60 | 
-`--io-block-size` |Size of each write in bytes. Size can be from 1 byte to 4 Megabytes (allowed suffix are b,k,m) | string | 1m | 
-`--io-workers` |Number of stressor instances | number | 5 | 
-`--io-write-bytes` |string writes N bytes for each hdd process. The size can be expressed as % of free space on the file system or in units of Bytes, KBytes, MBytes and GBytes using the suffix b, k, m or g | string | 10m | 
-`--node-mount-path` |the path in the node that will be mounted in the pod and where the io hog will be executed. NOTE: be sure that kubelet has the rights to write in that node path | string | /root | 
-`--namespace` |Namespace where the scenario container will be deployed | string | default | 
-`--node-selector` |Node selector where the scenario containers will be scheduled in the format "<selector>=<value>". NOTE:  Will be instantiated a container per each node selected with the same scenario options. If left empty a random node will be selected | string | 
-`--taints` | List of taints for which tolerations need to be created. For example ["node-role.kubernetes.io/master:NoSchedule"]" | string | [] |
-`--number-of-nodes` |restricts the number of selected nodes by the selector | number |
-`--image` |The hog container image. Can be changed if the hog image is mirrored on a private repository | string | quay.io/krkn-chaos/krkn-hog | 
+| Parameter      | Description    | Type      | Required |  Default | 
+| ----------------------- | ----------------------    | ----------------  | :------: | ------------------------------------ |
+`--chaos-duration` |Set chaos duration (in sec) as desired | number | No | 60 | 
+`--io-block-size` |Size of each write in bytes. Size can be from 1 byte to 4 Megabytes (allowed suffix are b,k,m) | string | No | 1m | 
+`--io-workers` |Number of stressor instances | number | No | 5 | 
+`--io-write-bytes` |string writes N bytes for each hdd process. The size can be expressed as % of free space on the file system or in units of Bytes, KBytes, MBytes and GBytes using the suffix b, k, m or g | string | No | 10m | 
+`--node-mount-path` |the path in the node that will be mounted in the pod and where the io hog will be executed. NOTE: be sure that kubelet has the rights to write in that node path | string | No | /root | 
+`--namespace` |Namespace where the scenario container will be deployed | string | No | default | 
+`--node-selector` |Node selector where the scenario containers will be scheduled in the format "<selector>=<value>". NOTE:  Will be instantiated a container per each node selected with the same scenario options. If left empty a random node will be selected | string | No | 
+`--taints` | List of taints for which tolerations need to be created. For example ["node-role.kubernetes.io/master:NoSchedule"]" | string | No | [] |
+`--number-of-nodes` |restricts the number of selected nodes by the selector | number | No |
+`--image` |The hog container image. Can be changed if the hog image is mirrored on a private repository | string | No | quay.io/krkn-chaos/krkn-hog | 
 
 
 

--- a/content/en/docs/scenarios/hog-scenarios/memory-hog-scenario/_tab-krknctl.md
+++ b/content/en/docs/scenarios/hog-scenarios/memory-hog-scenario/_tab-krknctl.md
@@ -15,7 +15,7 @@ Can also set any global variable listed [here](../../all-scenario-env-krknctl.md
 `--node-selector` |Node selector where the scenario containers will be scheduled in the format "<selector>=<value>". NOTE:  Will be instantiated a container per each node selected with the same scenario options. If left empty a random node will be selected | string | No | 
 `--taints` | List of taints for which tolerations need to be created. For example ["node-role.kubernetes.io/master:NoSchedule"]" | string | No | [] |
 `--number-of-nodes` |restricts the number of selected nodes by the selector | number | No |
-`--image` |The hog container image. Can be changed if the hog image is mirrored on a private repository | string | No | quay.memory/krkn-chaos/krkn-hog | 
+`--image` |The hog container image. Can be changed if the hog image is mirrored on a private repository | string | No | quay.io/krkn-chaos/krkn-hog | 
 
 
 

--- a/content/en/docs/scenarios/hog-scenarios/memory-hog-scenario/_tab-krknctl.md
+++ b/content/en/docs/scenarios/hog-scenarios/memory-hog-scenario/_tab-krknctl.md
@@ -6,16 +6,16 @@ krknctl run node-memory-hog [--<parameter> <value>]
 
 Can also set any global variable listed [here](../../all-scenario-env-krknctl.md )
 
-| Parameter      | Description  | Type      |  Default | 
-| ----------------------- | ----------------------    | ----------------  | ------------------------------------ |
-`--chaos-duration` |Set chaos duration (in sec) as desired | number | 60 | 
-`--memory-workers` | Total number of workers (stress-ng threads) |number|1|
-`--memory-consumption` | percentage (expressed with the suffix %) or amount (expressed with the suffix b, k, m or g) of memory to be consumed by the scenario |string|  90%|
-`--namespace` |Namespace where the scenario container will be deployed | string | default | 
-`--node-selector` |Node selector where the scenario containers will be scheduled in the format "<selector>=<value>". NOTE:  Will be instantiated a container per each node selected with the same scenario options. If left empty a random node will be selected | string | 
-`--taints` | List of taints for which tolerations need to be created. For example ["node-role.kubernetes.io/master:NoSchedule"]" | string | [] |
-`--number-of-nodes` |restricts the number of selected nodes by the selector | number |
-`--image` |The hog container image. Can be changed if the hog image is mirrored on a private repository | string | quay.memory/krkn-chaos/krkn-hog | 
+| Parameter      | Description  | Type      | Required |  Default | 
+| ----------------------- | ----------------------    | ----------------  | :------: | ------------------------------------ |
+`--chaos-duration` |Set chaos duration (in sec) as desired | number | No | 60 | 
+`--memory-workers` | Total number of workers (stress-ng threads) |number| No |1|
+`--memory-consumption` | percentage (expressed with the suffix %) or amount (expressed with the suffix b, k, m or g) of memory to be consumed by the scenario |string| No |  90%|
+`--namespace` |Namespace where the scenario container will be deployed | string | No | default | 
+`--node-selector` |Node selector where the scenario containers will be scheduled in the format "<selector>=<value>". NOTE:  Will be instantiated a container per each node selected with the same scenario options. If left empty a random node will be selected | string | No | 
+`--taints` | List of taints for which tolerations need to be created. For example ["node-role.kubernetes.io/master:NoSchedule"]" | string | No | [] |
+`--number-of-nodes` |restricts the number of selected nodes by the selector | number | No |
+`--image` |The hog container image. Can be changed if the hog image is mirrored on a private repository | string | No | quay.memory/krkn-chaos/krkn-hog | 
 
 
 

--- a/content/en/docs/scenarios/kubevirt-vm-outage-scenario/_tab-krknctl.md
+++ b/content/en/docs/scenarios/kubevirt-vm-outage-scenario/_tab-krknctl.md
@@ -7,12 +7,12 @@ Can also set any global variable listed [here](../all-scenario-env-krknctl.md)
 
 
 Scenario specific parameters:  (be sure to scroll to right)
-| Parameter      | Description    | Type      |  Default | Possible Values | 
-| ----------------------- | ----------------------    | ----------------  | ------------------------------------ | :----------------:  | 
-`--namespace` | VMI Namespace to target | string | default | 
-`--vm-name` | Name of the VM to delete | string | 
-`--timeout` | Time that scenario will wait for VM to come back | number | 60| 
-`--kill-count` | Number of VMI's to kill (will perform serially) | number | 1| 
+| Parameter      | Description    | Type      | Required |  Default | Possible Values | 
+| ----------------------- | ----------------------    | ----------------  | :------: | ------------------------------------ | :----------------:  | 
+`--namespace` | VMI Namespace to target | string | Yes | default | 
+`--vm-name` | Name of the VM to delete | string | Yes | | 
+`--timeout` | Time that scenario will wait for VM to come back | number | No | 60 | 
+`--kill-count` | Number of VMI's to kill (will perform serially) | number | No | 1| 
 
 #### Behavior Notes
 

--- a/content/en/docs/scenarios/network-chaos-scenario/_tab-krknctl.md
+++ b/content/en/docs/scenarios/network-chaos-scenario/_tab-krknctl.md
@@ -9,16 +9,16 @@ Can also set any global variable listed [here](../all-scenario-env-krknctl.md)
 Scenario specific parameters: 
 | Parameter      | Description    | Type      | Required |  Default | 
 | ----------------------- | ----------------------    | ----------------  | :------: | ------------------------------------ |
-`--traffic-type` | Selects the network chaos scenario type can be ingress or egress | enum | Yes |   ingress|egress
+`--traffic-type` | Selects the network chaos scenario type can be ingress or egress | enum | Yes | ingress \| egress
 `--image` | Image used to disrupt network on a pod  | string | No |  quay.io/krkn-chaos/krkn:tools | 
 `--duration` | Duration in seconds - during with network chaos will be applied. | number| No | 300 | 
 `--label-selector` | When NODE_NAME is not specified, a node with matching label_selector is selected for running. | string| No | node-role.kubernetes.io/master |
 `--execution` | Execute each of the egress option as a single scenario(parallel) or as separate scenario(serial). | enum | No | parallel |
 `--instance-count` | Targeted instance count matching the label selector. | number | No | 1 | 
 `--node-name` | Node name to inject faults in case of targeting a specific node; Can set multiple node names separated by a comma | string | No | 
-`--interfaces` | List of interface on which to apply the network restriction. eg. | [eth0,eth1,eth2] | string| No | | 
+`--interfaces` | List of interface on which to apply the network restriction. eg. [eth0,eth1,eth2] | string | No | [] |
 `--egress` | Dictonary of values to set network latency(latency: 50ms), packet loss(loss: 0.02), bandwidth restriction(bandwidth: 100mbit) eg. {bandwidth: 100mbit} | string| No | "{bandwidth: 100mbit}" | 
-`--target-node-interface` | Dictionary with key as node name(s) and value as a list of its interfaces to test. For example: {ip-10-0-216-2.us-west-2.compute.internal: ens5]} | string | No | 
+`--target-node-interface` | Dictionary with key as node name(s) and value as a list of its interfaces to test. For example: {ip-10-0-216-2.us-west-2.compute.internal: [ens5]} | string | No |
 `--network-params` | latency, loss and bandwidth are the three supported network parameters to alter for the chaos test. For example: {latency: 50ms, loss: 0.02} | string | No | 
 `--wait-duration` | Ensure that it is at least about twice of test_duration | number| No | 300| 
 

--- a/content/en/docs/scenarios/network-chaos-scenario/_tab-krknctl.md
+++ b/content/en/docs/scenarios/network-chaos-scenario/_tab-krknctl.md
@@ -7,20 +7,20 @@ Can also set any global variable listed [here](../all-scenario-env-krknctl.md)
 
 
 Scenario specific parameters: 
-| Parameter      | Description    | Type      |  Default | 
-| ----------------------- | ----------------------    | ----------------  | ------------------------------------ |
-`--traffic-type` | Selects the network chaos scenario type can be ingress or egress | enum |   ingress|egress
-`--image` | Image used to disrupt network on a pod  | string |  quay.io/krkn-chaos/krkn:tools | 
-`--duration` | Duration in seconds - during with network chaos will be applied. | number| 300 | 
-`--label-selector` | When NODE_NAME is not specified, a node with matching label_selector is selected for running. | string| node-role.kubernetes.io/master |
-`--execution` | Execute each of the egress option as a single scenario(parallel) or as separate scenario(serial). | enum | parallel |
-`--instance-count` | Targeted instance count matching the label selector. | number | 1 | 
-`--node-name` | Node name to inject faults in case of targeting a specific node; Can set multiple node names separated by a comma | string | 
-`--interfaces` | List of interface on which to apply the network restriction. eg. | [eth0,eth1,eth2] | string| | | 
-`--egress` | Dictonary of values to set network latency(latency: 50ms), packet loss(loss: 0.02), bandwidth restriction(bandwidth: 100mbit) eg. {bandwidth: 100mbit} | string| "{bandwidth: 100mbit}" | 
-`--target-node-interface` | Dictionary with key as node name(s) and value as a list of its interfaces to test. For example: {ip-10-0-216-2.us-west-2.compute.internal: ens5] | string | 
-`--network-params` | latency, loss and bandwidth are the three supported network parameters to alter for the chaos test. For example: {latency: 50ms, loss: 0.02} | string | 
-`--wait-duration` | Ensure that it is at least about twice of test_duration | number| 300| 
+| Parameter      | Description    | Type      | Required |  Default | 
+| ----------------------- | ----------------------    | ----------------  | :------: | ------------------------------------ |
+`--traffic-type` | Selects the network chaos scenario type can be ingress or egress | enum | Yes |   ingress|egress
+`--image` | Image used to disrupt network on a pod  | string | No |  quay.io/krkn-chaos/krkn:tools | 
+`--duration` | Duration in seconds - during with network chaos will be applied. | number| No | 300 | 
+`--label-selector` | When NODE_NAME is not specified, a node with matching label_selector is selected for running. | string| No | node-role.kubernetes.io/master |
+`--execution` | Execute each of the egress option as a single scenario(parallel) or as separate scenario(serial). | enum | No | parallel |
+`--instance-count` | Targeted instance count matching the label selector. | number | No | 1 | 
+`--node-name` | Node name to inject faults in case of targeting a specific node; Can set multiple node names separated by a comma | string | No | 
+`--interfaces` | List of interface on which to apply the network restriction. eg. | [eth0,eth1,eth2] | string| No | | 
+`--egress` | Dictonary of values to set network latency(latency: 50ms), packet loss(loss: 0.02), bandwidth restriction(bandwidth: 100mbit) eg. {bandwidth: 100mbit} | string| No | "{bandwidth: 100mbit}" | 
+`--target-node-interface` | Dictionary with key as node name(s) and value as a list of its interfaces to test. For example: {ip-10-0-216-2.us-west-2.compute.internal: ens5]} | string | No | 
+`--network-params` | latency, loss and bandwidth are the three supported network parameters to alter for the chaos test. For example: {latency: 50ms, loss: 0.02} | string | No | 
+`--wait-duration` | Ensure that it is at least about twice of test_duration | number| No | 300| 
 
 
 #### Parameter Dependencies

--- a/content/en/docs/scenarios/node-scenarios/_tab-krknctl.md
+++ b/content/en/docs/scenarios/node-scenarios/_tab-krknctl.md
@@ -11,7 +11,7 @@ Scenario specific parameters:  (be sure to scroll to right)
 | ----------------------- | ----------------------    | ------------------  | :------: | ------------------------------------ | :----------------:  | 
 `--action` | action performed on the node, visit https://github.com/krkn-chaos/krkn/blob/main/docs/node_scenarios.md for more infos | enum | Yes |  | node_start_scenario,node_stop_scenario,node_stop_start_scenario,node_termination_scenario,node_reboot_scenario,stop_kubelet_scenario,stop_start_kubelet_scenario,restart_kubelet_scenario,node_crash_scenario,stop_start_helper_node_scenario | 
 `--label-selector` | Node label to target | string | No | node-role.kubernetes.io/worker | 
-`--exclude-label` | excludes nodes marked by this label from chaos || No |
+`--exclude-label` | excludes nodes marked by this label from chaos | string | No |
 `--node-name` | Node name to inject faults in case of targeting a specific node; Can set multiple node names separated by a comma | string | No | 
 `--instance-count` | Targeted instance count matching the label selector | number | No | 1 | 
 `--runs` | Iterations to perform action on a single node | number | No | 1 | 

--- a/content/en/docs/scenarios/node-scenarios/_tab-krknctl.md
+++ b/content/en/docs/scenarios/node-scenarios/_tab-krknctl.md
@@ -7,37 +7,37 @@ Can also set any global variable listed [here](../all-scenario-env-krknctl.md)
 
 
 Scenario specific parameters:  (be sure to scroll to right)
-| Parameter      | Description    | Type      |  Default | Possible Values | 
-| ----------------------- | ----------------------    | ------------------  | ------------------------------------ | :----------------:  | 
-`--action` | action performed on the node, visit https://github.com/krkn-chaos/krkn/blob/main/docs/node_scenarios.md for more infos | enum |  | node_start_scenario,node_stop_scenario,node_stop_start_scenario,node_termination_scenario,node_reboot_scenario,stop_kubelet_scenario,stop_start_kubelet_scenario,restart_kubelet_scenario,node_crash_scenario,stop_start_helper_node_scenario | 
-`--label-selector` | Node label to target | string | node-role.kubernetes.io/worker | 
-`--exclude-label` | excludes nodes marked by this label from chaos ||
-`--node-name` | Node name to inject faults in case of targeting a specific node; Can set multiple node names separated by a comma | string | 
-`--instance-count` | Targeted instance count matching the label selector | number | 1 | 
-`--runs` | Iterations to perform action on a single node | number | 1 | 
-`--cloud-type` | Cloud platform on top of which cluster is running, supported platforms - aws, azure, gcp, vmware, ibmcloud, bm | enum | aws | 
-`--kube-check` | Connecting to the kubernetes api to check the node status, set to False for SNO | enum | true | 
-`--timeout` | Duration to wait for completion of node scenario injection | number | 180| 
-`--duration` | Duration to wait for completion of node scenario injection | number | 120 | 
-`--vsphere-ip` | vSphere IP address | string | 
-`--vsphere-username` | vSphere IP address | string (secret)| 
-`--vsphere-password` | vSphere password | string (secret)| 
-`--aws-access-key-id` | AWS Access Key Id | string (secret)| 
-`--aws-secret-access-key` | AWS Secret Access Key | string (secret)| 
-`--aws-default-region` | AWS default region | string | 
-`--bmc-user` | Only needed for Baremetal ( bm ) - IPMI/bmc username | string(secret) | 
-`--bmc-password` | Only needed for Baremetal ( bm ) - IPMI/bmc password | string(secret) | 
-`--bmc-address` | Only needed for Baremetal ( bm ) - IPMI/bmc address | string | 
-`--ibmc-address` | IBM Cloud URL | string | 
-`--ibmc-api-key` | IBM Cloud API Key | string (secret)| 
-`--ibmc-power-address` | IBM Power Cloud URL | string | 
-`--ibmc-cnr` | IBM Cloud Power Workspace CNR | string | 
-`--disable-ssl-verification` | Disable SSL verification, to avoid certificate errors | enum | false |
-`--azure-tenant` | Azure Tenant | string  | 
-`--azure-client-secret` | Azure Client Secret | string(secret) | 
-`--azure-client-id` | Azure Client ID | string(secret) | 
-`--azure-subscription-id` | Azure Subscription ID | string (secret)| 
-`--gcp-application-credentials` | GCP application credentials file location | file | 
+| Parameter      | Description    | Type      | Required |  Default | Possible Values | 
+| ----------------------- | ----------------------    | ------------------  | :------: | ------------------------------------ | :----------------:  | 
+`--action` | action performed on the node, visit https://github.com/krkn-chaos/krkn/blob/main/docs/node_scenarios.md for more infos | enum | Yes |  | node_start_scenario,node_stop_scenario,node_stop_start_scenario,node_termination_scenario,node_reboot_scenario,stop_kubelet_scenario,stop_start_kubelet_scenario,restart_kubelet_scenario,node_crash_scenario,stop_start_helper_node_scenario | 
+`--label-selector` | Node label to target | string | No | node-role.kubernetes.io/worker | 
+`--exclude-label` | excludes nodes marked by this label from chaos || No |
+`--node-name` | Node name to inject faults in case of targeting a specific node; Can set multiple node names separated by a comma | string | No | 
+`--instance-count` | Targeted instance count matching the label selector | number | No | 1 | 
+`--runs` | Iterations to perform action on a single node | number | No | 1 | 
+`--cloud-type` | Cloud platform on top of which cluster is running, supported platforms - aws, azure, gcp, vmware, ibmcloud, bm | enum | No | aws | 
+`--kube-check` | Connecting to the kubernetes api to check the node status, set to False for SNO | enum | No | true | 
+`--timeout` | Duration to wait for completion of node scenario injection | number | No | 180| 
+`--duration` | Duration to wait for completion of node scenario injection | number | No | 120 | 
+`--vsphere-ip` | vSphere IP address | string | No | 
+`--vsphere-username` | vSphere IP address | string (secret)| No | 
+`--vsphere-password` | vSphere password | string (secret)| No | 
+`--aws-access-key-id` | AWS Access Key Id | string (secret)| No | 
+`--aws-secret-access-key` | AWS Secret Access Key | string (secret)| No | 
+`--aws-default-region` | AWS default region | string | No | 
+`--bmc-user` | Only needed for Baremetal ( bm ) - IPMI/bmc username | string(secret) | No | 
+`--bmc-password` | Only needed for Baremetal ( bm ) - IPMI/bmc password | string(secret) | No | 
+`--bmc-address` | Only needed for Baremetal ( bm ) - IPMI/bmc address | string | No | 
+`--ibmc-address` | IBM Cloud URL | string | No | 
+`--ibmc-api-key` | IBM Cloud API Key | string (secret)| No | 
+`--ibmc-power-address` | IBM Power Cloud URL | string | No | 
+`--ibmc-cnr` | IBM Cloud Power Workspace CNR | string | No | 
+`--disable-ssl-verification` | Disable SSL verification, to avoid certificate errors | enum | Yes | false |
+`--azure-tenant` | Azure Tenant | string | No | 
+`--azure-client-secret` | Azure Client Secret | string(secret) | No | 
+`--azure-client-id` | Azure Client ID | string(secret) | No | 
+`--azure-subscription-id` | Azure Subscription ID | string (secret)| No | 
+`--gcp-application-credentials` | GCP application credentials file location | file | No | 
 
 NOTE: The secret string types will be masked when scenario is ran
 

--- a/content/en/docs/scenarios/pod-network-scenario/_tab-krknctl.md
+++ b/content/en/docs/scenarios/pod-network-scenario/_tab-krknctl.md
@@ -7,19 +7,19 @@ Can also set any global variable listed [here](../all-scenario-env-krknctl.md)
 
 
 Scenario specific parameters: 
-| Parameter      | Description    | Type      |  Default | 
-| ----------------------- | ----------------------    | ----------------  | ------------------------------------ | 
-`--namespace` | Namespace of the pod to which filter need to be applied  | string |
-`--image` | Image used to disrupt network on a pod  | string |  quay.io/krkn-chaos/krkn:tools | 
-`--label-selector` | When pod_name is not specified, pod matching the label will be selected for the chaos scenario  | string |
-`--exclude-label` | Pods matching this label will be excluded from the chaos even if they match other criteria | string | "" |
-`--pod-name` | When label_selector is not specified, pod matching the name will be selected for the chaos scenario  | string | 
-`--instance-count` | Targeted instance count matching the label selector  | number |  1 |
-`--traffic-type` | List of directions to apply filters - egress/ingress ( needs to be a list )  | string | "[ingress,egress]" | 
-`--ingress-ports` | Ingress ports to block ( needs to be a list )  | string |   | 
-`--egress-ports` | Egress ports to block ( needs to be a list )  | string |   | 
-`--wait-duration` | Ensure that it is at least about twice of test_duration  | number |  300 | 
-`--test-duration` | Duration of the test run  | number |  120 | 
+| Parameter      | Description    | Type      | Required |  Default | 
+| ----------------------- | ----------------------    | ----------------  | :------: | ------------------------------------ | 
+`--namespace` | Namespace of the pod to which filter need to be applied  | string | Yes |
+`--image` | Image used to disrupt network on a pod  | string | No |  quay.io/krkn-chaos/krkn:tools | 
+`--label-selector` | When pod_name is not specified, pod matching the label will be selected for the chaos scenario  | string | No |
+`--exclude-label` | Pods matching this label will be excluded from the chaos even if they match other criteria | string | No | "" |
+`--pod-name` | When label_selector is not specified, pod matching the name will be selected for the chaos scenario  | string | No | 
+`--instance-count` | Targeted instance count matching the label selector  | number | No |  1 |
+`--traffic-type` | List of directions to apply filters - egress/ingress ( needs to be a list )  | string | No | "[ingress,egress]" | 
+`--ingress-ports` | Ingress ports to block ( needs to be a list )  | string | No |   | 
+`--egress-ports` | Egress ports to block ( needs to be a list )  | string | No |   | 
+`--wait-duration` | Ensure that it is at least about twice of test_duration  | number | No |  300 | 
+`--test-duration` | Duration of the test run  | number | No |  120 | 
 
 #### Parameter Dependencies
 

--- a/content/en/docs/scenarios/pod-scenario/_tab-krknctl.md
+++ b/content/en/docs/scenarios/pod-scenario/_tab-krknctl.md
@@ -6,17 +6,17 @@ Can also set any global variable listed [here](../all-scenario-env-krknctl.md)
 
 
 Scenario specific parameters:
-| Parameter      | Description    | Type      |  Default |
-| ----------------------- | ----------------------    | ----------------  | ------------------------------------ |
-`--namespace` | Targeted namespace in the cluster ( supports regex ) | string | openshift-* |
-`--pod-label` | Label of the pod(s) to target ex. "app=test" | string |
-`--exclude-label` | Pods matching this label will be excluded from the chaos even if they match other criteria | string | "" |
-`--name-pattern` | Regex pattern to match the pods in NAMESPACE when POD_LABEL is not specified | string | .* |
-`--disruption-count` | Number of pods to disrupt | number | 1 |
-`--kill-timeout` | Timeout to wait for the target pod(s) to be removed in seconds | number | 180 |
-`--expected-recovery-time` | Fails if the pod disrupted do not recover within the timeout set | number | 120 |
-`--node-label-selector` | Label of the node(s) to target | string | "" |
-`--node-names` | Name of the node(s) to target. Example: ["worker-node-1","worker-node-2","master-node-1"] | string | [] |
+| Parameter      | Description    | Type      | Required |  Default |
+| ----------------------- | ----------------------    | ----------------  | :------: | ------------------------------------ |
+`--namespace` | Targeted namespace in the cluster ( supports regex ) | string | No | openshift-* |
+`--pod-label` | Label of the pod(s) to target ex. "app=test" | string | No |
+`--exclude-label` | Pods matching this label will be excluded from the chaos even if they match other criteria | string | No | "" |
+`--name-pattern` | Regex pattern to match the pods in NAMESPACE when POD_LABEL is not specified | string | No | .* |
+`--disruption-count` | Number of pods to disrupt | number | No | 1 |
+`--kill-timeout` | Timeout to wait for the target pod(s) to be removed in seconds | number | No | 180 |
+`--expected-recovery-time` | Fails if the pod disrupted do not recover within the timeout set | number | No | 120 |
+`--node-label-selector` | Label of the node(s) to target | string | No | "" |
+`--node-names` | Name of the node(s) to target. Example: ["worker-node-1","worker-node-2","master-node-1"] | string | No | [] |
 
 #### Behavior Notes
 

--- a/content/en/docs/scenarios/power-outage-scenarios/_tab-krknctl.md
+++ b/content/en/docs/scenarios/power-outage-scenarios/_tab-krknctl.md
@@ -7,27 +7,27 @@ Can also set any global variable listed [here](../all-scenario-env-krknctl.md)
 
 
 Scenario specific parameters: 
-| Parameter      | Description    | Type      |  Default | 
-| ----------------------- | ----------------------    | ----------------  | ------------------------------------ | 
-`--cloud-type` | Cloud platform on top of which cluster is running, supported platforms - aws, azure, gcp, vmware, ibmcloud, bm | enum | aws | 
-`--timeout` | Time in seconds to wait for each node to be stopped or running after the cluster comes back | number | 180| 
-`--shutdown-duration` | Duration in seconds to shut down the cluster | number | 1200 | 
-`--vsphere-ip` | vSphere IP address | string | 
-`--vsphere-username` | vSphere IP address | string (secret)| 
-`--vsphere-password` | vSphere password | string (secret)| 
-`--aws-access-key-id` | AWS Access Key Id | string (secret)| 
-`--aws-secret-access-key` | AWS Secret Access Key | string (secret)| 
-`--aws-default-region` | AWS default region | string | 
-`--bmc-user` | Only needed for Baremetal ( bm ) - IPMI/bmc username | string(secret) | 
-`--bmc-password` | Only needed for Baremetal ( bm ) - IPMI/bmc password | string(secret) | 
-`--bmc-address` | Only needed for Baremetal ( bm ) - IPMI/bmc address | string | 
-`--ibmc-address` | IBM Cloud URL | string | 
-`--ibmc-api-key` | IBM Cloud API Key | string (secret)| 
-`--azure-tenant` | Azure Tenant | string  | 
-`--azure-client-secret` | Azure Client Secret | string(secret) | 
-`--azure-client-id` | Azure Client ID | string(secret) | 
-`--azure-subscription-id` | Azure Subscription ID | string (secret)| 
-`--gcp-application-credentials` | GCP application credentials file location | file | 
+| Parameter      | Description    | Type      | Required |  Default | 
+| ----------------------- | ----------------------    | ----------------  | :------: | ------------------------------------ | 
+`--cloud-type` | Cloud platform on top of which cluster is running, supported platforms - aws, azure, gcp, vmware, ibmcloud, bm | enum | No | aws | 
+`--timeout` | Time in seconds to wait for each node to be stopped or running after the cluster comes back | number | No | 180| 
+`--shutdown-duration` | Duration in seconds to shut down the cluster | number | No | 1200 | 
+`--vsphere-ip` | vSphere IP address | string | No | 
+`--vsphere-username` | vSphere IP address | string (secret)| No | 
+`--vsphere-password` | vSphere password | string (secret)| No | 
+`--aws-access-key-id` | AWS Access Key Id | string (secret)| No | 
+`--aws-secret-access-key` | AWS Secret Access Key | string (secret)| No | 
+`--aws-default-region` | AWS default region | string | No | 
+`--bmc-user` | Only needed for Baremetal ( bm ) - IPMI/bmc username | string(secret) | No | 
+`--bmc-password` | Only needed for Baremetal ( bm ) - IPMI/bmc password | string(secret) | No | 
+`--bmc-address` | Only needed for Baremetal ( bm ) - IPMI/bmc address | string | No | 
+`--ibmc-address` | IBM Cloud URL | string | No | 
+`--ibmc-api-key` | IBM Cloud API Key | string (secret)| No | 
+`--azure-tenant` | Azure Tenant | string | No | 
+`--azure-client-secret` | Azure Client Secret | string(secret) | No | 
+`--azure-client-id` | Azure Client ID | string(secret) | No | 
+`--azure-subscription-id` | Azure Subscription ID | string (secret)| No | 
+`--gcp-application-credentials` | GCP application credentials file location | file | No | 
 
 NOTE: The secret string types will be masked when scenario is ran
 

--- a/content/en/docs/scenarios/pvc-scenario/_tab-krknctl.md
+++ b/content/en/docs/scenarios/pvc-scenario/_tab-krknctl.md
@@ -7,13 +7,13 @@ Can also set any global variable listed [here](../all-scenario-env-krknctl.md)
 
 
 Scenario specific parameters: 
-| Parameter      | Description    | Type      |  Default | 
-| ----------------------- | ----------------------    | ----------------  | ------------------------------------ | 
-`--pvc-name` | Targeted PersistentVolumeClaim in the cluster (if null, POD_NAME is required) | string | 
-`--pod-name` | Targeted pod in the cluster (if null, PVC_NAME is required) | string | 
-`--namespace` | Targeted namespace in the cluster (required) | string | 
-`--fill-percentage` | Targeted percentage to be filled up in the PVC | number |  50 |
-`--duration` | Duration in seconds with the PVC filled up | number | 60 | 
+| Parameter      | Description    | Type      | Required |  Default | 
+| ----------------------- | ----------------------    | ----------------  | :------: | ------------------------------------ | 
+`--pvc-name` | Targeted PersistentVolumeClaim in the cluster (if null, POD_NAME is required) | string | No | 
+`--pod-name` | Targeted pod in the cluster (if null, PVC_NAME is required) | string | No | 
+`--namespace` | Targeted namespace in the cluster (required) | string | Yes | 
+`--fill-percentage` | Targeted percentage to be filled up in the PVC | number | No |  50 |
+`--duration` | Duration in seconds with the PVC filled up | number | No | 60 | 
 
 
 #### Parameter Dependencies

--- a/content/en/docs/scenarios/service-disruption-scenarios/_tab-krknctl.md
+++ b/content/en/docs/scenarios/service-disruption-scenarios/_tab-krknctl.md
@@ -7,12 +7,12 @@ Can also set any global variable listed [here](../all-scenario-env-krknctl.md)
 
 
 Scenario specific parameters: 
-| Parameter      | Description    | Type      |  Default | 
-| ----------------------- | ----------------------    | ----------------  | ------------------------------------ | 
-`--namespace` | Targeted namespace in the cluster (required) |string | openshift-etcd | 
-`--label-selector` | Label of the namespace to target. Set this parameter only if NAMESPACE is not set |string | 
-`--delete-count` | Number of namespaces to kill in each run, based on matching namespace and label specified |number | 1 | 
-`--runs` | Number of runs to execute the action |number | 1 |
+| Parameter      | Description    | Type      | Required |  Default | 
+| ----------------------- | ----------------------    | ----------------  | :------: | ------------------------------------ | 
+`--namespace` | Targeted namespace in the cluster (required) |string | No | openshift-etcd | 
+`--label-selector` | Label of the namespace to target. Set this parameter only if NAMESPACE is not set |string | No | 
+`--delete-count` | Number of namespaces to kill in each run, based on matching namespace and label specified |number | No | 1 | 
+`--runs` | Number of runs to execute the action |number | No | 1 |
 
 
 #### Behavior Notes

--- a/content/en/docs/scenarios/service-hijacking-scenario/_tab-krknctl.md
+++ b/content/en/docs/scenarios/service-hijacking-scenario/_tab-krknctl.md
@@ -7,9 +7,9 @@ Can also set any global variable listed [here](../all-scenario-env-krknctl.md)
 
 
 Scenario specific parameters: 
-| Parameter      | Description    | Type      |  Default | 
-| ----------------------- | ----------------------    | ----------------  | ------------------------------------ | 
-`--scenario-file-path` | The absolute path of the scenario file compiled following the documentation |file_base64 |
+| Parameter      | Description    | Type      | Required |  Default | 
+| ----------------------- | ----------------------    | ----------------  | :------: | ------------------------------------ | 
+`--scenario-file-path` | The absolute path of the scenario file compiled following the documentation |file_base64 | Yes |
 
 
 A sample scenario file can be found [here](service-hijacking-scenarios-krkn.md#sample-scenario), you'll need to customize it based on your wanted response codes for API calls

--- a/content/en/docs/scenarios/syn-flood-scenario/_tab-krknctl.md
+++ b/content/en/docs/scenarios/syn-flood-scenario/_tab-krknctl.md
@@ -7,18 +7,18 @@ Can also set any global variable listed [here](../all-scenario-env-krknctl.md)
 
 
 Scenario specific parameters: 
-| Parameter      | Description    | Type      |  Default | 
-| ----------------------- | ----------------------    | ----------------  | ------------------------------------ | 
-`--packet-size` | The size in bytes of the SYN packet |number | 120 |
-`--window-size` | The TCP window size between packets in bytes | number | 64 | 
-`--chaos-duration` | The number of seconds the chaos will last | number | 120 | 
-`--namespace` | The namespace containing the target service and where the attacker pods will be deployed | string | default | 
-`--target-service` | The service name (or the hostname/IP address in case an external target will be hit) that will be affected by the attack.Must be empty if TARGET_SERVICE_LABEL will be set  | string |
-`--target-port` | The TCP port that will be targeted by the attack  | number |
-`--target-service-label` | The label that will be used to select one or more services.Must be left empty if TARGET_SERVICE variable is set  | string |
-`--number-of-pods` | The number of attacker pods that will be deployed | number | 2 | 
-`--image` | The container image that will be used to perform the scenario | string | quay.io/krkn-chaos/krkn-syn-flood:latest | 
-`--node-selectors` | The node selectors are used to guide the cluster on where to deploy attacker pods. You can specify one or more labels in the format key=value;key=value2 (even using the same key) to choose one or more node categories. If left empty, the pods will be scheduled on any available node, depending on the cluster s capacity.  | string |
+| Parameter      | Description    | Type      | Required |  Default | 
+| ----------------------- | ----------------------    | ----------------  | :------: | ------------------------------------ | 
+`--packet-size` | The size in bytes of the SYN packet |number | No | 120 |
+`--window-size` | The TCP window size between packets in bytes | number | No | 64 | 
+`--chaos-duration` | The number of seconds the chaos will last | number | No | 120 | 
+`--namespace` | The namespace containing the target service and where the attacker pods will be deployed | string | No | default | 
+`--target-service` | The service name (or the hostname/IP address in case an external target will be hit) that will be affected by the attack.Must be empty if TARGET_SERVICE_LABEL will be set  | string | No |
+`--target-port` | The TCP port that will be targeted by the attack  | number | Yes |
+`--target-service-label` | The label that will be used to select one or more services.Must be left empty if TARGET_SERVICE variable is set  | string | No |
+`--number-of-pods` | The number of attacker pods that will be deployed | number | No | 2 | 
+`--image` | The container image that will be used to perform the scenario | string | No | quay.io/krkn-chaos/krkn-syn-flood:latest | 
+`--node-selectors` | The node selectors are used to guide the cluster on where to deploy attacker pods. You can specify one or more labels in the format key=value;key=value2 (even using the same key) to choose one or more node categories. If left empty, the pods will be scheduled on any available node, depending on the cluster s capacity.  | string | No |
 
 
 

--- a/content/en/docs/scenarios/time-scenarios/_tab-krknctl.md
+++ b/content/en/docs/scenarios/time-scenarios/_tab-krknctl.md
@@ -7,14 +7,14 @@ Can also set any global variable listed [here](../all-scenario-env-krknctl.md)
 
 
 Scenario specific parameters: 
-| Parameter      | Description    | Type      |  Default | 
-| ----------------------- | ----------------------    | ----------------  | ------------------------------------ | 
-`--object-type` | Object to target. Supported options `pod` or `node` |enum| pod |
-`--label-selector` | Label of the container(s) or nodes to target |string| "k8s-app=etcd" |
-`--action` | Action to run. Supported actions: `skew_time` or `skew_date` |enum| skew_date|
-`--object-names` | List of the names of pods or nodes you want to skew |string| | |
-`--container-name` | Container in the specified pod to target in case the pod has multiple containers running. Random container is picked if empty |string | 
-`--namespace` | Namespace of the pods you want to skew, need to be set only if setting a specific pod name |string|
+| Parameter      | Description    | Type      | Required |  Default | 
+| ----------------------- | ----------------------    | ----------------  | :------: | ------------------------------------ | 
+`--object-type` | Object to target. Supported options `pod` or `node` |enum| No | pod |
+`--label-selector` | Label of the container(s) or nodes to target |string| No | "k8s-app=etcd" |
+`--action` | Action to run. Supported actions: `skew_time` or `skew_date` |enum| No | skew_date|
+`--object-names` | List of the names of pods or nodes you want to skew |string| No | | |
+`--container-name` | Container in the specified pod to target in case the pod has multiple containers running. Random container is picked if empty |string | No | 
+`--namespace` | Namespace of the pods you want to skew, need to be set only if setting a specific pod name |string| No |
 
 
 

--- a/content/en/docs/scenarios/time-scenarios/_tab-krknctl.md
+++ b/content/en/docs/scenarios/time-scenarios/_tab-krknctl.md
@@ -12,7 +12,7 @@ Scenario specific parameters:
 `--object-type` | Object to target. Supported options `pod` or `node` |enum| No | pod |
 `--label-selector` | Label of the container(s) or nodes to target |string| No | "k8s-app=etcd" |
 `--action` | Action to run. Supported actions: `skew_time` or `skew_date` |enum| No | skew_date|
-`--object-names` | List of the names of pods or nodes you want to skew |string| No | | |
+`--object-names` | List of the names of pods or nodes you want to skew |string| No | |
 `--container-name` | Container in the specified pod to target in case the pod has multiple containers running. Random container is picked if empty |string | No | 
 `--namespace` | Namespace of the pods you want to skew, need to be set only if setting a specific pod name |string| No |
 

--- a/content/en/docs/scenarios/zone-outage-scenarios/_tab-krknctl.md
+++ b/content/en/docs/scenarios/zone-outage-scenarios/_tab-krknctl.md
@@ -7,18 +7,18 @@ Can also set any global variable listed [here](../all-scenario-env-krknctl.md)
 
 
 Scenario specific parameters: 
-| Parameter      | Description    | Type      |  Default | 
-| ----------------------- | ----------------------    | ----------------  | ------------------------------------ | 
-`--cloud-type` | Cloud platform on top of which cluster is running, supported platforms - aws,  gcp | enum | aws | 
-`--duration` | Duration in seconds after which the zone will be back online | number | 600 | 
-`--vpc-id` | cluster virtual private network to target |string | 
-`--subnet-id` | subnet-id to deny both ingress and egress traffic ( REQUIRED ). Format: [subnet1, subnet2]  | string | 
-`--zone` | cluster zone to target (only for gcp cloud type )| string | 
-`--kube-check` | Connecting to the kubernetes api to check the node status, set to False for SNO | enum |
-`--aws-access-key-id` | AWS Access Key Id | string (secret)| 
-`--aws-secret-access-key` | AWS Secret Access Key | string (secret)| 
-`--aws-default-region` | AWS default region | string | 
-`--gcp-application-credentials` | GCP application credentials file location | file | 
+| Parameter      | Description    | Type      | Required |  Default | 
+| ----------------------- | ----------------------    | ----------------  | :------: | ------------------------------------ | 
+`--cloud-type` | Cloud platform on top of which cluster is running, supported platforms - aws,  gcp | enum | No | aws | 
+`--duration` | Duration in seconds after which the zone will be back online | number | No | 600 | 
+`--vpc-id` | cluster virtual private network to target |string | No | 
+`--subnet-id` | subnet-id to deny both ingress and egress traffic ( REQUIRED ). Format: [subnet1, subnet2]  | string | No | 
+`--zone` | cluster zone to target (only for gcp cloud type )| string | No | 
+`--kube-check` | Connecting to the kubernetes api to check the node status, set to False for SNO | enum | No |
+`--aws-access-key-id` | AWS Access Key Id | string (secret)| No | 
+`--aws-secret-access-key` | AWS Secret Access Key | string (secret)| No | 
+`--aws-default-region` | AWS default region | string | No | 
+`--gcp-application-credentials` | GCP application credentials file location | file | No | 
 
 NOTE: The secret string types will be masked when scenario is ran
 


### PR DESCRIPTION
## Summary
- Add Required/Optional column to 16 krknctl parameter tables that were missing it
- Values sourced from each scenario's `krknctl-input.json` in krkn-hub
- Scenarios with required params: node-scenarios (action, disable-ssl-verification), kubevirt (namespace, vm-name), pvc (namespace), network-chaos (traffic-type), pod-network (namespace), syn-flood (target-port), service-hijacking (scenario-file-path)

## Test plan
- [ ] Verify Required column renders correctly in all 16 updated files
- [ ] Spot-check required values against [krkn-hub krknctl-input.json files](https://github.com/krkn-chaos/krkn-hub)
- [ ] Tables render correctly in both dark and light themes

Closes #298