### PR TITLE
fix pod-network-filter missing params and incomplete krknctl tab (#300)

### DIFF
--- a/content/en/docs/scenarios/network-chaos-ng-scenarios/pod-network-filter/_tab-krkn-hub.md
+++ b/content/en/docs/scenarios/network-chaos-ng-scenarios/pod-network-filter/_tab-krkn-hub.md
@@ -32,7 +32,7 @@ ex.)
 
 See list of variables that apply to all scenarios [here](/docs/scenarios/all-scenario-env.md) that can be used/set in addition to these scenario specific variables
 
-| Parameter            | Description                                                                                                                      | Type | Default                           
+| Parameter            | Description                                                                                                                      | Type | Default                           |
 |----------------------|----------------------------------------------------------------------------------------------------------------------------------|------|-----------------------------------|
 | TOTAL_CHAOS_DURATION | set chaos duration (in sec) as desired                                                                                           | number | 60                                |
 | POD_SELECTOR         | defines the pod selector for choosing target pods. If multiple pods match the selector, all of them will be subjected to stress. | string | "app=selector" |
@@ -40,11 +40,14 @@ See list of variables that apply to all scenarios [here](/docs/scenarios/all-sce
 | INSTANCE_COUNT       | restricts the number of selected pods by the selector                                                                            | number | "1"                               |
 | EXECUTION            | sets the execution mode of the scenario on multiple pods, can be parallel or serial                                              | enum | "parallel"                        |
 | INGRESS              | sets the network filter on incoming traffic, can be true or false                                                                | boolean | false                             |
-| EGRESS               | sets the network filter on outgoing traffic, can be true or false                                                                | boolean | true                              |                       
+| EGRESS               | sets the network filter on outgoing traffic, can be true or false                                                                | boolean | true                              |
 | INTERFACES           | a list of comma separated names of network interfaces (eg. eth0 or eth0,eth1,eth2) to filter for outgoing traffic                | string | ""                                |
 | PORTS                | a list of comma separated port numbers (eg 8080 or 8080,8081,8082) to filter for both outgoing and incoming traffic              | string | ""                                |
 | PROTOCOLS            | a list of comma separated network protocols  (tcp, udp or both of them e.g. tcp,udp)                                             | string | "tcp"                             |
+| NAMESPACE            | namespace where the scenario container will be deployed                                                                          | string | default                           |
+| IMAGE                | the network chaos injection workload container image                                                                             | string | quay.io/krkn-chaos/krkn-network-chaos:latest |
 | TAINTS               | List of taints for which tolerations need to be created. Example: ["node-role.kubernetes.io/master:NoSchedule"] | string | [] |
+| SERVICE_ACCOUNT      | optional service account for the Pod Network Filter workload                                                                     | string | "" |
 
 
 **NOTE** In case of using custom metrics profile or alerts profile when `CAPTURE_METRICS` or `ENABLE_ALERTS` is enabled, mount the metrics profile from the host on which the container is run using podman/docker under `/home/krkn/kraken/config/metrics-aggregated.yaml` and `/home/krkn/kraken/config/alerts`. For example:

--- a/content/en/docs/scenarios/network-chaos-ng-scenarios/pod-network-filter/_tab-krknctl.md
+++ b/content/en/docs/scenarios/network-chaos-ng-scenarios/pod-network-filter/_tab-krknctl.md
@@ -20,4 +20,65 @@ Can also set any global variable listed [here](../../all-scenario-env-krknctl.md
 | `--ports`         | string  | Network ports to filter traffic (if more than one separated by comma)       | true     |                                     |
 | `--image`         | string  | The network chaos injection workload container image                        | false    | quay.io/krkn-chaos/krkn-network-chaos:latest |
 | `--protocols`     | string  | The network protocols that will be filtered                                 | false    | tcp                                 |
-| `--taints`| String | List of taints for which tolerations need to be created | false ||
+| `--taints`        | string  | Comma-separated taints (tolerations are derived for the workload), e.g. `node-role.kubernetes.io/master:NoSchedule` | false    |                                     |
+| `--service-account`| string | Service account for the Pod Network Filter workload (optional)              | false    |                                     |
+
+### Parameter Format Details
+
+**Pod Selection:**
+- `--pod-selector`: Label selector in format `key=value` (e.g., `app=myapp`)
+- `--pod-name`: Specific pod name (alternative to pod-selector)
+- Specify either `--pod-selector` OR `--pod-name`, not both
+- When using `--pod-selector`, use `--instance-count` to limit the number of selected pods
+
+**Port Format:**
+- Single port: `8080`
+- Multiple ports: `8080,8081,8082` (comma-separated, no spaces)
+
+**Protocol Format:**
+- Valid values: `tcp`, `udp`, `tcp,udp`, or `udp,tcp`
+- Default: `tcp`
+
+**Interface Format:**
+- Single interface: `eth0`
+- Multiple interfaces: `eth0,eth1,eth2` (comma-separated, no spaces)
+
+### Example Commands
+
+**Basic egress filtering (block outgoing traffic on a port):**
+```bash
+krknctl run pod-network-filter \
+  --pod-selector app=myapp \
+  --namespace default \
+  --ingress false \
+  --egress true \
+  --ports 8080 \
+  --protocols tcp \
+  --chaos-duration 120
+```
+
+**Ingress + egress filtering (block both directions):**
+```bash
+krknctl run pod-network-filter \
+  --pod-name my-pod-abc123 \
+  --namespace my-namespace \
+  --ingress true \
+  --egress true \
+  --ports 9090,9091 \
+  --protocols tcp,udp \
+  --chaos-duration 300
+```
+
+**Multi-pod filtering with parallel execution:**
+```bash
+krknctl run pod-network-filter \
+  --pod-selector app=redis \
+  --namespace redis-cluster \
+  --instance-count 3 \
+  --execution parallel \
+  --ingress false \
+  --egress true \
+  --ports 6379,6380 \
+  --protocols tcp \
+  --chaos-duration 180
+```


### PR DESCRIPTION
## Summary
- Add missing `--service-account` parameter to krknctl tab (from [krknctl-input.json](https://github.com/krkn-chaos/krkn-hub/blob/main/pod-network-filter/krknctl-input.json#L125-L133))
- Fix broken `--taints` row formatting in krknctl tab
- Add Parameter Format Details and Example Commands sections to match sibling node-network-filter tab
- Add missing `NAMESPACE`, `IMAGE`, `SERVICE_ACCOUNT` parameters to hub tab (from [env.sh](https://github.com/krkn-chaos/krkn-hub/blob/main/pod-network-filter/env.sh))

## Test plan
- [ ] Verify krknctl tab has all params matching [krknctl-input.json](https://github.com/krkn-chaos/krkn-hub/blob/main/pod-network-filter/krknctl-input.json)
- [ ] Verify hub tab has NAMESPACE, IMAGE, SERVICE_ACCOUNT params
- [ ] Example commands are syntactically valid
- [ ] Page renders correctly in both dark and light themes

Closes #300