### PR TITLE
add Type column to krkn-hub parameter tables (#302)

### DIFF
--- a/content/en/docs/scenarios/application-outage/_tab-krkn-hub.md
+++ b/content/en/docs/scenarios/application-outage/_tab-krkn-hub.md
@@ -75,13 +75,13 @@ OR on the command line like example:
 
 See list of variables that apply to all scenarios [here](/docs/scenarios/all-scenario-env.md) that can be used/set in addition to these scenario specific variables
 
-Parameter               | Description                                                           | Default
------------------------ | -----------------------------------------------------------------     | ------------------------------------ |
-DURATION                | Duration in seconds after which the routes will be accessible         | 600                                  |
-NAMESPACE               | Namespace to target - all application routes will go inaccessible if pod selector is empty ( Required )|  No default |
-POD_SELECTOR            | Pods to target. For example "{app: foo}"                                | No default                           |
-EXCLUDE_LABEL            | Pods to exclude after getting list of pods from POD_SELECTOR to target. For example "{app: foo}" | No default |
-BLOCK_TRAFFIC_TYPE      | It can be Ingress or Egress or Ingress, Egress ( needs to be a list ) | [Ingress]                            |
+Parameter               | Description                                                           | Type | Default
+----------------------- | -----------------------------------------------------------------     | ---- | ------------------------------------ |
+DURATION                | Duration in seconds after which the routes will be accessible         | number | 600                                  |
+NAMESPACE               | Namespace to target - all application routes will go inaccessible if pod selector is empty ( Required )| string |  No default |
+POD_SELECTOR            | Pods to target. For example "{app: foo}"                                | string | No default                           |
+EXCLUDE_LABEL            | Pods to exclude after getting list of pods from POD_SELECTOR to target. For example "{app: foo}" | string | No default |
+BLOCK_TRAFFIC_TYPE      | It can be Ingress or Egress or Ingress, Egress ( needs to be a list ) | string | [Ingress]                            |
 
 {{% alert title="Note" %}} Defining the `NAMESPACE` parameter is required for running this scenario while the pod_selector is optional. In case of using pod selector to target a particular application, make sure to define it using the following format with a space between key and value: "{key: value}". {{% /alert %}}
 

--- a/content/en/docs/scenarios/hog-scenarios/io-hog-scenario/_tab-krkn-hub.md
+++ b/content/en/docs/scenarios/hog-scenarios/io-hog-scenario/_tab-krkn-hub.md
@@ -58,17 +58,17 @@ OR on the command line like example:
 See list of variables that apply to all scenarios [here](/docs/scenarios/all-scenario-env.md) that can be used/set in addition to these scenario specific variables
 
 |  Parameter           | Description     | Type | Default
-|----------------------|-------------------------------------------------------------------------------------| ---- | ------------------------------------                   |
+|----------------------|-------------------------------------------------------------------------------------| ---- | ------------------------------------ |
 | TOTAL_CHAOS_DURATION | Set chaos duration (in sec) as desired   | number | 180                                  |
 | IO_BLOCK_SIZE        | string size of each write in bytes. Size can be from 1 byte to 4m   | string | 1m |
 | IO_WORKERS           | Number of stressorts     | number | 5 |
 | IO_WRITE_BYTES      | string writes N bytes for each hdd process. The size can be expressed as % of free space on the file system or in units of Bytes, KBytes, MBytes and GBytes using the suffix b, k, m or g   | string | 10m |
 | NAMESPACE            | Namespace where the scenario container will be deployed   | string | default |
-| NODE_SELECTOR        | defines the node selector for choosing target nodes. If not specified, one schedulable node in the cluster will be chosen at random. If multiple nodes match the selector, all of them will be subjected to stress. If number-of-nodes is specified, that many nodes will be randomly selected from those identified by the selector. | string | "" |     |
+| NODE_SELECTOR        | defines the node selector for choosing target nodes. If not specified, one schedulable node in the cluster will be chosen at random. If multiple nodes match the selector, all of them will be subjected to stress. If number-of-nodes is specified, that many nodes will be randomly selected from those identified by the selector. | string | "" |
 | TAINTS               | List of taints for which tolerations need to be created. Example: ["node-role.kubernetes.io/master:NoSchedule"] | string | [] |
-| NODE_MOUNT_PATH        | the local path in the node that will be mounted in the pod and that will be filled by the scenario              | string | "" |   |
-| NUMBER_OF_NODES      | restricts the number of selected nodes by the selector     | number | "" |                             |
-| IMAGE                | the container image of the stress workload      | string |quay.io/krkn-chaos/krkn-hog||
+| NODE_MOUNT_PATH        | the local path in the node that will be mounted in the pod and that will be filled by the scenario              | string | "" |
+| NUMBER_OF_NODES      | restricts the number of selected nodes by the selector     | number | "" |
+| IMAGE                | the container image of the stress workload      | string | quay.io/krkn-chaos/krkn-hog |
 
 {{% alert title="Note" %}} In case of using custom metrics profile or alerts profile when `CAPTURE_METRICS` or `ENABLE_ALERTS` is enabled, mount the metrics profile from the host on which the container is run using podman/docker under `/home/krkn/kraken/config/metrics-aggregated.yaml` and `/home/krkn/kraken/config/alerts`.{{% /alert %}}
  For example:

--- a/content/en/docs/scenarios/hog-scenarios/io-hog-scenario/_tab-krkn-hub.md
+++ b/content/en/docs/scenarios/hog-scenarios/io-hog-scenario/_tab-krkn-hub.md
@@ -57,18 +57,18 @@ OR on the command line like example:
 
 See list of variables that apply to all scenarios [here](/docs/scenarios/all-scenario-env.md) that can be used/set in addition to these scenario specific variables
 
-|  Parameter           | Description     | Default
-|----------------------|-------------------------------------------------------------------------------------| ------------------------------------                   |
-| TOTAL_CHAOS_DURATION | Set chaos duration (in sec) as desired   | 180                                  |
-| IO_BLOCK_SIZE        | string size of each write in bytes. Size can be from 1 byte to 4m   | 1m |
-| IO_WORKERS           | Number of stressorts     | 5 |
-| IO_WRITE_BYTES      | string writes N bytes for each hdd process. The size can be expressed as % of free space on the file system or in units of Bytes, KBytes, MBytes and GBytes using the suffix b, k, m or g   | 10m |
-| NAMESPACE            | Namespace where the scenario container will be deployed   | default |
-| NODE_SELECTOR        | defines the node selector for choosing target nodes. If not specified, one schedulable node in the cluster will be chosen at random. If multiple nodes match the selector, all of them will be subjected to stress. If number-of-nodes is specified, that many nodes will be randomly selected from those identified by the selector. | "" |     |
-| TAINTS               | List of taints for which tolerations need to be created. Example: ["node-role.kubernetes.io/master:NoSchedule"] | [] |
-| NODE_MOUNT_PATH        | the local path in the node that will be mounted in the pod and that will be filled by the scenario              | "" |   |
-| NUMBER_OF_NODES      | restricts the number of selected nodes by the selector     | "" |                             |
-| IMAGE                | the container image of the stress workload      |quay.io/krkn-chaos/krkn-hog||
+|  Parameter           | Description     | Type | Default
+|----------------------|-------------------------------------------------------------------------------------| ---- | ------------------------------------                   |
+| TOTAL_CHAOS_DURATION | Set chaos duration (in sec) as desired   | number | 180                                  |
+| IO_BLOCK_SIZE        | string size of each write in bytes. Size can be from 1 byte to 4m   | string | 1m |
+| IO_WORKERS           | Number of stressorts     | number | 5 |
+| IO_WRITE_BYTES      | string writes N bytes for each hdd process. The size can be expressed as % of free space on the file system or in units of Bytes, KBytes, MBytes and GBytes using the suffix b, k, m or g   | string | 10m |
+| NAMESPACE            | Namespace where the scenario container will be deployed   | string | default |
+| NODE_SELECTOR        | defines the node selector for choosing target nodes. If not specified, one schedulable node in the cluster will be chosen at random. If multiple nodes match the selector, all of them will be subjected to stress. If number-of-nodes is specified, that many nodes will be randomly selected from those identified by the selector. | string | "" |     |
+| TAINTS               | List of taints for which tolerations need to be created. Example: ["node-role.kubernetes.io/master:NoSchedule"] | string | [] |
+| NODE_MOUNT_PATH        | the local path in the node that will be mounted in the pod and that will be filled by the scenario              | string | "" |   |
+| NUMBER_OF_NODES      | restricts the number of selected nodes by the selector     | number | "" |                             |
+| IMAGE                | the container image of the stress workload      | string |quay.io/krkn-chaos/krkn-hog||
 
 {{% alert title="Note" %}} In case of using custom metrics profile or alerts profile when `CAPTURE_METRICS` or `ENABLE_ALERTS` is enabled, mount the metrics profile from the host on which the container is run using podman/docker under `/home/krkn/kraken/config/metrics-aggregated.yaml` and `/home/krkn/kraken/config/alerts`.{{% /alert %}}
  For example:

--- a/content/en/docs/scenarios/kubevirt-vm-outage-scenario/_tab-krkn-hub.md
+++ b/content/en/docs/scenarios/kubevirt-vm-outage-scenario/_tab-krkn-hub.md
@@ -57,12 +57,12 @@ OR on the command line like example:
 
 See list of variables that apply to all scenarios [here](../all-scenario-env.md) that can be used/set in addition to these scenario specific variables
 
-Parameter               | Description                                                           | Default
------------------------ | -----------------------------------------------------------------     | ------------------------------------ |
-NAMESPACE          | VMI Namespace to target                                                  | ""      |
-VM_NAME               | VMI name to delete, supports regex   | ""                                   |
-TIMEOUT               | Timeout to wait for VMI to start running again, will fail if timeout is hit  | 120                                   |
-KILL_COUNT               | Number of VMI's to kill (will perform serially)  | 1                                   |
+Parameter               | Description                                                           | Type | Default
+----------------------- | -----------------------------------------------------------------     | ---- | ------------------------------------ |
+NAMESPACE          | VMI Namespace to target                                                  | string | ""      |
+VM_NAME               | VMI name to delete, supports regex   | string | ""                                   |
+TIMEOUT               | Timeout to wait for VMI to start running again, will fail if timeout is hit  | number | 120                                   |
+KILL_COUNT               | Number of VMI's to kill (will perform serially)  | number | 1                                   |
 {{% alert title="Note" %}}In case of using custom metrics profile or alerts profile when `CAPTURE_METRICS` or `ENABLE_ALERTS` is enabled, mount the metrics profile from the host on which the container is run using podman/docker under `/home/krkn/kraken/config/metrics-aggregated.yaml` and `/home/krkn/kraken/config/alerts`. {{% /alert %}}
  For example:
 ```bash

--- a/content/en/docs/scenarios/network-chaos-ng-scenarios/node-network-filter/_tab-krkn-hub.md
+++ b/content/en/docs/scenarios/network-chaos-ng-scenarios/node-network-filter/_tab-krkn-hub.md
@@ -35,7 +35,7 @@ See list of variables that apply to all scenarios [here](/docs/scenarios/all-sce
 |-------------------------------| -----------------------------------------------------------------     | ---- | ------------------------------------ |
 | TOTAL_CHAOS_DURATION          | set chaos duration (in sec) as desired                                | number | 60                                  |
 | NODE_SELECTOR                 | defines the node selector for choosing target nodes. If not specified, one schedulable node in the cluster will be chosen at random. If multiple nodes match the selector, all of them will be subjected to stress.| string | "node-role.kubernetes.io/worker=" |
-| NODE_NAME                     | the node name to target (if label selector not selected| string |                        
+| NODE_NAME                     | the node name to target (if label selector not selected) | string |                        |
 | INSTANCE_COUNT               | restricts the number of selected nodes by the selector                                     | number | "1" |
 | EXECUTION                         | sets the execution mode of the scenario on multiple nodes, can be parallel or serial| enum |"parallel"|
 | INGRESS                       | sets the network filter on incoming traffic, can be true or false| boolean | false |

--- a/content/en/docs/scenarios/network-chaos-ng-scenarios/node-network-filter/_tab-krkn-hub.md
+++ b/content/en/docs/scenarios/network-chaos-ng-scenarios/node-network-filter/_tab-krkn-hub.md
@@ -31,20 +31,20 @@ ex.)
 
 See list of variables that apply to all scenarios [here](/docs/scenarios/all-scenario-env.md) that can be used/set in addition to these scenario specific variables
 
-|  Parameter                    | Description                                                           | Default
-|-------------------------------| -----------------------------------------------------------------     | ------------------------------------ |
-| TOTAL_CHAOS_DURATION          | set chaos duration (in sec) as desired                                | 60                                  |
-| NODE_SELECTOR                 | defines the node selector for choosing target nodes. If not specified, one schedulable node in the cluster will be chosen at random. If multiple nodes match the selector, all of them will be subjected to stress.| "node-role.kubernetes.io/worker=" |
-| NODE_NAME                     | the node name to target (if label selector not selected|                        
-| INSTANCE_COUNT               | restricts the number of selected nodes by the selector                                     | "1" |
-| EXECUTION                         | sets the execution mode of the scenario on multiple nodes, can be parallel or serial|"parallel"|
-| INGRESS                       | sets the network filter on incoming traffic, can be true or false| false |
-| EGRESS                       | sets the network filter on outgoing traffic, can be true or false| true |                       
-| INTERFACES                   | a list of comma separated names of network interfaces (eg. eth0 or eth0,eth1,eth2) to filter for outgoing traffic | "" |
-| PORTS                        | a list of comma separated port numbers (eg 8080 or 8080,8081,8082) to filter for both outgoing and incoming traffic | "" |
-| PROTOCOLS                    | a list of comma separated protocols to filter (tcp, udp or both) |
-| TAINTS               | List of taints for which tolerations need to be created. Example: ["node-role.kubernetes.io/master:NoSchedule"] | [] |
-| SERVICE_ACCOUNT             | optional service account for the Node Network Filter workload | "" |
+|  Parameter                    | Description                                                           | Type | Default
+|-------------------------------| -----------------------------------------------------------------     | ---- | ------------------------------------ |
+| TOTAL_CHAOS_DURATION          | set chaos duration (in sec) as desired                                | number | 60                                  |
+| NODE_SELECTOR                 | defines the node selector for choosing target nodes. If not specified, one schedulable node in the cluster will be chosen at random. If multiple nodes match the selector, all of them will be subjected to stress.| string | "node-role.kubernetes.io/worker=" |
+| NODE_NAME                     | the node name to target (if label selector not selected| string |                        
+| INSTANCE_COUNT               | restricts the number of selected nodes by the selector                                     | number | "1" |
+| EXECUTION                         | sets the execution mode of the scenario on multiple nodes, can be parallel or serial| enum |"parallel"|
+| INGRESS                       | sets the network filter on incoming traffic, can be true or false| boolean | false |
+| EGRESS                       | sets the network filter on outgoing traffic, can be true or false| boolean | true |                       
+| INTERFACES                   | a list of comma separated names of network interfaces (eg. eth0 or eth0,eth1,eth2) to filter for outgoing traffic | string | "" |
+| PORTS                        | a list of comma separated port numbers (eg 8080 or 8080,8081,8082) to filter for both outgoing and incoming traffic | string | "" |
+| PROTOCOLS                    | a list of comma separated protocols to filter (tcp, udp or both) | string |
+| TAINTS               | List of taints for which tolerations need to be created. Example: ["node-role.kubernetes.io/master:NoSchedule"] | string | [] |
+| SERVICE_ACCOUNT             | optional service account for the Node Network Filter workload | string | "" |
 
 
 **NOTE** In case of using custom metrics profile or alerts profile when `CAPTURE_METRICS` or `ENABLE_ALERTS` is enabled, mount the metrics profile from the host on which the container is run using podman/docker under `/home/krkn/kraken/config/metrics-aggregated.yaml` and `/home/krkn/kraken/config/alerts`. For example:

--- a/content/en/docs/scenarios/network-chaos-ng-scenarios/pod-network-filter/_tab-krkn-hub.md
+++ b/content/en/docs/scenarios/network-chaos-ng-scenarios/pod-network-filter/_tab-krkn-hub.md
@@ -32,19 +32,19 @@ ex.)
 
 See list of variables that apply to all scenarios [here](/docs/scenarios/all-scenario-env.md) that can be used/set in addition to these scenario specific variables
 
-| Parameter            | Description                                                                                                                      | Default                           
-|----------------------|----------------------------------------------------------------------------------------------------------------------------------|-----------------------------------|
-| TOTAL_CHAOS_DURATION | set chaos duration (in sec) as desired                                                                                           | 60                                |
-| POD_SELECTOR         | defines the pod selector for choosing target pods. If multiple pods match the selector, all of them will be subjected to stress. | "app=selector" |
-| POD_NAME             | the pod name to target (if POD_SELECTOR not specified)                                                                           |
-| INSTANCE_COUNT       | restricts the number of selected pods by the selector                                                                            | "1"                               |                             |
-| EXECUTION            | sets the execution mode of the scenario on multiple pods, can be parallel or serial                                              | "parallel"                        |
-| INGRESS              | sets the network filter on incoming traffic, can be true or false                                                                | false                             |
-| EGRESS               | sets the network filter on outgoing traffic, can be true or false                                                                | true                              |                       
-| INTERFACES           | a list of comma separated names of network interfaces (eg. eth0 or eth0,eth1,eth2) to filter for outgoing traffic                | ""                                |
-| PORTS                | a list of comma separated port numbers (eg 8080 or 8080,8081,8082) to filter for both outgoing and incoming traffic              | ""                                |
-| PROTOCOLS            | a list of comma separated network protocols  (tcp, udp or both of them e.g. tcp,udp)                                             | "tcp"                             |
-| TAINTS               | List of taints for which tolerations need to be created. Example: ["node-role.kubernetes.io/master:NoSchedule"] | [] |
+| Parameter            | Description                                                                                                                      | Type | Default                           
+|----------------------|----------------------------------------------------------------------------------------------------------------------------------|------|-----------------------------------|
+| TOTAL_CHAOS_DURATION | set chaos duration (in sec) as desired                                                                                           | number | 60                                |
+| POD_SELECTOR         | defines the pod selector for choosing target pods. If multiple pods match the selector, all of them will be subjected to stress. | string | "app=selector" |
+| POD_NAME             | the pod name to target (if POD_SELECTOR not specified)                                                                           | string |
+| INSTANCE_COUNT       | restricts the number of selected pods by the selector                                                                            | number | "1"                               |                             |
+| EXECUTION            | sets the execution mode of the scenario on multiple pods, can be parallel or serial                                              | enum | "parallel"                        |
+| INGRESS              | sets the network filter on incoming traffic, can be true or false                                                                | boolean | false                             |
+| EGRESS               | sets the network filter on outgoing traffic, can be true or false                                                                | boolean | true                              |                       
+| INTERFACES           | a list of comma separated names of network interfaces (eg. eth0 or eth0,eth1,eth2) to filter for outgoing traffic                | string | ""                                |
+| PORTS                | a list of comma separated port numbers (eg 8080 or 8080,8081,8082) to filter for both outgoing and incoming traffic              | string | ""                                |
+| PROTOCOLS            | a list of comma separated network protocols  (tcp, udp or both of them e.g. tcp,udp)                                             | string | "tcp"                             |
+| TAINTS               | List of taints for which tolerations need to be created. Example: ["node-role.kubernetes.io/master:NoSchedule"] | string | [] |
 
 
 **NOTE** In case of using custom metrics profile or alerts profile when `CAPTURE_METRICS` or `ENABLE_ALERTS` is enabled, mount the metrics profile from the host on which the container is run using podman/docker under `/home/krkn/kraken/config/metrics-aggregated.yaml` and `/home/krkn/kraken/config/alerts`. For example:

--- a/content/en/docs/scenarios/network-chaos-ng-scenarios/pod-network-filter/_tab-krkn-hub.md
+++ b/content/en/docs/scenarios/network-chaos-ng-scenarios/pod-network-filter/_tab-krkn-hub.md
@@ -36,8 +36,8 @@ See list of variables that apply to all scenarios [here](/docs/scenarios/all-sce
 |----------------------|----------------------------------------------------------------------------------------------------------------------------------|------|-----------------------------------|
 | TOTAL_CHAOS_DURATION | set chaos duration (in sec) as desired                                                                                           | number | 60                                |
 | POD_SELECTOR         | defines the pod selector for choosing target pods. If multiple pods match the selector, all of them will be subjected to stress. | string | "app=selector" |
-| POD_NAME             | the pod name to target (if POD_SELECTOR not specified)                                                                           | string |
-| INSTANCE_COUNT       | restricts the number of selected pods by the selector                                                                            | number | "1"                               |                             |
+| POD_NAME             | the pod name to target (if POD_SELECTOR not specified)                                                                           | string |                                   |
+| INSTANCE_COUNT       | restricts the number of selected pods by the selector                                                                            | number | "1"                               |
 | EXECUTION            | sets the execution mode of the scenario on multiple pods, can be parallel or serial                                              | enum | "parallel"                        |
 | INGRESS              | sets the network filter on incoming traffic, can be true or false                                                                | boolean | false                             |
 | EGRESS               | sets the network filter on outgoing traffic, can be true or false                                                                | boolean | true                              |                       

--- a/content/en/docs/scenarios/node-scenarios/_tab-krkn-hub.md
+++ b/content/en/docs/scenarios/node-scenarios/_tab-krkn-hub.md
@@ -58,26 +58,26 @@ OR on the command line like example:
 
 See list of variables that apply to all scenarios [here](../all-scenario-env.md) that can be used/set in addition to these scenario specific variables
 
-Parameter               | Description                                                           | Default
------------------------ | -----------------------------------------------------------------     | ------------------------------------ |
-ACTION                  | Action can be one of the [following](/docs/scenarios/node-scenarios/) | node_stop_start_scenario |
-LABEL_SELECTOR          | Node label to target                                                  | node-role.kubernetes.io/worker       |
-EXCLUDE_LABEL           | Nodes labeled with this value will be excluded from the chaos         |                                      |
-NODE_NAME               | Node name to inject faults in case of targeting a specific node; Can set multiple node names separated by a comma      | ""                                   |
-INSTANCE_COUNT          | Targeted instance count matching the label selector                   | 1                                    |
-RUNS                    | Iterations to perform action on a single node                         | 1                                    |
-CLOUD_TYPE              | Cloud platform on top of which cluster is running, supported platforms - aws, vmware, ibmcloud, ibmcloudpower, bm           | aws |
-TIMEOUT                 | Duration to wait for completion of node scenario injection             | 180                                |
-DURATION                | Duration to stop the node before running the start action - not supported for vmware and ibm cloud type             | 120                                |
-KUBE_CHECK       | Connect to the kubernetes api to see if the node gets to a certain state during the node scenario   | True                               |
-PARALLEL     | Run action on label or node name in parallel or sequential, set to true for parallel | False |
-DISABLE_SSL_VERIFICATION     | Disable SSL verification, to avoid certificate errors | False |
-VERIFY_SESSION           | Verify the SSH session during node scenarios                          | false                                |
-SKIP_OPENSHIFT_CHECKS    | Skip OpenShift-specific cluster checks (set to true for vanilla Kubernetes) | false                          |
-BMC_USER                 | Only needed for Baremetal ( bm ) - IPMI/bmc username | "" | 
-BMC_PASSWORD             | Only needed for Baremetal ( bm ) - IPMI/bmc password | "" |
-BMC_ADDR                 | Only needed for Baremetal ( bm ) - IPMI/bmc address | "" |
-DISKS                    | Comma-separated list of disks for baremetal disk detach/attach scenarios | ""                              |
+Parameter               | Description                                                           | Type | Default
+----------------------- | -----------------------------------------------------------------     | ---- | ------------------------------------ |
+ACTION                  | Action can be one of the [following](/docs/scenarios/node-scenarios/) | enum | node_stop_start_scenario |
+LABEL_SELECTOR          | Node label to target                                                  | string | node-role.kubernetes.io/worker       |
+EXCLUDE_LABEL           | Nodes labeled with this value will be excluded from the chaos         | string |                                      |
+NODE_NAME               | Node name to inject faults in case of targeting a specific node; Can set multiple node names separated by a comma      | string | ""                                   |
+INSTANCE_COUNT          | Targeted instance count matching the label selector                   | number | 1                                    |
+RUNS                    | Iterations to perform action on a single node                         | number | 1                                    |
+CLOUD_TYPE              | Cloud platform on top of which cluster is running, supported platforms - aws, vmware, ibmcloud, ibmcloudpower, bm           | enum | aws |
+TIMEOUT                 | Duration to wait for completion of node scenario injection             | number | 180                                |
+DURATION                | Duration to stop the node before running the start action - not supported for vmware and ibm cloud type             | number | 120                                |
+KUBE_CHECK       | Connect to the kubernetes api to see if the node gets to a certain state during the node scenario   | enum | True                               |
+PARALLEL     | Run action on label or node name in parallel or sequential, set to true for parallel | enum | False |
+DISABLE_SSL_VERIFICATION     | Disable SSL verification, to avoid certificate errors | enum | False |
+VERIFY_SESSION           | Verify the SSH session during node scenarios                          | string | false                                |
+SKIP_OPENSHIFT_CHECKS    | Skip OpenShift-specific cluster checks (set to true for vanilla Kubernetes) | string | false                          |
+BMC_USER                 | Only needed for Baremetal ( bm ) - IPMI/bmc username | string | "" | 
+BMC_PASSWORD             | Only needed for Baremetal ( bm ) - IPMI/bmc password | string | "" |
+BMC_ADDR                 | Only needed for Baremetal ( bm ) - IPMI/bmc address | string | "" |
+DISKS                    | Comma-separated list of disks for baremetal disk detach/attach scenarios | string | ""                              |
 
 {{% alert title="Note" %}}In case of using custom metrics profile or alerts profile when `CAPTURE_METRICS` or `ENABLE_ALERTS` is enabled, mount the metrics profile from the host on which the container is run using podman/docker under `/home/krkn/kraken/config/metrics-aggregated.yaml` and `/home/krkn/kraken/config/alerts`. {{% /alert %}}
  For example:

--- a/content/en/docs/scenarios/node-scenarios/_tab-krkn-hub.md
+++ b/content/en/docs/scenarios/node-scenarios/_tab-krkn-hub.md
@@ -69,9 +69,9 @@ RUNS                    | Iterations to perform action on a single node         
 CLOUD_TYPE              | Cloud platform on top of which cluster is running, supported platforms - aws, vmware, ibmcloud, ibmcloudpower, bm           | enum | aws |
 TIMEOUT                 | Duration to wait for completion of node scenario injection             | number | 180                                |
 DURATION                | Duration to stop the node before running the start action - not supported for vmware and ibm cloud type             | number | 120                                |
-KUBE_CHECK       | Connect to the kubernetes api to see if the node gets to a certain state during the node scenario   | enum | True                               |
-PARALLEL     | Run action on label or node name in parallel or sequential, set to true for parallel | enum | False |
-DISABLE_SSL_VERIFICATION     | Disable SSL verification, to avoid certificate errors | enum | False |
+KUBE_CHECK       | Connect to the kubernetes api to see if the node gets to a certain state during the node scenario. Supported values: `true`, `false`   | enum | True                               |
+PARALLEL     | Run action on label or node name in parallel or sequential. Supported values: `true`, `false` | enum | False |
+DISABLE_SSL_VERIFICATION     | Disable SSL verification, to avoid certificate errors. Supported values: `true`, `false` | enum | False |
 VERIFY_SESSION           | Verify the SSH session during node scenarios                          | string | false                                |
 SKIP_OPENSHIFT_CHECKS    | Skip OpenShift-specific cluster checks (set to true for vanilla Kubernetes) | string | false                          |
 BMC_USER                 | Only needed for Baremetal ( bm ) - IPMI/bmc username | string | "" | 

--- a/content/en/docs/scenarios/pod-scenario/_tab-krkn-hub.md
+++ b/content/en/docs/scenarios/pod-scenario/_tab-krkn-hub.md
@@ -59,17 +59,17 @@ OR on the command line like example:
 
 See list of variables that apply to all scenarios [here](/docs/scenarios/all-scenario-env.md) that can be used/set in addition to these scenario specific variables
 
-Parameter               | Description                                                           | Default
------------------------ | -----------------------------------------------------------------     | ------------------------------------ |
-NAMESPACE               | Targeted namespace in the cluster ( supports regex )                                     | openshift-.*                         |
-POD_LABEL               | Label of the pod(s) to target                                         | ""                                   |
-EXCLUDE_LABEL           | Pods matching this label will be excluded from the chaos even if they match other criteria | "" |
-NAME_PATTERN            | Regex pattern to match the pods in NAMESPACE  when POD_LABEL is not specified | .* |
-DISRUPTION_COUNT        | Number of pods to disrupt                                             | 1                                    |
-KILL_TIMEOUT            | Timeout to wait for the target pod(s) to be removed in seconds        | 180                                  |
-EXPECTED_RECOVERY_TIME           | Fails if the pod disrupted do not recover within the timeout set      | 120                                  |
-NODE_LABEL_SELECTOR           | Label of the node(s) to target                                         | ""                                   |
-NODE_NAMES            | Name of the node(s) to target. Example: ["worker-node-1","worker-node-2","master-node-1"]                                         | []                                   |
+Parameter               | Description                                                           | Type | Default
+----------------------- | -----------------------------------------------------------------     | ---- | ------------------------------------ |
+NAMESPACE               | Targeted namespace in the cluster ( supports regex )                                     | string | openshift-.*                         |
+POD_LABEL               | Label of the pod(s) to target                                         | string | ""                                   |
+EXCLUDE_LABEL           | Pods matching this label will be excluded from the chaos even if they match other criteria | string | "" |
+NAME_PATTERN            | Regex pattern to match the pods in NAMESPACE  when POD_LABEL is not specified | string | .* |
+DISRUPTION_COUNT        | Number of pods to disrupt                                             | number | 1                                    |
+KILL_TIMEOUT            | Timeout to wait for the target pod(s) to be removed in seconds        | number | 180                                  |
+EXPECTED_RECOVERY_TIME           | Fails if the pod disrupted do not recover within the timeout set      | number | 120                                  |
+NODE_LABEL_SELECTOR           | Label of the node(s) to target                                         | string | ""                                   |
+NODE_NAMES            | Name of the node(s) to target. Example: ["worker-node-1","worker-node-2","master-node-1"]                                         | string | []                                   |
 
 {{% alert title="Note" %}} Set NAMESPACE environment variable to `openshift-.*` to pick and disrupt pods randomly in openshift system namespaces, the DAEMON_MODE can also be enabled to disrupt the pods every x seconds in the background to check the reliability.{{% /alert %}}
 

--- a/content/en/docs/scenarios/power-outage-scenarios/_tab-krkn-hub.md
+++ b/content/en/docs/scenarios/power-outage-scenarios/_tab-krkn-hub.md
@@ -56,11 +56,11 @@ example:
 
 See list of variables that apply to all scenarios [here](/docs/scenarios/all-scenario-env.md) that can be used/set in addition to these scenario specific variables
 
-Parameter               | Description                                                           | Default
------------------------ | -----------------------------------------------------------------     | ------------------------------------ |
-SHUTDOWN_DURATION       | Duration in seconds to shut down the cluster                          | 1200                                 |
-CLOUD_TYPE              | Cloud platform on top of which cluster is running, [supported cloud platforms](/docs/scenarios/node-scenarios/)                     | aws |
-TIMEOUT                 | Time in seconds to wait for each node to be stopped or running after the cluster comes back | 600                                |
+Parameter               | Description                                                           | Type | Default
+----------------------- | -----------------------------------------------------------------     | ---- | ------------------------------------ |
+SHUTDOWN_DURATION       | Duration in seconds to shut down the cluster                          | number | 1200                                 |
+CLOUD_TYPE              | Cloud platform on top of which cluster is running, [supported cloud platforms](/docs/scenarios/node-scenarios/)                     | enum | aws |
+TIMEOUT                 | Time in seconds to wait for each node to be stopped or running after the cluster comes back | number | 600                                |
 
 
 The following environment variables need to be set for the scenarios that requires intereacting with the cloud platform API to perform the actions:

--- a/content/en/docs/scenarios/pvc-scenario/_tab-krkn-hub.md
+++ b/content/en/docs/scenarios/pvc-scenario/_tab-krkn-hub.md
@@ -62,14 +62,14 @@ If both `PVC_NAME` and `POD_NAME` are defined, `POD_NAME` value will be overridd
 
 See list of variables that apply to all scenarios [here](/docs/scenarios/all-scenario-env.md) that can be used/set in addition to these scenario specific variables
 
-Parameter               | Description                                                                     | Default
------------------------ | -----------------------------------------------------------------               | ------------------------------------ |
-PVC_NAME                | Targeted PersistentVolumeClaim in the cluster (if null, POD_NAME is required)   |                                      |
-POD_NAME                | Targeted pod in the cluster (if null, PVC_NAME is required)                     |                                      |
-NAMESPACE               | Targeted namespace in the cluster (required)                                    |                                      |
-FILL_PERCENTAGE         | Targeted percentage to be filled up in the PVC                                  | 50                                   |
-DURATION                | Duration in seconds with the PVC filled up                                      | 60                                   |
-BLOCK_SIZE              | Block size in bytes for the dd command used to fill the PVC                     | 102400                               |
+Parameter               | Description                                                                     | Type | Default
+----------------------- | -----------------------------------------------------------------               | ---- | ------------------------------------ |
+PVC_NAME                | Targeted PersistentVolumeClaim in the cluster (if null, POD_NAME is required)   | string |                                      |
+POD_NAME                | Targeted pod in the cluster (if null, PVC_NAME is required)                     | string |                                      |
+NAMESPACE               | Targeted namespace in the cluster (required)                                    | string |                                      |
+FILL_PERCENTAGE         | Targeted percentage to be filled up in the PVC                                  | number | 50                                   |
+DURATION                | Duration in seconds with the PVC filled up                                      | number | 60                                   |
+BLOCK_SIZE              | Block size in bytes for the dd command used to fill the PVC                     | number | 102400                               |
 
 {{% alert title="Note" %}} In case of using custom metrics profile or alerts profile when `CAPTURE_METRICS` or `ENABLE_ALERTS` is enabled, mount the metrics profile from the host on which the container is run using podman/docker under `/home/krkn/kraken/config/metrics-aggregated.yaml` and `/home/krkn/kraken/config/alerts`.{{% /alert %}}
  For example:

--- a/content/en/docs/scenarios/service-disruption-scenarios/_tab-krkn-hub.md
+++ b/content/en/docs/scenarios/service-disruption-scenarios/_tab-krkn-hub.md
@@ -58,13 +58,13 @@ OR on the command line like example:
 
 See list of variables that apply to all scenarios [here](/docs/scenarios/all-scenario-env.md) that can be used/set in addition to these scenario specific variables
 
-Parameter               | Description                                                           | Default
------------------------ | -----------------------------------------------------------------     | ------------------------------------ |
-LABEL_SELECTOR          | Label of the namespace to target. Set this parameter only if NAMESPACE is not set                                       |     ""                     |
-NAMESPACE               | Name of the namespace you want to target. Set this parameter only if LABEL_SELECTOR is not set  | "openshift-etcd"                   |
-SLEEP                   | Number of seconds to wait before polling to see if namespace exists again         | 15                                    |
-DELETE_COUNT            | Number of namespaces to kill in each run, based on matching namespace and label specified | 1 |
-RUNS                    | Number of runs to execute the action           | 1                                    |
+Parameter               | Description                                                           | Type | Default
+----------------------- | -----------------------------------------------------------------     | ---- | ------------------------------------ |
+LABEL_SELECTOR          | Label of the namespace to target. Set this parameter only if NAMESPACE is not set                                       | string |     ""                     |
+NAMESPACE               | Name of the namespace you want to target. Set this parameter only if LABEL_SELECTOR is not set  | string | "openshift-etcd"                   |
+SLEEP                   | Number of seconds to wait before polling to see if namespace exists again         | number | 15                                    |
+DELETE_COUNT            | Number of namespaces to kill in each run, based on matching namespace and label specified | number | 1 |
+RUNS                    | Number of runs to execute the action           | number | 1                                    |
 
 
 {{% alert title="Note" %}} In case of using custom metrics profile or alerts profile when `CAPTURE_METRICS` or `ENABLE_ALERTS` is enabled, mount the metrics profile from the host on which the container is run using podman/docker under `/home/krkn/kraken/config/metrics-aggregated.yaml` and `/home/krkn/kraken/config/alerts`.{{% /alert %}}

--- a/content/en/docs/scenarios/zone-outage-scenarios/_tab-krkn-hub.md
+++ b/content/en/docs/scenarios/zone-outage-scenarios/_tab-krkn-hub.md
@@ -58,14 +58,14 @@ OR on the command line like example:
 
 See list of variables that apply to all scenarios [here](/docs/scenarios/all-scenario-env.md) that can be used/set in addition to these scenario specific variables
 
-Parameter               | Description                                                           | Default
------------------------ | -----------------------------------------------------------------     | ------------------------------------ |
-CLOUD_TYPE              | Cloud platform on top of which cluster is running, [supported cloud platforms](/docs/scenarios/cloud_setup.md)                     | aws or gcp |
-DURATION                | Duration in seconds after which the zone will be back online          | 600                                  |
-VPC_ID                  | cluster virtual private network to target ( REQUIRED for AWS )                             | ""                                   |
-SUBNET_ID               | subnet-id to deny both ingress and egress traffic ( REQUIRED for AWS ). Format: [subenet1, subnet2]                    | ""                                   |
-ZONE                  | zone you want to target ( REQUIRED for GCP )                             | ""                                   |
-DEFAULT_ACL_ID          | (Optional) AWS Network ACL ID to reuse instead of creating a new one. If provided, this ACL will not be deleted after the scenario | ""                                   |
+Parameter               | Description                                                           | Type | Default
+----------------------- | -----------------------------------------------------------------     | ---- | ------------------------------------ |
+CLOUD_TYPE              | Cloud platform on top of which cluster is running, [supported cloud platforms](/docs/scenarios/cloud_setup.md)                     | enum | aws or gcp |
+DURATION                | Duration in seconds after which the zone will be back online          | number | 600                                  |
+VPC_ID                  | cluster virtual private network to target ( REQUIRED for AWS )                             | string | ""                                   |
+SUBNET_ID               | subnet-id to deny both ingress and egress traffic ( REQUIRED for AWS ). Format: [subenet1, subnet2]                    | string | ""                                   |
+ZONE                  | zone you want to target ( REQUIRED for GCP )                             | string | ""                                   |
+DEFAULT_ACL_ID          | (Optional) AWS Network ACL ID to reuse instead of creating a new one. If provided, this ACL will not be deleted after the scenario | string | ""                                   |
 The following environment variables need to be set for the scenarios that requires intereacting with the cloud platform API to perform the actions:
 
 Amazon Web Services


### PR DESCRIPTION
## Summary
- Add Type column to all 11 krkn-hub parameter tables for consistency with krknctl tabs
- Types sourced from each scenario's `krknctl-input.json` in krkn-hub
- Covers: node-scenarios, pod-scenario, application-outage, zone-outage, pvc, node/pod-network-filter, io-hog, kubevirt, power-outage, service-disruption

## Test plan
- [ ] Verify Type column renders correctly in all 11 hub tabs
- [ ] Spot-check types against [krkn-hub krknctl-input.json files](https://github.com/krkn-chaos/krkn-hub)
- [ ] Tables render correctly in both dark and light themes

Closes #302