### PR TITLE
docs: add parameter dependency notes to scenario tabs (#304)

### DIFF
--- a/content/en/docs/scenarios/network-chaos-scenario/_tab-krknctl.md
+++ b/content/en/docs/scenarios/network-chaos-scenario/_tab-krknctl.md
@@ -23,6 +23,12 @@ Scenario specific parameters:
 `--wait-duration` | Ensure that it is at least about twice of test_duration | number| 300| 
 
 
+#### Parameter Dependencies
+
+- **`--node-name`:** Egress only. Ignored when `--traffic-type` is `ingress`.
+- **`--network-params` and `--target-node-interface`:** Ingress only. Ignored when `--traffic-type` is `egress`.
+- **`--wait-duration`:** Must be at least 2× `--duration` to allow the network to stabilize before verification.
+
 To see all available scenario options 
 ```bash
 krknctl run network-chaos --help

--- a/content/en/docs/scenarios/node-scenarios/_tab-krknctl.md
+++ b/content/en/docs/scenarios/node-scenarios/_tab-krknctl.md
@@ -41,6 +41,12 @@ Scenario specific parameters:  (be sure to scroll to right)
 
 NOTE: The secret string types will be masked when scenario is ran
 
+#### Parameter Dependencies
+
+- **`--node-name` vs `--label-selector`:** When `--node-name` is set, `--label-selector` is ignored. The scenario targets the named node(s) directly.
+- **`--instance-count`:** Only applies when using `--label-selector`. It limits how many of the matched nodes are targeted.
+- **Cloud credentials:** The `--vsphere-*`, `--aws-*`, `--bmc-*`, `--ibmc-*`, `--azure-*`, and `--gcp-*` parameters are only required for their respective `--cloud-type` value. For example, `--aws-access-key-id` is only needed when `--cloud-type` is `aws`.
+
 To see all available scenario options 
 ```bash
 krknctl run node-scenarios --help

--- a/content/en/docs/scenarios/pod-network-scenario/_tab-krknctl.md
+++ b/content/en/docs/scenarios/pod-network-scenario/_tab-krknctl.md
@@ -21,6 +21,11 @@ Scenario specific parameters:
 `--wait-duration` | Ensure that it is at least about twice of test_duration  | number |  300 | 
 `--test-duration` | Duration of the test run  | number |  120 | 
 
+#### Parameter Dependencies
+
+- **`--ingress-ports` / `--egress-ports`:** When left empty, **all** ports are blocked for that traffic direction. Specify port numbers to restrict the filter to only those ports.
+- **`--wait-duration`:** Must be at least 2× `--test-duration` to allow the network to stabilize before verification.
+
 To see all available scenario options 
 ```bash
 krknctl run pod-network-chaos --help

--- a/content/en/docs/scenarios/pvc-scenario/_tab-krknctl.md
+++ b/content/en/docs/scenarios/pvc-scenario/_tab-krknctl.md
@@ -16,6 +16,10 @@ Scenario specific parameters:
 `--duration` | Duration to wait for completion of node scenario injection | number | 1200 | 
 
 
+#### Parameter Dependencies
+
+- **`--pvc-name` vs `--pod-name`:** At least one is required. If both are set, `--pvc-name` takes precedence and `--pod-name` is ignored.
+
 To see all available scenario options 
 ```bash
 krknctl run pvc-scenarios --help


### PR DESCRIPTION
## Summary
- Added "Parameter Dependencies" sections to 4 krknctl tab files documenting mutual exclusivity, conditional requirements, and implicit behaviors
- **node-scenarios**: `--node-name` vs `--label-selector` precedence, `--instance-count` scope, cloud credential conditions
- **network-chaos**: egress-only/ingress-only parameter restrictions, `--wait-duration` >= 2× constraint
- **pod-network-chaos**: empty ports = block ALL warning, `--wait-duration` >= 2× constraint
- **pvc-scenario**: `--pvc-name` vs `--pod-name` precedence and mutual requirement

## Test plan
- [ ] Verify parameter dependency sections render correctly in all 4 scenario pages
- [ ] Confirm markdown formatting is consistent across tabs
- [ ] Check both dark and light themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #304