### PR TITLE
docs: add pod_network_chaos and node_network_chaos NG scenario pages (#308)

### DIFF
--- a/content/en/docs/scenarios/network-chaos-ng-scenarios/_index.md
+++ b/content/en/docs/scenarios/network-chaos-ng-scenarios/_index.md
@@ -12,4 +12,6 @@ This scenario introduce a new infrastructure to refactor and port the current im
 #### Network Chaos NG scenarios:
 - [Pod Network Filter](/docs/scenarios/network-chaos-ng-scenarios/pod-network-filter/_index.md)
 - [Node Network Filter](/docs/scenarios/network-chaos-ng-scenarios/node-network-filter/_index.md)
+- [Pod Network Chaos](/docs/scenarios/network-chaos-ng-scenarios/pod-network-chaos/_index.md)
+- [Node Network Chaos](/docs/scenarios/network-chaos-ng-scenarios/node-network-chaos/_index.md)
 - [Node Interface Down](/docs/scenarios/network-chaos-ng-scenarios/node-interface-down/_index.md)

--- a/content/en/docs/scenarios/network-chaos-ng-scenarios/node-network-chaos/_index.md
+++ b/content/en/docs/scenarios/network-chaos-ng-scenarios/node-network-chaos/_index.md
@@ -1,0 +1,22 @@
+---
+title: Node Network Chaos
+description:
+date: 2017-01-04
+---
+Applies network degradation (latency, packet loss, bandwidth restriction) to one or more nodes using tc and Netem rules. This is the NG (next-generation) version of the legacy network chaos scenario, built on the improved NG infrastructure.
+
+## How to Run Node Network Chaos Scenarios
+
+Choose your preferred method to run node network chaos scenarios:
+
+{{< tabpane text=true >}}
+  {{< tab header="**Krkn**" lang="krkn" >}}
+{{< readfile file="_tab-krkn.md" >}}
+  {{< /tab >}}
+  {{< tab header="**Krkn-hub**" lang="krkn-hub" >}}
+{{< readfile file="_tab-krkn-hub.md" >}}
+  {{< /tab >}}
+  {{< tab header="**Krknctl**" lang="krknctl" >}}
+{{< readfile file="_tab-krknctl.md" >}}
+  {{< /tab >}}
+{{< /tabpane >}}

--- a/content/en/docs/scenarios/network-chaos-ng-scenarios/node-network-chaos/_tab-krkn-hub.md
+++ b/content/en/docs/scenarios/network-chaos-ng-scenarios/node-network-chaos/_tab-krkn-hub.md
@@ -1,0 +1,4 @@
+
+Krkn-hub container support for `node_network_chaos` is not yet available. This module can only be run via krkn directly using a scenario YAML file.
+
+See the **Krkn** tab for configuration and usage instructions.

--- a/content/en/docs/scenarios/network-chaos-ng-scenarios/node-network-chaos/_tab-krkn.md
+++ b/content/en/docs/scenarios/network-chaos-ng-scenarios/node-network-chaos/_tab-krkn.md
@@ -1,0 +1,84 @@
+
+
+### Configuration
+
+```yaml
+- id: node_network_chaos
+  wait_duration: 300
+  test_duration: 60
+  label_selector: "node-role.kubernetes.io/worker="
+  instance_count: 1
+  execution: serial
+  namespace: 'default'
+  # scenario specific settings
+  target: ''
+  interfaces: []
+  ingress: false
+  egress: true
+  latency: 200ms
+  loss: 2
+  bandwidth: 100mbit
+  force: false
+```
+
+For the common module settings please refer to the [documentation](../network-chaos-ng-scenario-api.md#basenetworkchaosconfig-base-module-configuration).
+
+- `target`: the node name to target (used when `label_selector` is not set)
+- `interfaces`: a list of network interfaces to apply chaos to. Leave empty to auto-detect the node's default interface
+- `ingress`: apply chaos to incoming traffic
+- `egress`: apply chaos to outgoing traffic
+- `latency`: network delay to inject (e.g. `100us`, `200ms`, `1s`)
+- `loss`: packet loss percentage as a whole number without `%` (e.g. `2` means 2% loss)
+- `bandwidth`: bandwidth restriction (e.g. `100mbit`, `1gbit`)
+- `force`: override existing tc rules on the interface. When `true`, a 10-second warning delay is added before proceeding
+
+#### Validation Rules
+
+| Field | Format | Valid Examples | Invalid Examples |
+|-------|--------|----------------|------------------|
+| `latency` | `<number>(us\|ms\|s)` | `100us`, `200ms`, `1s` | `200`, `1sec` |
+| `bandwidth` | `<number>(bit\|kbit\|mbit\|gbit\|tbit)` | `100mbit`, `1gbit` | `100mbps` |
+| `loss` | digits only (no `%`) | `2`, `50` | `2%`, `0.5` |
+
+### Usage
+
+To enable node network chaos scenarios, edit the kraken config file, go to the section `kraken -> chaos_scenarios` of the yaml structure
+and add a new element to the list named `network_chaos_ng_scenarios` then add the desired scenario
+pointing to the scenario yaml file.
+
+```yaml
+kraken:
+    ...
+    chaos_scenarios:
+        - network_chaos_ng_scenarios:
+            - scenarios/kube/node-network-chaos.yml
+```
+
+{{% alert title="Note" %}}
+You can specify multiple scenario files of the same type by adding additional paths to the list:
+```yaml
+kraken:
+    chaos_scenarios:
+        - network_chaos_ng_scenarios:
+            - scenarios/kube/node-network-chaos-1.yml
+            - scenarios/kube/node-network-chaos-2.yml
+```
+
+You can also combine multiple different scenario types in the same config.yaml file. Scenario types can be specified in any order, and you can include the same scenario type multiple times:
+```yaml
+kraken:
+    chaos_scenarios:
+        - network_chaos_ng_scenarios:
+            - scenarios/kube/node-network-chaos.yml
+        - pod_disruption_scenarios:
+            - scenarios/pod-kill.yaml
+        - node_scenarios:
+            - scenarios/node-reboot.yaml
+```
+{{% /alert %}}
+
+### Run 
+
+```bash
+python run_kraken.py --config config/config.yaml
+```

--- a/content/en/docs/scenarios/network-chaos-ng-scenarios/node-network-chaos/_tab-krknctl.md
+++ b/content/en/docs/scenarios/network-chaos-ng-scenarios/node-network-chaos/_tab-krknctl.md
@@ -1,0 +1,4 @@
+
+Krknctl support for `node_network_chaos` is not yet available. This module can only be run via krkn directly using a scenario YAML file.
+
+See the **Krkn** tab for configuration and usage instructions.

--- a/content/en/docs/scenarios/network-chaos-ng-scenarios/pod-network-chaos/_index.md
+++ b/content/en/docs/scenarios/network-chaos-ng-scenarios/pod-network-chaos/_index.md
@@ -1,0 +1,22 @@
+---
+title: Pod Network Chaos
+description:
+date: 2017-01-04
+---
+Applies network degradation (latency, packet loss, bandwidth restriction) to one or more pods using tc and Netem rules. This is the NG (next-generation) version of the legacy pod network chaos scenario, built on the improved NG infrastructure.
+
+## How to Run Pod Network Chaos Scenarios
+
+Choose your preferred method to run pod network chaos scenarios:
+
+{{< tabpane text=true >}}
+  {{< tab header="**Krkn**" lang="krkn" >}}
+{{< readfile file="_tab-krkn.md" >}}
+  {{< /tab >}}
+  {{< tab header="**Krkn-hub**" lang="krkn-hub" >}}
+{{< readfile file="_tab-krkn-hub.md" >}}
+  {{< /tab >}}
+  {{< tab header="**Krknctl**" lang="krknctl" >}}
+{{< readfile file="_tab-krknctl.md" >}}
+  {{< /tab >}}
+{{< /tabpane >}}

--- a/content/en/docs/scenarios/network-chaos-ng-scenarios/pod-network-chaos/_tab-krkn-hub.md
+++ b/content/en/docs/scenarios/network-chaos-ng-scenarios/pod-network-chaos/_tab-krkn-hub.md
@@ -1,0 +1,4 @@
+
+Krkn-hub container support for `pod_network_chaos` is not yet available. This module can only be run via krkn directly using a scenario YAML file.
+
+See the **Krkn** tab for configuration and usage instructions.

--- a/content/en/docs/scenarios/network-chaos-ng-scenarios/pod-network-chaos/_tab-krkn.md
+++ b/content/en/docs/scenarios/network-chaos-ng-scenarios/pod-network-chaos/_tab-krkn.md
@@ -1,0 +1,84 @@
+
+
+### Configuration
+
+```yaml
+- id: pod_network_chaos
+  wait_duration: 300
+  test_duration: 60
+  label_selector: "app=my-app"
+  instance_count: 1
+  execution: parallel
+  namespace: 'default'
+  # scenario specific settings
+  target: 'pod-name'
+  interfaces: []
+  ingress: false
+  egress: true
+  latency: 200ms
+  loss: 2
+  bandwidth: 100mbit
+  force: false
+```
+
+For the common module settings please refer to the [documentation](../network-chaos-ng-scenario-api.md#basenetworkchaosconfig-base-module-configuration).
+
+- `target`: the pod name to target (used when `label_selector` is not set)
+- `interfaces`: a list of network interfaces to apply chaos to. Leave empty to auto-detect the pod's default interface
+- `ingress`: apply chaos to incoming traffic
+- `egress`: apply chaos to outgoing traffic
+- `latency`: network delay to inject (e.g. `100us`, `200ms`, `1s`)
+- `loss`: packet loss percentage as a whole number without `%` (e.g. `2` means 2% loss)
+- `bandwidth`: bandwidth restriction (e.g. `100mbit`, `1gbit`)
+- `force`: override existing tc rules on the interface. When `true`, a 10-second warning delay is added before proceeding
+
+#### Validation Rules
+
+| Field | Format | Valid Examples | Invalid Examples |
+|-------|--------|----------------|------------------|
+| `latency` | `<number>(us\|ms\|s)` | `100us`, `200ms`, `1s` | `200`, `1sec` |
+| `bandwidth` | `<number>(bit\|kbit\|mbit\|gbit\|tbit)` | `100mbit`, `1gbit` | `100mbps` |
+| `loss` | digits only (no `%`) | `2`, `50` | `2%`, `0.5` |
+
+### Usage
+
+To enable pod network chaos scenarios, edit the kraken config file, go to the section `kraken -> chaos_scenarios` of the yaml structure
+and add a new element to the list named `network_chaos_ng_scenarios` then add the desired scenario
+pointing to the scenario yaml file.
+
+```yaml
+kraken:
+    ...
+    chaos_scenarios:
+        - network_chaos_ng_scenarios:
+            - scenarios/kube/pod-network-chaos.yml
+```
+
+{{% alert title="Note" %}}
+You can specify multiple scenario files of the same type by adding additional paths to the list:
+```yaml
+kraken:
+    chaos_scenarios:
+        - network_chaos_ng_scenarios:
+            - scenarios/kube/pod-network-chaos-1.yml
+            - scenarios/kube/pod-network-chaos-2.yml
+```
+
+You can also combine multiple different scenario types in the same config.yaml file. Scenario types can be specified in any order, and you can include the same scenario type multiple times:
+```yaml
+kraken:
+    chaos_scenarios:
+        - network_chaos_ng_scenarios:
+            - scenarios/kube/pod-network-chaos.yml
+        - pod_disruption_scenarios:
+            - scenarios/pod-kill.yaml
+        - node_scenarios:
+            - scenarios/node-reboot.yaml
+```
+{{% /alert %}}
+
+### Run 
+
+```bash
+python run_kraken.py --config config/config.yaml
+```

--- a/content/en/docs/scenarios/network-chaos-ng-scenarios/pod-network-chaos/_tab-krknctl.md
+++ b/content/en/docs/scenarios/network-chaos-ng-scenarios/pod-network-chaos/_tab-krknctl.md
@@ -1,0 +1,4 @@
+
+Krknctl support for `pod_network_chaos` is not yet available. This module can only be run via krkn directly using a scenario YAML file.
+
+See the **Krkn** tab for configuration and usage instructions.


### PR DESCRIPTION
## Summary
- Created 2 new scenario pages under `network-chaos-ng-scenarios/` for previously undocumented NG modules
- **pod_network_chaos**: applies latency/loss/bandwidth degradation to pod traffic via tc rules
- **node_network_chaos**: applies latency/loss/bandwidth degradation to node traffic via tc rules
- Both pages include krkn tab with configuration, validation rules, and usage instructions
- Hub and krknctl tabs note that container/CLI support is not yet available
- Updated NG scenarios index page to list all 5 modules

## Evidence
- Modules registered in [`network_chaos_factory.py`](https://github.com/krkn-chaos/krkn/blob/main/krkn/scenario_plugins/network_chaos_ng/network_chaos_factory.py)
- Config model validated from [`models.py`](https://github.com/krkn-chaos/krkn/blob/main/krkn/scenario_plugins/network_chaos_ng/models.py)
- No krkn-hub directories or krknctl support exists for these modules

## Test plan
- [ ] Both new scenario pages render correctly with tabpane
- [ ] Krkn tab YAML config is syntactically valid
- [ ] Validation rules table renders correctly
- [ ] Hub/krknctl tabs show "not yet available" message
- [ ] NG scenarios index lists all 5 modules
- [ ] Check both dark and light themes

Closes #308

🤖 Generated with [Claude Code](https://claude.com/claude-code)