### PR TITLE
docs: fix krknctl synopsis format across all scenario tabs (#310)

### DIFF
--- a/content/en/docs/scenarios/application-outage/_tab-krknctl.md
+++ b/content/en/docs/scenarios/application-outage/_tab-krknctl.md
@@ -1,6 +1,6 @@
 
 ```bash
-krknctl run application-outages (optional: --<parameter>:<value>)
+krknctl run application-outages [--<parameter> <value>]
 ```
 
 Can also set any global variable listed [here](../all-scenario-env-krknctl.md)

--- a/content/en/docs/scenarios/container-scenario/_tab-krknctl.md
+++ b/content/en/docs/scenarios/container-scenario/_tab-krknctl.md
@@ -1,6 +1,6 @@
 
 ```bash
-krknctl run container-scenarios (optional: --<parameter>:<value> )
+krknctl run container-scenarios [--<parameter> <value>]
 ```
 
 Can also set any global variable listed [here](../all-scenario-env-krknctl.md)

--- a/content/en/docs/scenarios/hog-scenarios/cpu-hog-scenario/_tab-krknctl.md
+++ b/content/en/docs/scenarios/hog-scenarios/cpu-hog-scenario/_tab-krknctl.md
@@ -1,6 +1,6 @@
 
 ```bash
-krknctl run node-cpu-hog (optional: --<parameter>:<value> )
+krknctl run node-cpu-hog [--<parameter> <value>]
 ```
 
 

--- a/content/en/docs/scenarios/hog-scenarios/io-hog-scenario/_tab-krknctl.md
+++ b/content/en/docs/scenarios/hog-scenarios/io-hog-scenario/_tab-krknctl.md
@@ -1,6 +1,6 @@
 
 ```bash
-krknctl run node-io-hog (optional: --<parameter>:<value> )
+krknctl run node-io-hog [--<parameter> <value>]
 ```
 
 

--- a/content/en/docs/scenarios/hog-scenarios/memory-hog-scenario/_tab-krknctl.md
+++ b/content/en/docs/scenarios/hog-scenarios/memory-hog-scenario/_tab-krknctl.md
@@ -1,6 +1,6 @@
 
 ```bash
-krknctl run node-memory-hog (optional: --<parameter>:<value> )
+krknctl run node-memory-hog [--<parameter> <value>]
 ```
 
 

--- a/content/en/docs/scenarios/kubevirt-vm-outage-scenario/_tab-krknctl.md
+++ b/content/en/docs/scenarios/kubevirt-vm-outage-scenario/_tab-krknctl.md
@@ -1,6 +1,6 @@
 
 ```bash
-krknctl run kubevirt-outage (optional: --<parameter>:<value> )
+krknctl run kubevirt-outage [--<parameter> <value>]
 ```
 
 Can also set any global variable listed [here](../all-scenario-env-krknctl.md)

--- a/content/en/docs/scenarios/network-chaos-ng-scenarios/node-interface-down/_tab-krknctl.md
+++ b/content/en/docs/scenarios/network-chaos-ng-scenarios/node-interface-down/_tab-krknctl.md
@@ -1,6 +1,6 @@
 
 ```bash
-krknctl run node-interface-down (optional: --<parameter>:<value> )
+krknctl run node-interface-down [--<parameter> <value>]
 ```
 
 Can also set any global variable listed [here](../../all-scenario-env-krknctl.md)

--- a/content/en/docs/scenarios/network-chaos-ng-scenarios/node-network-filter/_tab-krknctl.md
+++ b/content/en/docs/scenarios/network-chaos-ng-scenarios/node-network-filter/_tab-krknctl.md
@@ -1,5 +1,5 @@
 ```bash
-krknctl run node-network-filter (optional: --<parameter>:<value>)
+krknctl run node-network-filter [--<parameter> <value>]
 ```
 
 Can also set any global variable listed [here](../../all-scenario-env-krknctl.md)

--- a/content/en/docs/scenarios/network-chaos-ng-scenarios/pod-network-filter/_tab-krknctl.md
+++ b/content/en/docs/scenarios/network-chaos-ng-scenarios/pod-network-filter/_tab-krknctl.md
@@ -1,6 +1,6 @@
 
 ```bash
-krknctl run pod-network-filter (optional: --<parameter>:<value> )
+krknctl run pod-network-filter [--<parameter> <value>]
 ```
 
 Can also set any global variable listed [here](../../all-scenario-env-krknctl.md)

--- a/content/en/docs/scenarios/network-chaos-scenario/_tab-krknctl.md
+++ b/content/en/docs/scenarios/network-chaos-scenario/_tab-krknctl.md
@@ -1,6 +1,6 @@
 
 ```bash
-krknctl run network-chaos (optional: --<parameter>:<value> )
+krknctl run network-chaos [--<parameter> <value>]
 ```
 
 Can also set any global variable listed [here](../all-scenario-env-krknctl.md)

--- a/content/en/docs/scenarios/node-scenarios/_tab-krknctl.md
+++ b/content/en/docs/scenarios/node-scenarios/_tab-krknctl.md
@@ -1,6 +1,6 @@
 
 ```bash
-krknctl run node-scenarios (optional: --<parameter>:<value> )
+krknctl run node-scenarios [--<parameter> <value>]
 ```
 
 Can also set any global variable listed [here](../all-scenario-env-krknctl.md)

--- a/content/en/docs/scenarios/pod-network-scenario/_tab-krknctl.md
+++ b/content/en/docs/scenarios/pod-network-scenario/_tab-krknctl.md
@@ -1,6 +1,6 @@
 
 ```bash
-krknctl run pod-network-chaos (optional: --<parameter>:<value> )
+krknctl run pod-network-chaos [--<parameter> <value>]
 ```
 
 Can also set any global variable listed [here](../all-scenario-env-krknctl.md)

--- a/content/en/docs/scenarios/pod-scenario/_tab-krknctl.md
+++ b/content/en/docs/scenarios/pod-scenario/_tab-krknctl.md
@@ -1,5 +1,5 @@
 ```bash
-krknctl run pod-scenarios (optional: --<parameter>:<value> )
+krknctl run pod-scenarios [--<parameter> <value>]
 ```
 
 Can also set any global variable listed [here](../all-scenario-env-krknctl.md)

--- a/content/en/docs/scenarios/power-outage-scenarios/_tab-krknctl.md
+++ b/content/en/docs/scenarios/power-outage-scenarios/_tab-krknctl.md
@@ -1,6 +1,6 @@
 
 ```bash
-krknctl run power-outages (optional: --<parameter>:<value> )
+krknctl run power-outages [--<parameter> <value>]
 ```
 
 Can also set any global variable listed [here](../all-scenario-env-krknctl.md)

--- a/content/en/docs/scenarios/pvc-scenario/_tab-krknctl.md
+++ b/content/en/docs/scenarios/pvc-scenario/_tab-krknctl.md
@@ -1,6 +1,6 @@
 
 ```bash
-krknctl run pvc-scenarios (optional: --<parameter>:<value> )
+krknctl run pvc-scenarios [--<parameter> <value>]
 ```
 
 Can also set any global variable listed [here](../all-scenario-env-krknctl.md)

--- a/content/en/docs/scenarios/service-disruption-scenarios/_tab-krknctl.md
+++ b/content/en/docs/scenarios/service-disruption-scenarios/_tab-krknctl.md
@@ -1,6 +1,6 @@
 
 ```bash
-krknctl run service-disruption-scenarios (optional: --<parameter>:<value> )
+krknctl run service-disruption-scenarios [--<parameter> <value>]
 ```
 
 Can also set any global variable listed [here](../all-scenario-env-krknctl.md)

--- a/content/en/docs/scenarios/service-hijacking-scenario/_tab-krknctl.md
+++ b/content/en/docs/scenarios/service-hijacking-scenario/_tab-krknctl.md
@@ -1,6 +1,6 @@
 
 ```bash
-krknctl run service-hijacking (optional: --<parameter>:<value> )
+krknctl run service-hijacking [--<parameter> <value>]
 ```
 
 Can also set any global variable listed [here](../all-scenario-env-krknctl.md)

--- a/content/en/docs/scenarios/syn-flood-scenario/_tab-krknctl.md
+++ b/content/en/docs/scenarios/syn-flood-scenario/_tab-krknctl.md
@@ -1,6 +1,6 @@
 
 ```bash
-krknctl run syn-flood (optional: --<parameter>:<value> )
+krknctl run syn-flood [--<parameter> <value>]
 ```
 
 Can also set any global variable listed [here](../all-scenario-env-krknctl.md) 

--- a/content/en/docs/scenarios/time-scenarios/_tab-krknctl.md
+++ b/content/en/docs/scenarios/time-scenarios/_tab-krknctl.md
@@ -1,6 +1,6 @@
 
 ```bash
-krknctl run time-scenarios  (optional: --<parameter>:<value> )
+krknctl run time-scenarios [--<parameter> <value>]
 ```
 
 Can also set any global variable listed [here](../all-scenario-env-krknctl.md) 

--- a/content/en/docs/scenarios/zone-outage-scenarios/_tab-krknctl.md
+++ b/content/en/docs/scenarios/zone-outage-scenarios/_tab-krknctl.md
@@ -1,6 +1,6 @@
 
 ```bash
-krknctl run zone-outages (optional: --<parameter>:<value> )
+krknctl run zone-outages [--<parameter> <value>]
 ```
 
 Can also set any global variable listed [here](../all-scenario-env-krknctl.md)


### PR DESCRIPTION
## Summary
- Fixed krknctl synopsis format in all 20 scenario `_tab-krknctl.md` files
- Changed `(optional: --<parameter>:<value> )` → `[--<parameter> <value>]` to match actual krknctl CLI syntax (Go cobra flags use `--flag value`, not `--flag:value`)
- Also fixed minor formatting inconsistencies (trailing `|`, double spaces, missing trailing space)

## Test plan
- [ ] Verify krknctl tabs render correctly on all 20 scenario pages
- [ ] Confirm synopsis matches `krknctl run <scenario> --help` output

Closes #310