### PR TITLE
fix: chatbot Krkn Assistant heading invisible in light mode

### DIFF
--- a/static/css/chatbot.css
+++ b/static/css/chatbot.css
@@ -189,7 +189,7 @@
     font-size: var(--krkn-chat-font-lg);
     font-weight: 700;
     font-family: 'Satoshi', sans-serif;
-    color: var(--krkn-chat-text);
+    color: var(--krkn-chat-text) !important;
 }
 
 .krkn-chat-title p {


### PR DESCRIPTION
## Summary
- The "Krkn Assistant" heading inside the chatbot window was invisible in light mode due to a global `h3 { color: var(--krkn-text) !important }` rule in `_styles_project.scss`
- In light mode `--krkn-text` resolves to `#1C1917` (near-black), but the chatbot header background stays dark (`#0A0B10`), causing dark text on dark background
- Fixed #322 

[Screencast From 2026-04-29 11-02-26.webm](https://github.com/user-attachments/assets/045b253e-7c86-4ba5-a48d-177ede0513d5)


## Test Plan
- [ ] Open the site in light mode
- [ ] Click the floating "Ask about Krkn" button to open the chatbot
- [ ] Verify "Krkn Assistant" heading is visible in the chat header
- [ ] Switch to dark mode and verify heading is still visible
- [ ] Check no regressions on chatbot functionality (send message, quick buttons, close)

