### PR TITLE
feat(blog): add client-side category and type filter bar - feat/blog-filter-bar

### DIFF
--- a/assets/scss/_custom_pages.scss
+++ b/assets/scss/_custom_pages.scss
@@ -11,14 +11,15 @@
   min-height: 100vh;
 
   // Hide Docsy's default sidebar, TOC, breadcrumb, taxonomy cloud on these pages
-  & ~ .td-sidebar,
-  & ~ .td-toc {
+  &~.td-sidebar,
+  &~.td-toc {
     display: none !important;
   }
 }
 
 // Hide the taxonomy sidebar + right rail that Docsy injects on blog pages
 .td-blog {
+
   .td-sidebar-toc,
   .td-toc,
   aside.td-sidebar {
@@ -40,8 +41,9 @@
 
 // Hide community page sidebar from Docsy
 .td-default .krkn-community {
-  & ~ aside,
-  & ~ .td-sidebar {
+
+  &~aside,
+  &~.td-sidebar {
     display: none !important;
   }
 }
@@ -183,10 +185,184 @@
   }
 }
 
+// Hidden cards (set by JS filter)
+.krkn-blog__card--hidden {
+  display: none !important;
+}
 
-// =============================================================================
+// Hidden sections (set by JS when all cards hidden)
+.krkn-blog__section--hidden {
+  display: none !important;
+}
+
+
+// BLOG FILTER BAR
+
+.krkn-filter {
+  margin-bottom: 2.5rem;
+  padding: 1.25rem 1.75rem;
+  background: var(--krkn-surface);
+  border: 1px solid var(--krkn-border-subtle);
+  border-radius: 0.875rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0; // rows manage their own spacing via padding + divider
+}
+
+.krkn-filter__row {
+  display: grid;
+  // Fixed label column + pills take remaining space
+  grid-template-columns: 5.5rem 1fr;
+  align-items: start; // label stays top-aligned when pills wrap
+  gap: 0 1rem;
+  padding: 0.875rem 0;
+
+  // Divider between Category row and Type row
+  & + .krkn-filter__row {
+    border-top: 1px solid var(--krkn-border-subtle);
+  }
+}
+
+.krkn-filter__label {
+  font-family: 'Satoshi', sans-serif;
+  font-size: 0.6875rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--krkn-text-subtle);
+  white-space: nowrap;
+  padding-top: 0.35rem; // nudge down to optically align with pill centre
+  line-height: 1;
+}
+
+.krkn-filter__pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+// Base pill button
+.krkn-filter__btn {
+  appearance: none;
+  display: inline-flex;
+  align-items: center;
+  cursor: pointer;
+  border: 1px solid var(--krkn-border-subtle);
+  border-radius: 9999px;
+  background: transparent;
+  color: var(--krkn-text-muted);
+  font-family: 'General Sans', sans-serif;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  line-height: 1;
+  padding: 0.35rem 0.9rem;
+  white-space: nowrap;
+  transition:
+    background 0.18s ease,
+    border-color 0.18s ease,
+    color 0.18s ease;
+
+  &:hover {
+    border-color: var(--krkn-border-prominent);
+    color: var(--krkn-text);
+    background: var(--krkn-elevated);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--krkn-secondary-light);
+    outline-offset: 2px;
+  }
+}
+
+// Active — Category row: blue accent
+.krkn-filter__btn--active {
+  background: var(--krkn-secondary-alpha);
+  border-color: var(--krkn-secondary-light);
+  color: var(--krkn-secondary-light);
+  font-weight: 600;
+
+  &:hover {
+    background: var(--krkn-secondary-alpha-hover);
+  }
+}
+
+// Active — Type row: red accent (distinguishes from category)
+.krkn-filter__btn--type.krkn-filter__btn--active {
+  background: var(--krkn-primary-alpha);
+  border-color: var(--krkn-primary);
+  color: var(--krkn-primary);
+
+  &:hover {
+    background: var(--krkn-primary-alpha-hover);
+  }
+}
+
+// Responsive: collapse grid to single column on small screens
+@media (max-width: 600px) {
+  .krkn-filter {
+    padding: 0.875rem 1.125rem;
+  }
+
+  .krkn-filter__row {
+    grid-template-columns: 1fr;
+    gap: 0.5rem;
+    padding: 0.75rem 0;
+  }
+
+  .krkn-filter__label {
+    padding-top: 0;
+  }
+}
+
+// Empty state
+.krkn-filter__empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 4rem 1rem;
+  color: var(--krkn-text-muted);
+  text-align: center;
+
+  svg {
+    opacity: 0.4;
+    color: var(--krkn-text-subtle);
+  }
+
+  p {
+    font-size: 1rem;
+    margin: 0;
+  }
+}
+
+.krkn-filter__reset {
+  appearance: none;
+  cursor: pointer;
+  background: transparent;
+  border: 1px solid var(--krkn-border-prominent);
+  border-radius: 9999px;
+  color: var(--krkn-text-muted);
+  font-family: 'General Sans', sans-serif;
+  font-size: 0.875rem;
+  font-weight: 500;
+  padding: 0.4rem 1.25rem;
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+
+  &:hover {
+    background: var(--krkn-elevated);
+    border-color: var(--krkn-border-prominent);
+    color: var(--krkn-text);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--krkn-secondary-light);
+    outline-offset: 2px;
+  }
+}
+
 // COMMUNITY PAGE
-// =============================================================================
 
 // Hero
 .krkn-community__hero {
@@ -401,6 +577,7 @@
 
 // Responsive
 @media (max-width: 768px) {
+
   .krkn-blog__title,
   .krkn-community__title {
     font-size: 2rem;
@@ -417,6 +594,7 @@
 }
 
 @media (max-width: 375px) {
+
   .krkn-blog__title,
   .krkn-community__title {
     font-size: 1.625rem;

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -34,6 +34,10 @@
   --krkn-glass-bg: rgba(10, 11, 16, 0.88);
   --krkn-glass-bg-solid: rgba(10, 11, 16, 0.97);
   --krkn-nav-hover-bg: rgba(255, 255, 255, 0.05);
+  --krkn-secondary-alpha: rgba(59, 130, 246, 0.15);  // blue tint for active states (dark)
+  --krkn-secondary-alpha-hover: rgba(59, 130, 246, 0.22); // blue tint hover (dark)
+  --krkn-primary-alpha: rgba(236, 28, 36, 0.12);    // red tint for active states (dark)
+  --krkn-primary-alpha-hover: rgba(236, 28, 36, 0.18); // red tint hover (dark)
   --krkn-logo-filter: none;
   --krkn-cncf-logo: url('/img/cncf-white.svg');
   color-scheme: dark;
@@ -60,6 +64,10 @@
   --krkn-glass-bg: rgba(244, 243, 239, 0.95);
   --krkn-glass-bg-solid: rgba(244, 243, 239, 0.99);
   --krkn-nav-hover-bg: rgba(0, 0, 0, 0.05);
+  --krkn-secondary-alpha: rgba(37, 99, 235, 0.1);   // blue tint for active states (light)
+  --krkn-secondary-alpha-hover: rgba(37, 99, 235, 0.16); // blue tint hover (light)
+  --krkn-primary-alpha: rgba(220, 38, 38, 0.08);    // red tint for active states (light)
+  --krkn-primary-alpha-hover: rgba(220, 38, 38, 0.14); // red tint hover (light)
   --krkn-logo-filter: none;
   --krkn-cncf-logo: url('/img/cncf-color.png');
   color-scheme: light;

--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -3,33 +3,76 @@
   <!-- Hero header -->
   <section class="krkn-blog__hero">
     <div class="container">
-      <h1 class="krkn-blog__title">Blog & Resources</h1>
+      <h1 class="krkn-blog__title">Blog &amp; Resources</h1>
       <p class="krkn-blog__subtitle">Articles, talks, and guides from the Krkn community and beyond.</p>
     </div>
   </section>
 
   <div class="container krkn-blog__body">
 
+    <!-- ── Filter bar ──────────────────────────────────────────────────────── -->
+    <div id="blog-filter-bar" class="krkn-filter" role="group" aria-label="Filter blog posts">
+
+      <!-- Row 1: category filters -->
+      <div class="krkn-filter__row">
+        <span class="krkn-filter__label">Category</span>
+        <div class="krkn-filter__pills" role="group" aria-label="Filter by category">
+          <button class="krkn-filter__btn krkn-filter__btn--active" data-group="category" data-filter="all" aria-pressed="true" type="button">All</button>
+          <button class="krkn-filter__btn" data-group="category" data-filter="announcement"   aria-pressed="false" type="button">Announcement</button>
+          <button class="krkn-filter__btn" data-group="category" data-filter="ai"             aria-pressed="false" type="button">AI</button>
+          <button class="krkn-filter__btn" data-group="category" data-filter="cli"            aria-pressed="false" type="button">CLI</button>
+          <button class="krkn-filter__btn" data-group="category" data-filter="introduction"   aria-pressed="false" type="button">Introduction</button>
+          <button class="krkn-filter__btn" data-group="category" data-filter="best-practices" aria-pressed="false" type="button">Best Practices</button>
+          <button class="krkn-filter__btn" data-group="category" data-filter="case-study"     aria-pressed="false" type="button">Case Study</button>
+          <button class="krkn-filter__btn" data-group="category" data-filter="dashboard"      aria-pressed="false" type="button">Dashboard</button>
+          <button class="krkn-filter__btn" data-group="category" data-filter="tutorial"       aria-pressed="false" type="button">Tutorial</button>
+          <button class="krkn-filter__btn" data-group="category" data-filter="community"      aria-pressed="false" type="button">Community</button>
+          <button class="krkn-filter__btn" data-group="category" data-filter="video"          aria-pressed="false" type="button">Video</button>
+          <button class="krkn-filter__btn" data-group="category" data-filter="guide"          aria-pressed="false" type="button">Guide</button>
+        </div>
+      </div>
+
+      <!-- Row 2: type filters -->
+      <div class="krkn-filter__row">
+        <span class="krkn-filter__label">Type</span>
+        <div class="krkn-filter__pills" role="group" aria-label="Filter by content type">
+          <button class="krkn-filter__btn krkn-filter__btn--active krkn-filter__btn--type" data-group="type" data-filter="all"      aria-pressed="true"  type="button">All</button>
+          <button class="krkn-filter__btn krkn-filter__btn--type"                          data-group="type" data-filter="featured"  aria-pressed="false" type="button">Featured</button>
+          <button class="krkn-filter__btn krkn-filter__btn--type"                          data-group="type" data-filter="article"   aria-pressed="false" type="button">Articles</button>
+          <button class="krkn-filter__btn krkn-filter__btn--type"                          data-group="type" data-filter="talk"      aria-pressed="false" type="button">Talks &amp; Videos</button>
+          <button class="krkn-filter__btn krkn-filter__btn--type"                          data-group="type" data-filter="guide"     aria-pressed="false" type="button">Guides</button>
+        </div>
+      </div>
+
+    </div>
+    <!-- /filter bar -->
+
     <!-- Featured / pinned section -->
-    <section class="krkn-blog__section">
+    <section class="krkn-blog__section" data-section="featured">
       <h2 class="krkn-blog__section-title">Featured</h2>
       <div class="krkn-blog__grid krkn-blog__grid--featured">
 
-        <a href="https://www.redhat.com/en/blog/krknchaos-joining-cncf-sandbox" target="_blank" rel="noopener" class="krkn-blog__card krkn-blog__card--featured">
+        <a href="https://www.redhat.com/en/blog/krknchaos-joining-cncf-sandbox" target="_blank" rel="noopener"
+           class="krkn-blog__card krkn-blog__card--featured"
+           data-category="announcement" data-type="featured">
           <span class="krkn-blog__card-badge">Announcement</span>
           <h3 class="krkn-blog__card-title">Krkn Joins CNCF Sandbox</h3>
           <p class="krkn-blog__card-desc">Krkn is now a Cloud Native Computing Foundation Sandbox project, marking a major milestone for the community.</p>
           <span class="krkn-blog__card-source">Red Hat Blog</span>
         </a>
 
-        <a href="https://www.redhat.com/en/blog/supercharging-chaos-testing-using-ai" target="_blank" rel="noopener" class="krkn-blog__card krkn-blog__card--featured">
+        <a href="https://www.redhat.com/en/blog/supercharging-chaos-testing-using-ai" target="_blank" rel="noopener"
+           class="krkn-blog__card krkn-blog__card--featured"
+           data-category="ai" data-type="featured">
           <span class="krkn-blog__card-badge">AI</span>
           <h3 class="krkn-blog__card-title">Supercharging Chaos Testing with AI</h3>
           <p class="krkn-blog__card-desc">How AI integration in Krkn helps predict failures, analyze patterns, and recommend chaos scenarios.</p>
           <span class="krkn-blog__card-source">Red Hat Blog</span>
         </a>
 
-        <a href="https://developers.redhat.com/articles/2025/08/21/unleash-controlled-chaos-krknctl" target="_blank" rel="noopener" class="krkn-blog__card krkn-blog__card--featured">
+        <a href="https://developers.redhat.com/articles/2025/08/21/unleash-controlled-chaos-krknctl" target="_blank" rel="noopener"
+           class="krkn-blog__card krkn-blog__card--featured"
+           data-category="cli" data-type="featured">
           <span class="krkn-blog__card-badge">CLI</span>
           <h3 class="krkn-blog__card-title">Unleashing Controlled Chaos with krknctl</h3>
           <p class="krkn-blog__card-desc">A deep dive into krknctl — the CLI tool for running and orchestrating chaos scenarios with ease.</p>
@@ -40,46 +83,58 @@
     </section>
 
     <!-- Articles -->
-    <section class="krkn-blog__section">
-      <h2 class="krkn-blog__section-title">Articles & Blog Posts</h2>
+    <section class="krkn-blog__section" data-section="articles">
+      <h2 class="krkn-blog__section-title">Articles &amp; Blog Posts</h2>
       <div class="krkn-blog__grid">
 
-        <a href="https://www.openshift.com/blog/introduction-to-kraken-a-chaos-tool-for-openshift/kubernetes" target="_blank" rel="noopener" class="krkn-blog__card">
+        <a href="https://www.openshift.com/blog/introduction-to-kraken-a-chaos-tool-for-openshift/kubernetes" target="_blank" rel="noopener"
+           class="krkn-blog__card"
+           data-category="introduction" data-type="article">
           <span class="krkn-blog__card-badge">Introduction</span>
           <h3 class="krkn-blog__card-title">Introduction to Kraken</h3>
           <p class="krkn-blog__card-desc">A chaos tool for OpenShift/Kubernetes — the original blog post that introduced Krkn to the community.</p>
           <span class="krkn-blog__card-source">OpenShift Blog</span>
         </a>
 
-        <a href="https://www.openshift.com/blog/making-chaos-part-of-kubernetes/openshift-performance-and-scalability-tests" target="_blank" rel="noopener" class="krkn-blog__card">
+        <a href="https://www.openshift.com/blog/making-chaos-part-of-kubernetes/openshift-performance-and-scalability-tests" target="_blank" rel="noopener"
+           class="krkn-blog__card"
+           data-category="best-practices" data-type="article">
           <span class="krkn-blog__card-badge">Best Practices</span>
           <h3 class="krkn-blog__card-title">Making Chaos Part of Performance Tests</h3>
           <p class="krkn-blog__card-desc">Why chaos should be part of performance and scalability runs to mimic production environments.</p>
           <span class="krkn-blog__card-source">OpenShift Blog</span>
         </a>
 
-        <a href="https://cloud.redhat.com/blog/openshift/kubernetes-chaos-stories" target="_blank" rel="noopener" class="krkn-blog__card">
+        <a href="https://cloud.redhat.com/blog/openshift/kubernetes-chaos-stories" target="_blank" rel="noopener"
+           class="krkn-blog__card"
+           data-category="case-study" data-type="article">
           <span class="krkn-blog__card-badge">Case Study</span>
           <h3 class="krkn-blog__card-title">OpenShift/Kubernetes Chaos Stories</h3>
           <p class="krkn-blog__card-desc">Real-world findings and lessons learned from chaos test runs in OpenShift and Kubernetes environments.</p>
           <span class="krkn-blog__card-source">Red Hat Cloud</span>
         </a>
 
-        <a href="https://developers.redhat.com/articles/2025/08/14/enhancing-system-resilience-krkn-chaos-dashboard" target="_blank" rel="noopener" class="krkn-blog__card">
+        <a href="https://developers.redhat.com/articles/2025/08/14/enhancing-system-resilience-krkn-chaos-dashboard" target="_blank" rel="noopener"
+           class="krkn-blog__card"
+           data-category="dashboard" data-type="article">
           <span class="krkn-blog__card-badge">Dashboard</span>
           <h3 class="krkn-blog__card-title">Enhancing Resilience with Krkn Chaos Dashboard</h3>
           <p class="krkn-blog__card-desc">Visualize chaos test results, track trends, and improve system resilience with the Krkn dashboard.</p>
           <span class="krkn-blog__card-source">Red Hat Developers</span>
         </a>
 
-        <a href="https://medium.com/@abhinavs1920/krkn-custom-chaos-engineering-plugins-70d73c7e2118" target="_blank" rel="noopener" class="krkn-blog__card">
+        <a href="https://medium.com/@abhinavs1920/krkn-custom-chaos-engineering-plugins-70d73c7e2118" target="_blank" rel="noopener"
+           class="krkn-blog__card"
+           data-category="tutorial" data-type="article">
           <span class="krkn-blog__card-badge">Tutorial</span>
           <h3 class="krkn-blog__card-title">Custom Chaos Engineering Plugins</h3>
           <p class="krkn-blog__card-desc">Step-by-step guide on creating custom chaos scenarios and plugins in Krkn.</p>
           <span class="krkn-blog__card-source">Medium</span>
         </a>
 
-        <a href="https://blog.zhu424.dev/open-source-contribution/lfx-mentorship-2025-cncf-krkn" target="_blank" rel="noopener" class="krkn-blog__card">
+        <a href="https://blog.zhu424.dev/open-source-contribution/lfx-mentorship-2025-cncf-krkn" target="_blank" rel="noopener"
+           class="krkn-blog__card"
+           data-category="community" data-type="article">
           <span class="krkn-blog__card-badge">Community</span>
           <h3 class="krkn-blog__card-title">LFX Mentorship Experience with Krkn</h3>
           <p class="krkn-blog__card-desc">A mentee's experience working on the rollback feature during LFX Mentorship Term 2 2025.</p>
@@ -90,11 +145,13 @@
     </section>
 
     <!-- Talks & Videos -->
-    <section class="krkn-blog__section">
-      <h2 class="krkn-blog__section-title">Talks & Videos</h2>
+    <section class="krkn-blog__section" data-section="talks">
+      <h2 class="krkn-blog__section-title">Talks &amp; Videos</h2>
       <div class="krkn-blog__grid">
 
-        <a href="https://www.youtube.com/watch?v=s1PvupI5sD0&ab_channel=OpenShift" target="_blank" rel="noopener" class="krkn-blog__card">
+        <a href="https://www.youtube.com/watch?v=s1PvupI5sD0&ab_channel=OpenShift" target="_blank" rel="noopener"
+           class="krkn-blog__card"
+           data-category="video" data-type="talk">
           <span class="krkn-blog__card-badge">Video</span>
           <h3 class="krkn-blog__card-title">Krkn: Reliable, Performant and Scalable OpenShift</h3>
           <p class="krkn-blog__card-desc">Discussion and demo on how Krkn can be leveraged to ensure OpenShift is reliable, performant and scalable.</p>
@@ -105,11 +162,12 @@
     </section>
 
     <!-- Guides -->
-    <section class="krkn-blog__section">
+    <section class="krkn-blog__section" data-section="guides">
       <h2 class="krkn-blog__section-title">Guides</h2>
       <div class="krkn-blog__grid">
 
-        <a href="/docs/chaos-testing-guide/" class="krkn-blog__card">
+        <a href="/docs/chaos-testing-guide/" class="krkn-blog__card"
+           data-category="guide" data-type="guide">
           <span class="krkn-blog__card-badge">Guide</span>
           <h3 class="krkn-blog__card-title">Chaos Testing Guide</h3>
           <p class="krkn-blog__card-desc">Best practices and recommendations for making your OpenShift platform and applications resilient, performant and reliable.</p>
@@ -119,6 +177,20 @@
       </div>
     </section>
 
+    <!-- Empty state (shown by JS when no cards match) -->
+    <div id="blog-filter-empty" class="krkn-filter__empty" hidden>
+      <svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 24 24" fill="none"
+           stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/>
+      </svg>
+      <p>No posts match the selected filters.</p>
+      <button id="krkn-filter-reset" class="krkn-filter__reset" type="button">
+        Reset filters
+      </button>
+    </div>
+
   </div>
 </div>
+
+<script src="/js/blog-filter.js" defer></script>
 {{ end }}

--- a/static/js/blog-filter.js
+++ b/static/js/blog-filter.js
@@ -1,0 +1,134 @@
+/**
+ * blog-filter.js — Krkn Blog page client-side filter
+ *
+ * Reads data-category and data-type attributes from .krkn-blog__card elements
+ * and shows/hides them when the user clicks a filter button.
+ *
+ * No external dependencies — vanilla JS only.
+ */
+(function () {
+  'use strict';
+
+  function init() {
+    const filterBar = document.getElementById('blog-filter-bar');
+    if (!filterBar) return;
+
+    const allCards = Array.from(document.querySelectorAll('.krkn-blog__card'));
+    const sections = Array.from(document.querySelectorAll('.krkn-blog__section[data-section]'));
+    const emptyState = document.getElementById('blog-filter-empty');
+    const resetBtn  = document.getElementById('krkn-filter-reset');
+
+    let activeCategory = 'all';
+    let activeType = 'all';
+
+    // ─ Helper: normalise a badge text to a canonical token 
+    function toToken(str) {
+      return (str || '').trim().toLowerCase().replace(/\s+/g, '-');
+    }
+
+    // ─ Update visible cards based on current filters
+    function applyFilter() {
+      let visibleCount = 0;
+
+      // Show / hide individual cards
+      allCards.forEach(function (card) {
+        const cardCategory = toToken(card.dataset.category || '');
+        const cardType = toToken(card.dataset.type || '');
+
+        const categoryMatch = activeCategory === 'all' || cardCategory === activeCategory;
+        const typeMatch = activeType === 'all' || cardType === activeType;
+
+        const visible = categoryMatch && typeMatch;
+        card.classList.toggle('krkn-blog__card--hidden', !visible);
+        if (visible) visibleCount++;
+      });
+
+      // Show / hide section headings: hide a section if ALL its cards are hidden
+      sections.forEach(function (section) {
+        const sectionCards = Array.from(section.querySelectorAll('.krkn-blog__card'));
+        const anyVisible = sectionCards.some(function (c) {
+          return !c.classList.contains('krkn-blog__card--hidden');
+        });
+        section.classList.toggle('krkn-blog__section--hidden', !anyVisible);
+      });
+
+      // Empty state
+      if (emptyState) {
+        emptyState.hidden = visibleCount > 0;
+      }
+    }
+
+    // Button click handler
+    filterBar.addEventListener('click', function (e) {
+      const btn = e.target.closest('.krkn-filter__btn');
+      if (!btn) return;
+
+      const filterValue = btn.dataset.filter;
+      const filterGroup = btn.dataset.group; // 'category' | 'type'
+
+      if (filterGroup === 'category') {
+        activeCategory = filterValue;
+        // Update active state within this group
+        filterBar.querySelectorAll('.krkn-filter__btn[data-group="category"]').forEach(function (b) {
+          b.classList.toggle('krkn-filter__btn--active', b.dataset.filter === filterValue);
+          b.setAttribute('aria-pressed', b.dataset.filter === filterValue ? 'true' : 'false');
+        });
+      } else if (filterGroup === 'type') {
+        activeType = filterValue;
+        filterBar.querySelectorAll('.krkn-filter__btn[data-group="type"]').forEach(function (b) {
+          b.classList.toggle('krkn-filter__btn--active', b.dataset.filter === filterValue);
+          b.setAttribute('aria-pressed', b.dataset.filter === filterValue ? 'true' : 'false');
+        });
+      }
+
+      applyFilter();
+
+      // Smooth scroll back to filter bar if user is far down the page
+      if (window.scrollY > filterBar.getBoundingClientRect().top + window.scrollY + 100) {
+        filterBar.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      }
+    });
+
+    // Reset button — scoped to filterBar, no inline onclick
+    if (resetBtn) {
+      resetBtn.addEventListener('click', function () {
+        activeCategory = 'all';
+        activeType     = 'all';
+
+        filterBar.querySelectorAll('.krkn-filter__btn[data-group="category"]').forEach(function (b) {
+          const isAll = b.dataset.filter === 'all';
+          b.classList.toggle('krkn-filter__btn--active', isAll);
+          b.setAttribute('aria-pressed', isAll ? 'true' : 'false');
+        });
+        filterBar.querySelectorAll('.krkn-filter__btn[data-group="type"]').forEach(function (b) {
+          const isAll = b.dataset.filter === 'all';
+          b.classList.toggle('krkn-filter__btn--active', isAll);
+          b.setAttribute('aria-pressed', isAll ? 'true' : 'false');
+        });
+
+        applyFilter();
+      });
+    }
+
+    // Keyboard accessibility: Space / Enter on buttons
+    filterBar.addEventListener('keydown', function (e) {
+      if (e.key === ' ' || e.key === 'Enter') {
+        const btn = e.target.closest('.krkn-filter__btn');
+        if (btn) {
+          e.preventDefault();
+          btn.click();
+        }
+      }
+    });
+
+    // Initial render (all visible)
+    applyFilter();
+  }
+
+  // Run after DOM is ready
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();


### PR DESCRIPTION
## Documentation Update
**Related Feature:** #327  (feat/blog-filter-bar)

### Changes:
- Adds a client-side filter bar to the `/blog` page so users can quickly
- find content by category or type without scrolling the entire page.

### New files:
- `static/js/blog-filter.js` — vanilla JS filter logic (zero new dependencies)

### Modified files
- `layouts/blog/list.html` — added `data-category` / `data-type` attributes
  to every card and `data-section` to every section; added the two-row filter
  bar and an empty-state message with a reset button
- `assets/scss/_custom_pages.scss` — added `.blog-filter` component styles
  using existing `var(--krkn-*)` design tokens; works in dark and light themes
  
  
## Screenshots


## Before
<img width="1913" height="944" alt="image" src="https://github.com/user-attachments/assets/674713c1-c2cf-48ca-a1ee-c868455bf50d" />

## After

<img width="956" height="473" alt="demo" src="https://github.com/user-attachments/assets/be7cd8bb-488d-428a-a9ef-e432c895d6eb" />
