### PR TITLE
fix: correct "Enviornment" typo in Disconnected Environment page

### DIFF
--- a/content/en/docs/installation/disconnected-env.md
+++ b/content/en/docs/installation/disconnected-env.md
@@ -1,13 +1,13 @@
 ---
-title: Setting Up Disconnected Enviornment
+title: Setting Up Disconnected Environment
 # date: 2017-01-05
-description: Getting Your Disconnected Enviornment Set Up
+description: Getting Your Disconnected Environment Set Up
 weight : 2
 categories: [Best Practices]
 tags: [docs]
 ---
 
-## Getting Started Running Chaos Scenarios in a Disconnected Enviornment 
+## Getting Started Running Chaos Scenarios in a Disconnected Environment 
 
 ### Mirror following images on the bastion host
 - **quay.io/krkn-chaos/krkn-hub:node-scenarios-bm** - Master/worker node disruptions on baremetal


### PR DESCRIPTION
## Documentation Update

**Related Feature:** N/A - Bug fix for existing documentation

**Changes:**

Fixed the typo "Enviornment" → "Environment" in `content/en/docs/installation/disconnected-env.md` on lines 2, 4, and 10.

This typo was in the frontmatter `title` and `description`, so it propagated across the sidebar navigation, breadcrumbs, page heading, and table of contents on every docs page.

**Before:**
<img width="1710" height="952" alt="Screenshot 2026-05-02 at 4 24 08 PM" src="https://github.com/user-attachments/assets/480ff20a-119d-4bfe-a065-8e94075a14cb" />


**After:**
<img width="1710" height="951" alt="Screenshot 2026-05-02 at 4 35 35 PM" src="https://github.com/user-attachments/assets/4a23359d-ff9c-45ce-839f-efd9506f9a31" />


Fixes #329 