### PR TITLE
ci: replace sleep with Netlify deploy polling and add admin auth header (#332)

### DIFF
--- a/.github/workflows/rebuild-docs-index.yml
+++ b/.github/workflows/rebuild-docs-index.yml
@@ -28,16 +28,66 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         
-      - name: Wait for Netlify deployment
+      - name: Install jq
         if: github.event_name == 'push'
         run: |
-          echo "⏳ Waiting 2 minutes for Netlify deployment to complete..."
-          sleep 120
+          if ! command -v jq &>/dev/null; then
+            sudo apt-get update -qq && sudo apt-get install -y -qq jq
+          fi
+          echo "jq $(jq --version)"
+
+      - name: Wait for Netlify deployment
+        if: github.event_name == 'push'
+        env:
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+          NETLIFY_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "$NETLIFY_SITE_ID" ] || [ -z "$NETLIFY_TOKEN" ]; then
+            echo "⚠️  NETLIFY_SITE_ID or NETLIFY_AUTH_TOKEN not configured — falling back to 30s wait"
+            sleep 30
+            exit 0
+          fi
+
+          echo "⏳ Polling Netlify deploy status (max 5 min)..."
+          MAX_WAIT=300
+          POLL_INTERVAL=15
+          elapsed=0
+
+          while [ "$elapsed" -lt "$MAX_WAIT" ]; do
+            RESPONSE=$(curl -sf \
+              -H "Authorization: Bearer $NETLIFY_TOKEN" \
+              "https://api.netlify.com/api/v1/sites/$NETLIFY_SITE_ID/deploys?per_page=1" 2>&1) || {
+              echo "  ⚠️  curl failed (elapsed=${elapsed}s), retrying..."
+              sleep "$POLL_INTERVAL"
+              elapsed=$((elapsed + POLL_INTERVAL))
+              continue
+            }
+
+            STATE=$(echo "$RESPONSE" | jq -r '.[0].state // empty' 2>/dev/null) || {
+              echo "  ⚠️  Failed to parse deploy state (elapsed=${elapsed}s), retrying..."
+              sleep "$POLL_INTERVAL"
+              elapsed=$((elapsed + POLL_INTERVAL))
+              continue
+            }
+
+            echo "  state=${STATE:-unknown} elapsed=${elapsed}s"
+            case "${STATE:-}" in
+              ready) echo "✅ Netlify deploy complete!"; exit 0 ;;
+              error) echo "❌ Netlify deploy failed";    exit 1 ;;
+            esac
+
+            sleep "$POLL_INTERVAL"
+            elapsed=$((elapsed + POLL_INTERVAL))
+          done
+
+          echo "⏱️  Timed out after ${MAX_WAIT}s waiting for Netlify deploy"
+          exit 1
           
       - name: Get Netlify site URL
         id: get-url
         run: |
-          # Try to get from Netlify API or use default
           SITE_URL="${{ secrets.NETLIFY_SITE_URL }}"
           if [ -z "$SITE_URL" ]; then
             SITE_URL="https://krkn-chaos.netlify.app"
@@ -52,6 +102,7 @@ jobs:
           RESPONSE=$(curl -s -w "\n%{http_code}" \
             -X POST "${{ steps.get-url.outputs.SITE_URL }}/api/admin/rebuild-index" \
             -H "Content-Type: application/json" \
+            -H "x-admin-key: ${{ secrets.ADMIN_API_KEY }}" \
             -d '{}' \
             --max-time 30)
           
@@ -63,7 +114,6 @@ jobs:
           
           if [ "$HTTP_CODE" = "200" ]; then
             echo "✅ Documentation index rebuilt successfully!"
-            # Parse document count if available
             if echo "$BODY" | grep -q "documentCount"; then
               DOC_COUNT=$(echo "$BODY" | grep -o '"documentCount":[0-9]*' | cut -d':' -f2)
               echo "📊 Indexed $DOC_COUNT documents"


### PR DESCRIPTION
## Summary

Fixes two issues in `.github/workflows/rebuild-docs-index.yml` that would cause it to waste CI minutes today and break entirely once #326 is merged.

Closes #332
Related to #326

## Changes

### 1. Replace `sleep 120` with Netlify deploy status polling

The existing step blindly waits 2 minutes regardless of actual deploy duration — a CI anti-pattern that wastes runner minutes and still races if Netlify is slow.

**Before:**
```yaml
- name: Wait for Netlify deployment
  if: github.event_name == 'push'
  run: |
    echo "⏳ Waiting 2 minutes for Netlify deployment to complete..."
    sleep 120
```

**After:** polls `GET /api/v1/sites/{site_id}/deploys?per_page=1` every 15 seconds until `state == ready` (or `error`), with a 5-minute hard timeout. Gracefully falls back to a 30s wait when secrets are absent so nothing breaks if the secrets haven't been added yet.

**New secrets to add in repo settings:**
| Secret | Where to find it |
|--------|-----------------|
| `NETLIFY_SITE_ID` | Netlify → Site configuration → Site details |
| `NETLIFY_AUTH_TOKEN` | Netlify → User settings → OAuth applications → Personal access tokens |

### 2. Pass `x-admin-key` header in the rebuild curl call

PR #326 adds `x-admin-key` authentication to `POST /api/admin/rebuild-index`. Once #326 is merged and `ADMIN_API_KEY` is set in Netlify, the workflow will receive `401 Unauthorized` on every run without this header. The Qodo review on #326 flagged this exact gap.

**Before:**
```yaml
RESPONSE=$(curl -s -w "\n%{http_code}" \
  -X POST "${{ steps.get-url.outputs.SITE_URL }}/api/admin/rebuild-index" \
  -H "Content-Type: application/json" \
  -d '{}' \
  --max-time 30)
```

**After:**
```yaml
RESPONSE=$(curl -s -w "\n%{http_code}" \
  -X POST "${{ steps.get-url.outputs.SITE_URL }}/api/admin/rebuild-index" \
  -H "Content-Type: application/json" \
  -H "x-admin-key: ${{ secrets.ADMIN_API_KEY }}" \
  -d '{}' \
  --max-time 30)
```

`ADMIN_API_KEY` is already being introduced by #326 — no new secret needed here.

## Test Plan

- [x] Workflow YAML is valid (no syntax errors)
- [ ] Add `NETLIFY_SITE_ID` and `NETLIFY_AUTH_TOKEN` to repo secrets, then trigger via `workflow_dispatch` to verify polling behaviour
- [ ] After #326 merges and `ADMIN_API_KEY` is set, verify the rebuild step returns 200