### PR TITLE
fix: resolve tag label misalignment and content overflow (#213)

### DIFF
--- a/assets/scss/_custom_docs.scss
+++ b/assets/scss/_custom_docs.scss
@@ -195,6 +195,8 @@
   color: var(--krkn-text) !important;
   background: var(--krkn-bg) !important;
   padding: 2rem 0;
+  overflow-wrap: break-word;
+  word-break: break-word;
 }
 
 .td-content p,
@@ -822,10 +824,15 @@ table tbody tr:hover {
     display: flex;
     flex-wrap: wrap;
     gap: 0.5rem;
+    overflow: visible;
   }
 
   .taxonomy-terms li {
+    display: flex;
+    align-items: center;
+    list-style: none;
     margin: 0;
+    padding: 0;
   }
 
   a,
@@ -887,6 +894,16 @@ table tbody tr:hover {
   flex-wrap: wrap;
   gap: 0.75rem;
   margin: 0.5rem 0;
+  list-style: none;
+  padding: 0;
+
+  li {
+    display: flex;
+    align-items: center;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
 
   .taxonomy-title {
     width: max-content !important;


### PR DESCRIPTION
## Summary

Fixes two CSS bugs reported in issue #213 in `assets/scss/_custom_docs.scss`.

Closes #213

---

## Bug 1: Tag labels disoriented / misaligned

**Root cause:** Docsy 0.12.0 sets `.taxonomy-terms li { display: inline }` in its bundled `_taxonomy.scss`. When the krkn custom CSS overrides `.taxonomy-terms` to `display: flex`, the `li` children conflict — they still have `display: inline` and Docsy's `overflow: hidden` on `.taxonomy-terms` can clip pill labels. Additionally, `.td-tags` (the per-page inline tags list) had no `list-style: none` or `padding: 0` reset, so default browser bullet markers leaked into the flex row, causing uneven spacing.

**Fix:**
- Added `overflow: visible` to `.taxonomy-terms` inside `.taxonomy-terms-cloud` to un-clip the flex container.
- Added `display: flex; align-items: center; list-style: none; padding: 0` to `.taxonomy-terms li` to override Docsy's `display: inline` and remove bullet markers.
- Applied the same `li` reset inside `.td-content .td-tags` and `.td-content .taxonomy-terms-article` so per-page tag rows render consistently.

**Before / After:**

| Before | After |
|--------|-------|
| `li` items use `display: inline` — flex gaps are uneven, bullets may show | Each `li` is an explicit `display: flex` item with `align-items: center` — uniform spacing, no stray bullets |

---

## Bug 2: Text overflow in "Understanding the Result" section

**Root cause:** The `overflow-wrap: break-word; word-break: break-word` rule in `_styles_project.scss` targets `p, li, td, th, h1–h6` but not generic `div` elements used as container wrappers within `.td-content`. Long tokens in those containers could escape the layout bounds.

**Fix:** Added `overflow-wrap: break-word; word-break: break-word` directly on `.td-content` so all descendant containers — including divs, sections, and tab panes — inherit the rule without needing individual selectors.

---

## Test Plan

- [ ] Navigate to `/tags/` and verify tag pills are evenly spaced with no stray bullets
- [ ] Navigate to a doc page with multiple tags (e.g. `/docs/installation/krkn/`) and verify inline tag row is properly aligned
- [ ] Navigate to `/docs/krkn_ai/getting-started-krkn-ai/` and verify the "Understanding the Results" section text wraps at the container boundary on narrow viewports