### PR TITLE
docs: add missing Basic Run user journey page (#284)

### DIFF
--- a/content/en/docs/getting-started/_index.md
+++ b/content/en/docs/getting-started/_index.md
@@ -161,6 +161,7 @@ Whether you're running your first scenario or building a production resilience p
 
 | Journey | I want to... | Experience level | Tools needed |
 |---|---|---|---|
+| [Basic Run](user-journeys/basic-run/) | Run my first scenario and verify the setup | Beginner | krknctl |
 | [Metrics Validation](user-journeys/metrics-validation/) | Automatically pass/fail based on Prometheus metrics | Intermediate | krknctl + Prometheus |
 | [Resilience Score](user-journeys/resilience-score/) | Generate a scored report to validate an environment | Intermediate | krknctl + Prometheus |
 | [Long-Term Storage](user-journeys/long-term-storage/) | Store metrics across runs for regression analysis | Advanced | krknctl + Prometheus + Elasticsearch |

--- a/content/en/docs/getting-started/user-journeys/basic-run.md
+++ b/content/en/docs/getting-started/user-journeys/basic-run.md
@@ -1,0 +1,144 @@
+---
+title: "Basic Run"
+description: Run your first chaos scenario against a test workload — no metrics, no scoring, just see what happens when Krkn disrupts a pod.
+weight: 1
+categories: [Getting Started]
+tags: [docs]
+---
+
+**Goal:** Run a chaos scenario from start to finish — no metrics, no scoring, no pipeline. This is the fastest way to see Krkn in action and verify your environment is set up correctly before layering in observability.
+
+All other user journeys build on the steps here, so completing this first is recommended.
+
+## What you need
+
+| Requirement | Minimum Version | Check command |
+|-------------|-----------------|---------------|
+| Kubernetes or OpenShift cluster | 1.21+ | `kubectl version` |
+| kubeconfig with cluster-admin access | — | `kubectl get nodes` |
+| Docker **or** Podman | Docker 20.10+ / Podman 4.0+ | `docker --version` or `podman --version` |
+
+## Steps
+
+### 1. Install krknctl
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/krkn-chaos/krknctl/refs/heads/main/install.sh | bash
+```
+
+Verify the installation:
+
+```bash
+krknctl --version
+```
+
+{{% alert title="Tip" color="success" %}}
+Enable shell auto-completion for the best experience:
+
+**Bash:** `source <(krknctl completion bash)`
+
+**Zsh:** `autoload -Uz compinit && compinit && source <(krknctl completion zsh)`
+{{% /alert %}}
+
+### 2. Create a test workload
+
+```bash
+kubectl create namespace chaos-test
+kubectl create deployment nginx-test --image=nginx --replicas=3 -n chaos-test
+kubectl wait --for=condition=Available deployment/nginx-test -n chaos-test --timeout=60s
+```
+
+### 3. List available scenarios
+
+```bash
+krknctl list
+```
+
+This shows all chaos scenarios you can run. For your first test, use `pod-scenarios`.
+
+### 4. Run a scenario
+
+```bash
+krknctl run pod-scenarios \
+  --namespace chaos-test \
+  --pod-label "app=nginx-test" \
+  --disruption-count 1 \
+  --kill-timeout 180 \
+  --expected-recovery-time 120
+```
+
+krknctl will prompt you for required inputs interactively, or you can pass them as flags.
+
+The scenario will:
+1. Find pods matching the label `app=nginx-test` in the `chaos-test` namespace
+2. Disrupt 1 pod (delete it)
+3. Wait up to 180 seconds for the pod to be removed
+4. Monitor recovery for up to 120 seconds
+
+### 5. Observe results
+
+In a separate terminal, watch the pods recover:
+
+```bash
+kubectl get pods -n chaos-test -l app=nginx-test -w
+```
+
+A restarted pod will show a much shorter uptime than its neighbours:
+
+```text
+NAMESPACE     NAME                          READY   STATUS    RESTARTS   AGE
+chaos-test    nginx-test-7d9f8b6c4-xk2pq   1/1     Running   0          8s
+chaos-test    nginx-test-5c6d7f8b9-lm3rt   1/1     Running   0          4d2h
+chaos-test    nginx-test-787d4945fb-nqpzj   1/1     Running   0          4d2h
+```
+
+**What success looks like:** The disrupted pod is deleted and Kubernetes recreates it. The new pod reaches `Ready` state within the `--expected-recovery-time` window. The scenario exits with code 0.
+
+```json
+{
+  "recovered": [
+    {
+      "pod_name": "nginx-test-7d9f8b6c4-xk2pq",
+      "namespace": "chaos-test",
+      "pod_rescheduling_time": 2.3,
+      "pod_readiness_time": 5.7,
+      "total_recovery_time": 8.0
+    }
+  ],
+  "unrecovered": []
+}
+```
+
+**What failure looks like:** The pod does not recover within the timeout. The scenario exits with a non-zero code and logs the unrecovered pod.
+
+```json
+{
+  "recovered": [],
+  "unrecovered": [
+    {
+      "pod_name": "nginx-test-7d9f8b6c4-xk2pq",
+      "namespace": "chaos-test",
+      "pod_rescheduling_time": 0.0,
+      "pod_readiness_time": 0.0,
+      "total_recovery_time": 0.0
+    }
+  ]
+}
+```
+
+### 6. Clean up
+
+```bash
+kubectl delete namespace chaos-test
+krknctl clean
+```
+
+## Reference docs
+
+- [krknctl installation guide](../../installation/krknctl.md) — full setup options including binary download and container image
+- [pod-scenarios reference](../../scenarios/pod-scenarios/_index.md) — all flags and configuration for pod disruption
+- [Scenario catalog](../../scenarios/) — browse all available chaos scenarios with descriptions
+
+## Next steps
+
+Now that you have verified Krkn can run against your cluster, add observability by continuing to [Metrics Validation](../metrics-validation/) — it shows how to automatically evaluate Prometheus metrics after each run so you get a clear pass or fail without manual inspection.


### PR DESCRIPTION
## Summary

Adds the missing **Basic Run** user journey page — Journey 1 from issue #284.

Partially addresses #284

---

## Problem

`content/en/docs/getting-started/user-journeys/metrics-validation.md` references `[Basic Run](../basic-run/)` as a prerequisite, but the file `basic-run.md` never existed. This produces a broken link on the live site and leaves users with no beginner entry point before the Intermediate/Advanced journeys.

The journey table in `getting-started/_index.md` also started at Metrics Validation (Intermediate), with no path for first-time users who just want to verify their setup works before adding Prometheus.

## Changes

### New file: `user-journeys/basic-run.md` (weight: 1)

Covers the complete zero-to-chaos workflow:
1. Install krknctl via the one-line installer
2. Create a test workload (nginx deployment in a dedicated namespace)
3. List available scenarios with `krknctl list`
4. Run `pod-scenarios` with explicit flags
5. Observe pod recovery in a second terminal, with annotated success and failure output examples
6. Clean up

Follows the same front-matter, section, and tone conventions as the existing `metrics-validation.md`, `resilience-score.md`, `long-term-storage.md`, and `multi-cluster.md` pages. Ends with a **Next steps** link to Metrics Validation to continue the journey chain.

### Updated: `getting-started/_index.md`

Added **Basic Run** as the first row in the journey-selection table so users see the Beginner entry point before the Intermediate/Advanced options:

| Journey | I want to... | Experience level | Tools needed |
|---|---|---|---|
| **Basic Run** *(new)* | Run my first scenario and verify the setup | Beginner | krknctl |
| Metrics Validation | Automatically pass/fail based on Prometheus metrics | Intermediate | krknctl + Prometheus |
| Resilience Score | Generate a scored report to validate an environment | Intermediate | krknctl + Prometheus |
| Long-Term Storage | Store metrics across runs for regression analysis | Advanced | krknctl + Prometheus + Elasticsearch |
| Multi-Cluster Orchestration | Run chaos across multiple clusters or clouds | Advanced | krkn-operator |

## Test Plan

- [ ] Navigate to `/docs/getting-started/` and verify the journey table shows Basic Run as the first row
- [ ] Click the Basic Run link and verify the page loads at `/docs/getting-started/user-journeys/basic-run/`
- [ ] Navigate to Metrics Validation and verify the `[Basic Run](../basic-run/)` prerequisite link resolves correctly
- [ ] Verify page renders correctly in both light and dark mode