### PR TITLE
fix: resolve mobile responsiveness issues across homepage, docs, and search modal

### DIFF
--- a/assets/scss/_custom_docs.scss
+++ b/assets/scss/_custom_docs.scss
@@ -1691,7 +1691,6 @@ table tbody tr:hover {
     }
   }
 
-  .td-outer,
   .td-main {
     padding-bottom: 80px;
   }

--- a/assets/scss/_custom_docs.scss
+++ b/assets/scss/_custom_docs.scss
@@ -1654,3 +1654,45 @@ table tbody tr:hover {
     background: var(--krkn-surface) !important;
   }
 }
+@media (max-width: 480px) {
+  .td-content pre,
+  .td-content .highlight pre,
+  .td-content .chroma {
+    max-width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    white-space: pre;
+  }
+
+  .td-content .highlight {
+    max-width: 100%;
+    overflow-x: auto;
+  }
+
+  .td-content table {
+    display: block;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .td-content h1 { font-size: 1.625rem; }
+  .td-content h2 { font-size: 1.375rem; }
+  .td-content h3 { font-size: 1.125rem; }
+
+  .nav.nav-tabs {
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;
+    padding-bottom: 2px;
+
+    &::-webkit-scrollbar {
+      display: none;
+    }
+  }
+
+  .td-outer,
+  .td-main {
+    padding-bottom: 80px;
+  }
+}

--- a/assets/scss/_custom_hero.scss
+++ b/assets/scss/_custom_hero.scss
@@ -632,3 +632,38 @@
   height: 1.125rem;
   flex-shrink: 0;
 }
+@media (max-width: 480px) {
+  .hero-title {
+    font-size: 2rem;
+  }
+
+  .hero-subtitle {
+    font-size: 0.9375rem;
+    margin-bottom: 1rem;
+  }
+
+  .hero-badge {
+    font-size: 0.75rem;
+    padding: 0.25rem 0.625rem;
+  }
+
+  .hero-cta {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.75rem;
+  }
+
+  .btn-primary-krkn,
+  .btn-outline-krkn {
+    width: 100%;
+    justify-content: center;
+    padding: 0.8125rem 1.25rem;
+  }
+
+  .hero-cluster {
+    width: Min(300px, 90vw);
+    max-width: 90vw;
+    height: Min(300px, 90vw);
+    max-height: 90vw;
+  }
+}

--- a/assets/scss/_custom_navbar.scss
+++ b/assets/scss/_custom_navbar.scss
@@ -837,3 +837,27 @@ button.krkn-navbar__search {
     display: none !important;
   }
 }
+
+@media (max-width: 480px) {
+  .krkn-search-overlay {
+    padding-top: 10vh;
+    padding-left: 16px;
+    padding-right: 16px;
+    align-items: flex-start;
+  }
+
+  .krkn-search-overlay__panel {
+    width: 100%;
+    max-width: 100%;
+    border-radius: 12px;
+  }
+
+  .krkn-navbar__inner {
+    padding: 0.875rem 1rem;
+    min-height: 4rem;
+  }
+
+  .krkn-navbar__logo img {
+    height: 44px;
+  }
+}

--- a/assets/scss/_custom_pages.scss
+++ b/assets/scss/_custom_pages.scss
@@ -437,3 +437,19 @@
     font-size: 1rem;
   }
 }
+
+@media (max-width: 480px) {
+  .krkn-blog__body,
+  .krkn-community__body {
+    padding-bottom: 80px;
+  }
+
+  .krkn-community__callout {
+    padding: 1.25rem 1rem;
+  }
+
+  .krkn-blog__title,
+  .krkn-community__title {
+    font-size: 1.75rem;
+  }
+}

--- a/assets/scss/_custom_pages.scss
+++ b/assets/scss/_custom_pages.scss
@@ -448,8 +448,4 @@
     padding: 1.25rem 1rem;
   }
 
-  .krkn-blog__title,
-  .krkn-community__title {
-    font-size: 1.75rem;
-  }
 }

--- a/assets/scss/_custom_sections.scss
+++ b/assets/scss/_custom_sections.scss
@@ -50,7 +50,7 @@
   gap: 1.5rem;
 
   @media (min-width: 640px) {
-    grid-template-columns: repeat(2, 1fr);
+    grid-template-columns: 1fr;
   }
 
   @media (min-width: 1100px) {
@@ -457,7 +457,7 @@ svg.scenario-card__icon {
 
 @media (max-width: 992px) {
   .krkn-footer__grid {
-    grid-template-columns: repeat(2, 1fr);
+    grid-template-columns: 1fr;
   }
 }
 
@@ -553,12 +553,6 @@ svg.scenario-card__icon {
     overflow: hidden;
   }
 
-  .step-card p,
-  .step-card h3 {
-    overflow-wrap: break-word;
-    word-break: break-word;
-  }
-
   .steps-grid {
     max-width: 100%;
     overflow-x: hidden;
@@ -581,7 +575,7 @@ svg.scenario-card__icon {
   }
 
   .krkn-footer__grid {
-    grid-template-columns: repeat(2, 1fr);
+    grid-template-columns: 1fr;
     gap: 2rem 1.5rem;
   }
 }

--- a/assets/scss/_custom_sections.scss
+++ b/assets/scss/_custom_sections.scss
@@ -546,3 +546,42 @@ svg.scenario-card__icon {
   font-size: 0.8125rem;
   margin: 0;
 }
+
+@media (max-width: 480px) {
+  .step-card {
+    min-width: 0;
+    overflow: hidden;
+  }
+
+  .step-card p,
+  .step-card h3 {
+    overflow-wrap: break-word;
+    word-break: break-word;
+  }
+
+  .steps-grid {
+    max-width: 100%;
+    overflow-x: hidden;
+  }
+
+  .section-title {
+    font-size: 1.875rem;
+  }
+
+  .feature-card {
+    padding: 1.5rem;
+  }
+
+  .cta-section {
+    padding: 2.5rem 1rem;
+  }
+
+  .krkn-footer__inner {
+    padding: 0 1rem;
+  }
+
+  .krkn-footer__grid {
+    grid-template-columns: repeat(2, 1fr);
+    gap: 2rem 1.5rem;
+  }
+}

--- a/static/css/chatbot.css
+++ b/static/css/chatbot.css
@@ -546,3 +546,10 @@
         border-width: 2px;
     }
 }
+
+@media (max-width: 480px) {
+  .krkn-chat-button .krkn-chat-logo {
+    width: 28px;
+    height: 28px;
+  }
+}


### PR DESCRIPTION
## Documentation Update

**Related Feature:** N/A - Bug fix for mobile responsiveness on small viewports (375px / iPhone SE)

**Changes:**

Fixed 7 mobile responsiveness issues across 6 SCSS/CSS files (165 lines added):

- **Step cards overflow:** Added `min-width: 0` on `.step-card` to prevent CSS Grid from expanding beyond viewport width
- **Code blocks clipping:** Added `max-width: 100%` and `overflow-x: auto` on `.highlight` and `pre` so long commands scroll horizontally
- **Search modal margins:** Added `padding: 16px` on the overlay so the search panel has visible side margins on mobile
- **Table overflow:** Added `display: block; overflow-x: auto` for horizontal scrolling on narrow screens
- **Scenario tabs wrapping:** Added `flex-wrap: nowrap; overflow-x: auto` so tabs scroll instead of wrapping
- **Hero sizing:** Reduced title from `2.5rem` to `2rem`, stacked CTA buttons vertically with full width
- **Chatbot FAB overlap:** Added `padding-bottom: 80px` on docs/blog pages so content isn't hidden behind the floating button

### Before / After

| Bug | Before | After |
|-----|--------|-------|
| Step cards overflow | [<img width="388" height="678" alt="before 1 " src="https://github.com/user-attachments/assets/6251f8c1-edbf-496f-9b29-61b72ded96ca" />] | [<img width="393" height="682" alt="after 1 " src="https://github.com/user-attachments/assets/857462fe-4ba2-4b6e-be35-87cc04fa667a" />] |
| Search modal | [<img width="375" height="667" alt="search-modal" src="https://github.com/user-attachments/assets/6e164ba1-0dfe-4c37-b59e-b6f327fe9921" />] | [<img width="375" height="667" alt="search-modal" src="https://github.com/user-attachments/assets/22a50a38-a970-42b0-9640-fbb473fe0136" />] |

Closes #336