### PR TITLE
fix: remove debug beacon POSTing to localhost from production build

### DIFF
--- a/layouts/_partials/hooks/body-end.html
+++ b/layouts/_partials/hooks/body-end.html
@@ -341,7 +341,6 @@
           card.style.removeProperty('aspectRatio');
         });
         // #region agent log
-        fetch('http://127.0.0.1:7905/ingest/58111621-164e-4fc0-80aa-1a565995fece',{method:'POST',headers:{'Content-Type':'application/json','X-Debug-Session-Id':'008ba3'},body:JSON.stringify({sessionId:'008ba3',location:'body-end.html:measureAndSetRowHeights',message:'row measure',data:{rowIndex:rowIndex,titles:titles,scrollHeights:scrollHeights,maxContentH:maxContentH,rowHeightPx:rowHeightPx,rowWidth:rowWidth},timestamp:Date.now(),hypothesisId:'H1-H5'})}).catch(function(){});
         // #endregion
       });
       requestAnimationFrame(function() {


### PR DESCRIPTION
## Documentation Update

**Related Feature:** N/A(Bug fix)

**Changes:**

Removed a leftover debug `fetch` call from `layouts/_partials/hooks/body-end.html` line 344 that was POSTing internal measurement data to `http://127.0.0.1:7905/ingest/...` on every homepage load for all production visitors.

Closes #338 