### PR TITLE
fix-links-pointers: docs: fix broken performance dashboards links in long-term-storage.md

### DIFF
--- a/content/en/docs/getting-started/user-journeys/long-term-storage.md
+++ b/content/en/docs/getting-started/user-journeys/long-term-storage.md
@@ -52,7 +52,7 @@ This journey enables regression analysis — for example, detecting that API ser
      --grafana-password <grafana-admin-password>
    ```
 
-   This deploys [krkn-visualize](../../performance_dashboards.md) to your cluster and wires it to both Elasticsearch and Prometheus. To tear it down later:
+   This deploys [krkn-visualize](../../krkn-visualize.md) to your cluster and wires it to both Elasticsearch and Prometheus. To tear it down later:
 
    ```bash
    krknctl visualize --delete
@@ -61,7 +61,7 @@ This journey enables regression analysis — for example, detecting that API ser
 ## Reference docs
 
 - [krknctl usage](../../krknctl/_index.md) — full flag reference for `run` and `visualize`
-- [Performance Dashboards](../../performance_dashboards.md) — krkn-visualize dashboards and manual deploy script
+- [Performance Dashboards](../../krkn-visualize.md) — krkn-visualize dashboards and manual deploy script
 - [Telemetry](../../krkn/telemetry.md) — understanding the data Krkn captures and stores per run
 - [Installing Elasticsearch on a kind cluster](../../developers-guide/testing-changes.md#elasticsearch) — Helm-based setup for local testing
 


### PR DESCRIPTION
## Documentation Update
Guided User Journeys (specifically the Long-Term Storage user journey documentation).
Found this issue while working on #284

**Changes:** 

- Updated two broken links in `content/en/docs/getting-started/user-journeys/long-term-storage.md`.
- Replaced the non-existent `../../performance_dashboards.md` links on lines 55 and 64 with `../../krkn-visualize.md` (the actual documentation file for the krkn-visualize / performance dashboards).
- Verified that these links now resolve correctly without any 404 errors.
