### PR TITLE
fix-tags-alignment: Fix horizontal alignment in tags and categories section

### DIFF
--- a/assets/scss/_custom_docs.scss
+++ b/assets/scss/_custom_docs.scss
@@ -853,9 +853,24 @@ table tbody tr:hover {
 .td-content .td-tags,
 .td-content .taxonomy-terms-article {
   display: flex;
+  align-items: center;
   flex-wrap: wrap;
-  gap: 0.5rem;
+  gap: 0.75rem;
   margin: 0.5rem 0;
+
+  .taxonomy-title {
+    width: max-content !important;
+    margin-bottom: 0 !important;
+  }
+
+  .taxonomy-terms {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    padding: 0;
+    margin: 0;
+    list-style: none;
+  }
 
   a {
     display: inline-flex !important;


### PR DESCRIPTION
## Website Styling Bug Fix
**Related Feature:** 

- Resolves #348

**Changes:** 

- Restructured the `.td-content .taxonomy-terms-article` CSS/SCSS layout inside `_custom_docs.scss`.
- Updated the `.taxonomy-title` wrapper to use `width: max-content !important`, ensuring the bottom underline matches only the word length rather than stretching out across the container.
- Aligned the tag/category pills (`.taxonomy-terms`) next to their respective titles naturally with a clean `0.75rem` gap, resolving the excessive white-space alignment gap.

**Before:** 
<img width="780" height="149" alt="Screenshot 2026-05-08 at 2 10 18 AM" src="https://github.com/user-attachments/assets/e5fa24c6-6b1b-4ba4-9d9e-0bda806c1409" />

**After:**
<img width="805" height="147" alt="Screenshot 2026-05-08 at 2 10 39 AM" src="https://github.com/user-attachments/assets/dfff0cfa-be0b-4300-addf-1c4bc1bd3de3" />

Closes #348 