### PR TITLE
docs: fix 14 broken external links (closes #353)

### DIFF
--- a/content/en/docs/krkn-operator/configuration/_index.md
+++ b/content/en/docs/krkn-operator/configuration/_index.md
@@ -605,7 +605,7 @@ If a cluster shows authentication errors after configuring a ManagedServiceAccou
 
 3. Ensure the ManagedServiceAccount token hasn't expired
 
-For more detailed troubleshooting, see the [ACM Integration Troubleshooting Guide](https://github.com/krkn-chaos/krkn-operator/tree/main/docs/acm).
+For more detailed troubleshooting, see the [ACM Integration Troubleshooting Guide](https://github.com/krkn-chaos/krkn-operator-acm).
 
 ---
 

--- a/content/en/docs/scenarios/aurora-disruption/_tab-krkn.md
+++ b/content/en/docs/scenarios/aurora-disruption/_tab-krkn.md
@@ -1,7 +1,7 @@
 
 This scenario blocks a pod's outgoing MySQL and PostgreSQL traffic, effectively preventing it from connecting to any AWS Aurora SQL engine. It works just as well for standard MySQL and PostgreSQL connections too.
 
-Example scenario file: [aurora_disruption.yml](https://github.com/krkn-chaos/scenarios-hub/blob/main/openshift/aurora_disruption.yml)
+Example scenario file: [aurora_disruption.yml](https://github.com/krkn-chaos/scenarios-hub)
 
 ##### Scenario config
 ```yaml

--- a/content/en/docs/scenarios/dns-outage/_tab-krkn.md
+++ b/content/en/docs/scenarios/dns-outage/_tab-krkn.md
@@ -1,4 +1,4 @@
-Example scenario file: [dns_outage.yml](https://github.com/krkn-chaos/scenarios-hub/blob/main/openshift/dns_outage.yml)
+Example scenario file: [dns_outage.yml](https://github.com/krkn-chaos/scenarios-hub)
 
 ##### Sample scenario config
 ```yaml

--- a/content/en/docs/scenarios/efs-disruption/_tab-krkn.md
+++ b/content/en/docs/scenarios/efs-disruption/_tab-krkn.md
@@ -1,6 +1,6 @@
 This scenario creates an outgoing firewall rule on specific nodes in your cluster, chosen by node name or a selector. This rule blocks connections to AWS EFS, leading to a temporary failure of any EFS volumes mounted on those affected nodes.
 
-Example scenario file: [efs_disruption.yml](https://github.com/krkn-chaos/scenarios-hub/blob/main/openshift/efs_disruption.yml)
+Example scenario file: [efs_disruption.yml](https://github.com/krkn-chaos/scenarios-hub)
 
 ##### Sample scenario config
 ```yaml

--- a/content/en/docs/scenarios/etcd-split-brain/_tab-krkn.md
+++ b/content/en/docs/scenarios/etcd-split-brain/_tab-krkn.md
@@ -2,7 +2,7 @@
 
 This scenario isolates an etcd node by blocking its network traffic. This action forces an etcd leader re-election. Once the scenario concludes, the cluster should temporarily exhibit a split-brain condition, with two etcd leaders active simultaneously. This is particularly useful for testing the etcd cluster’s resilience under such a challenging state.
 
-Example scenario file: [etcd_split_brain.yml](https://github.com/krkn-chaos/scenarios-hub/blob/main/openshift/etcd_split_brain.yml)
+Example scenario file: [etcd_split_brain.yml](https://github.com/krkn-chaos/scenarios-hub)
 
 To run
 

--- a/content/en/docs/scenarios/hog-scenarios/cpu-hog-scenario/_tab-krkn.md
+++ b/content/en/docs/scenarios/hog-scenarios/cpu-hog-scenario/_tab-krkn.md
@@ -1,7 +1,7 @@
 To enable this plugin add the pointer to the scenario input file `scenarios/kube/cpu-hog.yml` as described in the
 [Usage](#usage) section.
 
-Example scenario file: [cpu-hog.yml](https://github.com/krkn-chaos/scenarios-hub/blob/main/openshift/cpu-hog/cpu-hog.yml)
+Example scenario file: [cpu-hog.yml](https://github.com/krkn-chaos/scenarios-hub/blob/main/openshift/cpu-hog/workflow.yaml)
 
 #### `cpu-hog` options
 In addition to the common [hog scenario options](../_index.md#common-options), you can specify the below options in your scenario configuration to specificy the amount of CPU to hog on a certain worker node

--- a/content/en/docs/scenarios/hog-scenarios/io-hog-scenario/_tab-krkn.md
+++ b/content/en/docs/scenarios/hog-scenarios/io-hog-scenario/_tab-krkn.md
@@ -1,7 +1,7 @@
 To enable this plugin add the pointer to the scenario input file `scenarios/kube/io-hog.yaml` as described in the
 [Usage](#usage) section.
 
-Example scenario file: [io-hog.yml](https://github.com/krkn-chaos/scenarios-hub/blob/main/openshift/io-hog/io-hog.yml)
+Example scenario file: [io-hog.yml](https://github.com/krkn-chaos/scenarios-hub/blob/main/openshift/io-hog/workflow.yaml)
 
 #### `io-hog` options
 In addition to the common [hog scenario options](../_index.md#common-options), you can specify the below options in your scenario configuration to target specific pod IO

--- a/content/en/docs/scenarios/hog-scenarios/memory-hog-scenario/_tab-krkn.md
+++ b/content/en/docs/scenarios/hog-scenarios/memory-hog-scenario/_tab-krkn.md
@@ -1,7 +1,7 @@
 To enable this plugin add the pointer to the scenario input file `scenarios/kube/memory-hog.yml` as described in the
 [Usage](#usage) section.
 
-Example scenario file: [memory-hog.yml](https://github.com/krkn-chaos/scenarios-hub/blob/main/openshift/memory-hog/memory-hog.yml)
+Example scenario file: [memory-hog.yml](https://github.com/krkn-chaos/scenarios-hub/blob/main/openshift/memory-hog/workflow.yaml)
 
 #### `memory-hog` options
 In addition to the common [hog scenario options](../_index.md#common-options), you can specify the below options in your scenario configuration to specificy the amount of memory to hog on a certain worker node

--- a/content/en/docs/scenarios/kubevirt-vm-outage-scenario/_tab-krkn.md
+++ b/content/en/docs/scenarios/kubevirt-vm-outage-scenario/_tab-krkn.md
@@ -3,7 +3,7 @@
 
 The `kubevirt_vm_outage` scenario in Kraken enables users to simulate VM-level disruptions by deleting a Virtual Machine Instance (VMI) to test resilience and recovery capabilities.
 
-Example scenario file: [kubevirt-vm-outage.yaml](https://github.com/krkn-chaos/scenarios-hub/blob/main/kubevirt/kubevirt-vm-outage.yaml)
+Example scenario file: [kubevirt-vm-outage.yaml](https://github.com/krkn-chaos/scenarios-hub/blob/main/cnv/snapshot_creation_disruption.yaml)
 
 ## Implementation
 

--- a/content/en/docs/scenarios/network-chaos-ng-scenarios/node-network-filter/_tab-krkn.md
+++ b/content/en/docs/scenarios/network-chaos-ng-scenarios/node-network-filter/_tab-krkn.md
@@ -1,5 +1,5 @@
 
-Example scenario file: [node-network-filter.yml](https://github.com/krkn-chaos/scenarios-hub/blob/main/kubernetes/node-network-filter.yml)
+Example scenario file: [node-network-filter.yml](https://github.com/krkn-chaos/scenarios-hub)
 
 ### Configuration
 

--- a/content/en/docs/scenarios/network-chaos-ng-scenarios/pod-network-filter/_tab-krkn.md
+++ b/content/en/docs/scenarios/network-chaos-ng-scenarios/pod-network-filter/_tab-krkn.md
@@ -1,6 +1,6 @@
 
 
-Example scenario file: [pod-network-filter.yml](https://github.com/krkn-chaos/scenarios-hub/blob/main/kubernetes/pod-network-filter.yml)
+Example scenario file: [pod-network-filter.yml](https://github.com/krkn-chaos/scenarios-hub)
 
 ### Configuration
 

--- a/content/en/docs/scenarios/network-chaos-scenario/_tab-krkn.md
+++ b/content/en/docs/scenarios/network-chaos-scenario/_tab-krkn.md
@@ -41,7 +41,7 @@ network_chaos:                                    # Scenario to create an outage
     image: quay.io/krkn-chaos/krkn:tools
 ```
 
-Note: For ingress traffic shaping, ensure that your node doesn't have any [IFB](https://wiki.linuxfoundation.org/networking/ifb) interfaces already present. The scenario relies on creating IFBs to do the shaping, and they are deleted at the end of the scenario.
+Note: For ingress traffic shaping, ensure that your node doesn't have any [IFB](https://www.kernel.org/doc/html/latest/networking/ifb.html) interfaces already present. The scenario relies on creating IFBs to do the shaping, and they are deleted at the end of the scenario.
 
 
 ##### Steps

--- a/content/en/docs/scenarios/network-chaos-scenario/_tab-krkn.md
+++ b/content/en/docs/scenarios/network-chaos-scenario/_tab-krkn.md
@@ -41,7 +41,7 @@ network_chaos:                                    # Scenario to create an outage
     image: quay.io/krkn-chaos/krkn:tools
 ```
 
-Note: For ingress traffic shaping, ensure that your node doesn't have any [IFB](https://www.kernel.org/doc/html/latest/networking/ifb.html) interfaces already present. The scenario relies on creating IFBs to do the shaping, and they are deleted at the end of the scenario.
+Note: For ingress traffic shaping, ensure that your node doesn't have any [IFB](https://wiki.linuxfoundation.org/networking/ifb) interfaces already present. The scenario relies on creating IFBs to do the shaping, and they are deleted at the end of the scenario.
 
 
 ##### Steps

--- a/content/en/docs/scenarios/service-hijacking-scenario/_tab-krkn.md
+++ b/content/en/docs/scenarios/service-hijacking-scenario/_tab-krkn.md
@@ -1,5 +1,5 @@
 
-Example scenario file: [service_hijacking.yaml](https://github.com/krkn-chaos/scenarios-hub/blob/main/kubernetes/service_hijacking.yaml)
+Example scenario file: [service_hijacking.yaml](https://github.com/krkn-chaos/scenarios-hub)
 
 ### Sample Scenario
 ```yaml

--- a/content/en/docs/scenarios/syn-flood-scenario/_tab-krkn.md
+++ b/content/en/docs/scenarios/syn-flood-scenario/_tab-krkn.md
@@ -1,4 +1,4 @@
-Example scenario file: [syn_flood.yaml](https://github.com/krkn-chaos/scenarios-hub/blob/main/kubernetes/syn_flood.yaml)
+Example scenario file: [syn_flood.yaml](https://github.com/krkn-chaos/scenarios-hub)
 
 ##### Sample scenario config
 

--- a/content/en/docs/scenarios/zone-outage-scenarios/_tab-krkn.md
+++ b/content/en/docs/scenarios/zone-outage-scenarios/_tab-krkn.md
@@ -2,7 +2,7 @@ Zone outage can be injected by placing the zone_outage config file under zone_ou
 
 Example scenario files from [scenarios-hub](https://github.com/krkn-chaos/scenarios-hub):
 - [zone_outage.yaml](https://github.com/krkn-chaos/scenarios-hub/blob/main/openshift/zone_outage.yaml) (AWS)
-- [zone_outage_gcp.yaml](https://github.com/krkn-chaos/scenarios-hub/blob/main/openshift/zone_outage_gcp.yaml) (GCP)
+- [zone_outage_gcp.yaml](https://github.com/krkn-chaos/scenarios-hub) (GCP)
 
 Refer to [cloud setup](/docs/scenarios/cloud_setup.md) to configure your cli properly for the cloud provider of the cluster you want to run zone outages on
 


### PR DESCRIPTION
#353
branch name : fix-broken-link

hi @paigerube14 
While working on https://github.com/krkn-chaos/website/issues/343 (adding a GitHub Action to check for broken links), I ran the new Python link checker script across the repository. The script identified 15 broken internal/external links in the documentation that currently return 404s or fail to resolve.

I am opening this issue to track and fix these broken links to ensure our documentation remains accurate and accessible.
3 fixes → update path to workflow.yaml (hog scenarios restructured)
9 fixes → link to the scenarios-hub repo root since the specific files were deleted
1 fix → kubevirt folder renamed to cnv, point to the new file
1 fix → replace docs/acm with the krkn-operator-acm repo link


| Group | Old (broken) | New (fixed) |
|---|---|---|
| Group 1 — Scenarios moved/removed | <ul><li><a href="https://github.com/krkn-chaos/scenarios-hub/blob/main/kubernetes/node-network-filter.yml">node-network-filter.yml</a></li><li><a href="https://github.com/krkn-chaos/scenarios-hub/blob/main/kubernetes/pod-network-filter.yml">pod-network-filter.yml</a></li><li><a href="https://github.com/krkn-chaos/scenarios-hub/blob/main/kubernetes/service_hijacking.yaml">service_hijacking.yaml</a></li><li><a href="https://github.com/krkn-chaos/scenarios-hub/blob/main/kubernetes/syn_flood.yaml">syn_flood.yaml</a></li><li><a href="https://github.com/krkn-chaos/scenarios-hub/blob/main/openshift/aurora_disruption.yml">aurora_disruption.yml</a></li><li><a href="https://github.com/krkn-chaos/scenarios-hub/blob/main/openshift/dns_outage.yml">dns_outage.yml</a></li><li><a href="https://github.com/krkn-chaos/scenarios-hub/blob/main/openshift/efs_disruption.yml">efs_disruption.yml</a></li><li><a href="https://github.com/krkn-chaos/scenarios-hub/blob/main/openshift/etcd_split_brain.yml">etcd_split_brain.yml</a></li><li><a href="https://github.com/krkn-chaos/scenarios-hub/blob/main/openshift/zone_outage_gcp.yaml">zone_outage_gcp.yaml</a></li></ul> | <a href="https://github.com/krkn-chaos/scenarios-hub">scenarios-hub</a> |
| Group 2 — Hog scenarios restructured | <ul><li><a href="https://github.com/krkn-chaos/scenarios-hub/blob/main/openshift/cpu-hog/cpu-hog.yml">cpu-hog.yml</a> → <a href="https://github.com/krkn-chaos/scenarios-hub/blob/main/openshift/cpu-hog/workflow.yaml">cpu-hog/workflow.yaml</a></li><li><a href="https://github.com/krkn-chaos/scenarios-hub/blob/main/openshift/io-hog/io-hog.yml">io-hog.yml</a> → <a href="https://github.com/krkn-chaos/scenarios-hub/blob/main/openshift/io-hog/workflow.yaml">io-hog/workflow.yaml</a></li><li><a href="https://github.com/krkn-chaos/scenarios-hub/blob/main/openshift/memory-hog/memory-hog.yml">memory-hog.yml</a> → <a href="https://github.com/krkn-chaos/scenarios-hub/blob/main/openshift/memory-hog/workflow.yaml">memory-hog/workflow.yaml</a></li></ul> | Restructured to workflow.yaml |
| Group 3 — kubevirt folder renamed | <a href="https://github.com/krkn-chaos/scenarios-hub/blob/main/kubevirt/kubevirt-vm-outage.yaml">kubevirt/kubevirt-vm-outage.yaml</a> | <a href="https://github.com/krkn-chaos/scenarios-hub/blob/main/cnv/snapshot_creation_disruption.yaml">cnv/snapshot_creation_disruption.yaml</a> |
| Group 4 — krkn-operator missing directory | <a href="https://github.com/krkn-chaos/krkn-operator/tree/main/docs/acm">krkn-operator/docs/acm</a> | <a href="https://github.com/krkn-chaos/krkn-operator-acm">krkn-operator-acm</a> |
