### PR TITLE
Fixed the build-your-changes section

### DIFF
--- a/content/en/docs/developers-guide/testing-changes.md
+++ b/content/en/docs/developers-guide/testing-changes.md
@@ -296,38 +296,45 @@ To get latest podman-compose features we need, use this installation command
 1. Run [build.sh](../build.sh) to create Dockerfile's for each scenario
 2. Edit the docker-compose.yaml file to point to your quay.io repository (optional; required if you want to push or are testing krknctl)
 
-```txt
-ex.) 
-image: containers.krkn-chaos.dev/krkn-chaos/krkn-hub:chaos-recommender 
+   For example, change:
 
-change to >
+   ```text
+   image: containers.krkn-chaos.dev/krkn-chaos/krkn-hub:chaos-recommender
+   ```
 
-image: quay.io/<user>/krkn-hub:chaos-recommender
-```
+   to:
 
-3. Build your image(s) from base krkn-hub directory
-    
-    Builds all images in docker-compose file
-    ```bash
-    docker-compose build
-```
+   ```text
+   image: quay.io/<user>/krkn-hub:chaos-recommender
+   ```
 
-    Builds single image defined by service/scenario name 
-    ```bash
-    docker-compose build <scenario_type>
-```
+3. Build your image(s) from base krkn-hub directory.
 
-    OR 
+   Build all images in the docker-compose file:
 
-    Builds all images in podman-compose file
-    ```bash
-    podman-compose build
-```
+   ```bash
+   docker-compose build
+   ```
 
-    Builds single image defined by service/scenario name 
-    ```bash
-    podman-compose build <scenario_type>
-```
+   Build a single image defined by service/scenario name:
+
+   ```bash
+   docker-compose build <scenario_type>
+   ```
+
+   OR
+
+   Build all images in the podman-compose file:
+
+   ```bash
+   podman-compose build
+   ```
+
+   Build a single image defined by service/scenario name:
+
+   ```bash
+   podman-compose build <scenario_type>
+   ```
 
 
 ### Push Images to your quay.io


### PR DESCRIPTION
Earlier, the build your changes section was not proper. The normal text was also there along with the code.

Earlier:
<img width="1498" height="426" alt="image" src="https://github.com/user-attachments/assets/b30dfe4a-96b5-47d4-8f51-53005d935296" />

<img width="1520" height="482" alt="image" src="https://github.com/user-attachments/assets/38194fd7-e312-4d69-986e-c9274870afb7" />


Now:
<img width="1588" height="1556" alt="image" src="https://github.com/user-attachments/assets/a7e3dcb3-6522-424e-a8a5-6fa677feb7d5" />
<img width="1486" height="218" alt="image" src="https://github.com/user-attachments/assets/9e4e0556-112f-47c5-86ab-198a06efe194" />


Fixes #352