### PR TITLE
fixed the broken tables and column fix in the UI

### DIFF
--- a/assets/scss/_custom_docs.scss
+++ b/assets/scss/_custom_docs.scss
@@ -539,6 +539,27 @@ table td {
   border: 1px solid var(--krkn-border-subtle) !important;
   text-align: left;
   color: var(--krkn-text) !important;
+  overflow-wrap: break-word;
+  vertical-align: top;
+}
+
+// Keep short, fixed-vocabulary columns from being squeezed onto two lines.
+// First column (Parameter / Scenario Type) and the last two columns
+// (typically Type / Required / Default / Possible Values) hold short tokens
+// that should stay on one line; the Description column in the middle does
+// the wrapping.
+.td-content table th:first-child,
+.td-content table td:first-child,
+.td-content table th:nth-last-child(-n + 3),
+.td-content table td:nth-last-child(-n + 3) {
+  white-space: nowrap;
+}
+
+// Description (and other long-form middle cells) wraps naturally.
+.td-content table th:nth-child(2),
+.td-content table td:nth-child(2) {
+  white-space: normal;
+  min-width: 18ch;
 }
 
 .td-content th,

--- a/content/en/docs/krkn/rbac.md
+++ b/content/en/docs/krkn/rbac.md
@@ -145,7 +145,6 @@ The following table lists the available Krkn scenarios and their required RBAC p
 | service_disruption_scenarios | Namespace | Ns-Privileged | Scenarios that disrupt services |
 | service_hijacking_scenarios | Namespace | Privileged | Scenarios that hijack services |
 | syn_flood_scenarios | Cluster | Privileged | SYN flood attack scenarios |
-
 | time_scenarios | Cluster | Privileged | Scenarios that manipulate system time |
 | zone_outages_scenarios | Cluster | Privileged | Scenarios that simulate zone outages |
 


### PR DESCRIPTION
Before:
1.

<img width="837" height="555" alt="Image" src="https://github.com/user-attachments/assets/d4929c80-ec9d-419c-89c7-30e9048d1203" />

2.

<img width="749" height="124" alt="Image" src="https://github.com/user-attachments/assets/394a6886-e2df-47de-ac26-f3a06b632fec" />

3.

<img width="785" height="330" alt="Image" src="https://github.com/user-attachments/assets/7633c29a-8518-4cb4-89e8-b38609aade5e" />

Here, the default column text is collapsing while it should have not been collapsed.

After making the fix:
1.

<img width="787" height="525" alt="Image" src="https://github.com/user-attachments/assets/7b142efe-900c-402b-8ac0-d856ea6d12f4" />

2.

<img width="759" height="82" alt="Image" src="https://github.com/user-attachments/assets/2403bdaa-67dd-4498-ad5e-0bb27deb57bd" />

3.

<img width="743" height="199" alt="Image" src="https://github.com/user-attachments/assets/e8476bfe-04fc-40c2-97e7-4c0a304367dc" />



Fixes #370