### PR TITLE
fixed logo image size

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="./static/img/logo.png" alt="Krkn - Chaos Engineering for Kubernetes" width="100%"/>
+  <img src="./static/img/logo.png" alt="Krkn - Chaos Engineering for Kubernetes" width="40%"/>
 </p>
 
 <p align="center">


### PR DESCRIPTION
After making the fix:
<img width="798" height="443" alt="image" src="https://github.com/user-attachments/assets/d9dfca28-f0d1-4d33-be71-2d7e2ca66aed" />


Fixes #372