### PR TITLE
fix-table-layout: Fix: global table layout on mobile

### DIFF
--- a/assets/scss/_custom_docs.scss
+++ b/assets/scss/_custom_docs.scss
@@ -525,10 +525,18 @@ pre.chroma span {
 // -----------------------------------------------------------------------------
 .td-content table,
 table {
+  display: block;
   width: 100%;
+  max-width: 100%;
+  overflow-x: auto;
   border-collapse: collapse;
   margin: 1.5rem 0;
   color: var(--krkn-text) !important;
+}
+
+.td-content td code,
+table td code {
+  white-space: nowrap;
 }
 
 .td-content th,
@@ -538,9 +546,9 @@ table td {
   padding: 0.75rem 1rem;
   border: 1px solid var(--krkn-border-subtle) !important;
   text-align: left;
-  color: var(--krkn-text) !important;
   overflow-wrap: break-word;
   vertical-align: top;
+  min-width: 120px; /* Prevents columns from compressing into single letters on mobile */
 }
 
 // Keep short, fixed-vocabulary columns from being squeezed onto two lines.
@@ -566,6 +574,7 @@ table td {
 .td-content thead th,
 table th,
 table thead th {
+  white-space: nowrap; /* Keeps headers clean on a single line */
   background: var(--krkn-elevated) !important;
   color: var(--krkn-text) !important;
   font-weight: 600;


### PR DESCRIPTION
## UI Update
Making the documentation tables fully responsive and readable on mobile screens.

**Changes:** 
Right now, if you look at any of the documentation pages on a phone, tables containing keys or descriptions get squeezed so much that column headers and text break down into vertical single letters (like "Parameter" or "Description" stacked completely vertically), which makes them unreadable.

To fix this, I added some clean global CSS rules:

- Made tables block-level and added `overflow-x: auto` so they can be scrolled smoothly sideways on smaller screens without pushing the whole page layout open.
- Set a safe `min-width: 120px` on cells so columns have enough breathing room and don't collapse into single letters.
- Prevented code blocks (like parameter flags) and headers from wrapping awkwardly mid-word by using `white-space: nowrap`.

**Before:**
<img width="502" height="726" alt="Screenshot 2026-05-08 at 11 19 00 PM" src="https://github.com/user-attachments/assets/4f3fbcc1-f1fc-4ebd-a9dc-4cc8742b3654" />

**After:** 

https://github.com/user-attachments/assets/22afac7f-e9fa-47d2-aaf6-c8d337866912

