### PR TITLE
fix: update stale scenario count from 15+ to 25+ on docs landing page

### DIFF
--- a/content/en/docs/_index.md
+++ b/content/en/docs/_index.md
@@ -260,7 +260,7 @@ type: "docs/scenarios"
             <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="7" height="7" x="3" y="3" rx="1"/><rect width="7" height="7" x="14" y="3" rx="1"/><rect width="7" height="7" x="14" y="14" rx="1"/><rect width="7" height="7" x="3" y="14" rx="1"/></svg>
           </div>
           <h3 class="feature-card__title">Browse Scenarios</h3>
-          <p class="feature-card__desc">Explore 15+ chaos scenarios for pods, nodes, network, and more.</p>
+          <p class="feature-card__desc">Explore 25+ chaos scenarios for pods, nodes, network, and more.</p>
         </a>
       </div>
     </div>


### PR DESCRIPTION
## Summary
The Browse Scenarios feature card on the docs landing page showed 
"15+ chaos scenarios" which was significantly understated.

## Root Cause
The scenario count was not updated as new scenarios were added over time.
Counting all scenario folders under `content/en/docs/scenarios/` including 
sub-scenarios (hog-scenarios has 3 and network-chaos-ng-scenarios has 3), 
the actual total is 26.

## Fix
Updated "15+" to "25+" in `content/en/docs/_index.md` line 263 to 
accurately reflect current scenario coverage and be consistent with 
the homepage which already says "20+".

## Testing
- Hugo build passes locally with 0 errors (241 pages built)
- Verified change at localhost:1313/docs/

Fixes #380