### PR TITLE
fix-hugo-leak: Prevent Website Crashes & Clean Up the Sidebar for Future Updates

### DIFF
--- a/content/en/docs/installation/_index.md
+++ b/content/en/docs/installation/_index.md
@@ -19,12 +19,17 @@ Krkn provides multiple ways to run chaos scenarios. Choose the method that best 
 | **[krkn](krkn.md)**          | Standalone Python program     | Full control, development, and customization           |
 
 {{% alert title="Recommendation" color="success" %}}
+
 **krknctl** is the recommended way to run Krkn. It provides the simplest path to chaos testing with powerful capabilities including complex workflow orchestration, built-in scenario discovery, and interactive query support — all without managing configuration files.
+
 {{% /alert %}}
 
 {{% alert title="Recommendation" color="success" %}}
+
 Look for features marked with [BETA] (e.g., [BETA] Krkn Resilience Score). Beta features provide early access to new capabilities for experimentation and feedback and may not yet meet the stability, performance, or compatibility guarantees of GA features. Please refer to the [Beta feature policy](https://github.com/krkn-chaos/krkn/blob/main/BETA_FEATURE_POLICY.md) for more details.
+
 {{% /alert %}}
+
 ---
 
 ## Installation Methods
@@ -58,7 +63,11 @@ Look for features marked with [BETA] (e.g., [BETA] Krkn Resilience Score). Beta 
 
 **Best for:** CI/CD pipelines, automated testing, and users who prefer containers over local Python setups.
 
-{{% alert title="Note" %}}krkn-hub runs **one scenario type per execution**. For running multiple scenarios in a single run, use the standalone **krkn** installation.{{% /alert %}}
+{{% alert title="Note" %}}
+
+krkn-hub runs **one scenario type per execution**. For running multiple scenarios in a single run, use the standalone **krkn** installation.
+
+{{% /alert %}}
 
 👉 **[Install krkn-hub →](krkn-hub.md)**
 
@@ -91,7 +100,11 @@ Look for features marked with [BETA] (e.g., [BETA] Krkn Resilience Score). Beta 
 
 **Best for:** Advanced users, developers contributing to Krkn, and scenarios requiring fine-grained control.
 
-{{% alert title="Note" %}}Requires Python 3.9 environment and manual dependency management.{{% /alert %}}
+{{% alert title="Note" %}}
+
+Requires Python 3.9 environment and manual dependency management.
+
+{{% /alert %}}
 
 👉 **[Install krkn →](krkn.md)**
 
@@ -100,9 +113,13 @@ Look for features marked with [BETA] (e.g., [BETA] Krkn Resilience Score). Beta 
 ## Important Considerations
 
 {{% alert title="Run External to Cluster" color="warning" %}}
+
 It is recommended to run Krkn **external to the cluster** (Standalone or Containerized) hitting the Kubernetes/OpenShift API. Running it inside the cluster might be disruptive to itself and may not report results if the chaos leads to API server instability.
+
 {{% /alert %}}
 
 {{% alert title="Power Architecture (ppc64le)" %}}
+
 To run Krkn on Power (ppc64le) architecture, build and run a containerized version by following the instructions [here](https://github.com/krkn-chaos/krkn/blob/main/containers/build_own_image-README.md).
+
 {{% /alert %}}


### PR DESCRIPTION
### Description
While testing the website locally, I noticed that some pages look broken: ugly code placeholders like `HAHAHUGOSHORTCODE` appear, and the sidebar gets filled with junk link.

This happens because the latest versions of Hugo (our website builder) have stricter rules about blank spaces in text files. While the live website currently uses an older version of Hugo that ignores this mistake, any future upgrade to Hugo will break the live website exactly like this.

By merging this fix now, we protect the website and make it ready for future updates!

**The Fix:**

- Added Spacing to Alert Boxes: This PR adds a simple empty line inside the `{{% alert %}}` boxes. This ensures Hugo can always read the text inside perfectly.
- Fixed the Sidebar (Table of Contents): This PR puts a blank line between an alert box and a horizontal divider `(---)`. Without this space, the computer gets confused and accidentally jams internal code into the sidebar list.

### Results
**Before:** 
<img width="1470" height="775" alt="Screenshot 2026-05-10 at 10 15 42 PM" src="https://github.com/user-attachments/assets/c7a454ca-320c-4af6-8671-c4386bd06ea8" />

**After:**
<img width="1470" height="771" alt="Screenshot 2026-05-10 at 10 15 14 PM" src="https://github.com/user-attachments/assets/23476d5a-7aba-4772-9b59-04a12785e2ec" />
