### PR TITLE
docs(krkn-ai): add output directory structure to run page

### DIFF
--- a/content/en/docs/krkn_ai/run.md
+++ b/content/en/docs/krkn_ai/run.md
@@ -37,3 +37,23 @@ By default, Krkn-AI uses [krknctl](../krknctl/) as engine. You can switch to [kr
 ```bash
 $ uv run krkn_ai run -r krknhub -c ./krkn-ai.yaml -o ./tmp/results/
 ```
+
+### Output Structure
+
+Each run creates a UUID-named subdirectory under the path passed to `-o`, so multiple runs don't overwrite each other.
+
+```text
+tmp/results/
+└── <run-uuid>/
+    ├── krkn-ai.yaml         # config snapshot (useful for re-running)
+    ├── reports/
+    │   ├── health_check_report.csv  # app health across scenarios
+    │   ├── all.csv                  # metrics for every scenario
+    │   ├── best_scenarios.yaml      # top scenarios found by the algorithm
+    │   └── graphs/                  # per-scenario PNG plots
+    ├── yaml/
+    │   ├── generation_0/    # scenario files for gen 0
+    │   ├── generation_1/    # scenario files for gen 1
+    │   └── ...
+    └── log/                 # per-scenario logs
+```


### PR DESCRIPTION
Fixes #388

The run page showed how to invoke `krkn_ai run` but never explained
what gets created in the output directory after execution.

Added an "Output Structure" section to `content/en/docs/krkn_ai/run.md` covering:
- UUID subdirectory per run (so multiple runs don't overwrite each other)
- reports/ with health_check_report.csv, all.csv, best_scenarios.yaml, graphs/
- yaml/generation_N/ folders for scenario files per generation
- logs/ for per-scenario execution logs
- run.log, results.json, krkn-ai.yaml at the root level

Also added a note clarifying the -f flag switches output between yaml and json.