### PR TITLE
embed the video in the website instead of redirecting externally

### DIFF
--- a/content/en/docs/scenarios/hog-scenarios/cpu-hog-scenario/_index.md
+++ b/content/en/docs/scenarios/hog-scenarios/cpu-hog-scenario/_index.md
@@ -55,4 +55,5 @@ Choose your preferred method to run CPU hog scenarios:
 {{< /tabpane >}}
 
 ## Demo
-You can find a link to a demo of the scenario [here](https://asciinema.org/a/452762)
+See a demo of this scenario:
+<script src="https://asciinema.org/a/452762.js" id="asciicast-452762" async="true" style="max-width:900px; max-height:400px; width:100%; aspect-ratio:20/9;"></script>

--- a/content/en/docs/scenarios/hog-scenarios/memory-hog-scenario/_index.md
+++ b/content/en/docs/scenarios/hog-scenarios/memory-hog-scenario/_index.md
@@ -60,4 +60,5 @@ Choose your preferred method to run memory hog scenarios:
 {{< /tabpane >}}
 
 ## Demo
-You can find a link to a demo of the scenario [here](https://asciinema.org/a/452742?speed=3&theme=solarized-dark)
+See a demo of this scenario:
+<script src="https://asciinema.org/a/452742.js" id="asciicast-452742" async="true" data-speed="3" data-theme="solarized-dark" style="max-width:900px; max-height:400px; width:100%; aspect-ratio:20/9;"></script>

--- a/content/en/docs/scenarios/service-disruption-scenarios/_index.md
+++ b/content/en/docs/scenarios/service-disruption-scenarios/_index.md
@@ -25,4 +25,5 @@ Choose your preferred method to run service disruption scenarios:
 {{< /tabpane >}}
 
 ## Demo
-You can find a link to a demo of the scenario [here](https://asciinema.org/a/kKPSI0D7upV9HQWH5jnroTaKb)
+See a demo of this scenario:
+<script src="https://asciinema.org/a/kKPSI0D7upV9HQWH5jnroTaKb.js" id="asciicast-kKPSI0D7upV9HQWH5jnroTaKb" async="true" style="max-width:900px; max-height:400px; width:100%; aspect-ratio:20/9;"></script>

--- a/content/en/docs/scenarios/zone-outage-scenarios/_index.md
+++ b/content/en/docs/scenarios/zone-outage-scenarios/_index.md
@@ -32,4 +32,5 @@ Choose your preferred method to run zone outage scenarios:
 {{< /tabpane >}}
 
 ## Demo
-You can find a link to a demo of the scenario [here](https://asciinema.org/a/452672?speed=3&theme=solarized-dark)
+See a demo of this scenario:
+<script src="https://asciinema.org/a/452672.js" id="asciicast-452672" async="true" data-speed="3" data-theme="solarized-dark" style="max-width:900px; max-height:400px; width:100%; aspect-ratio:20/9;"></script>


### PR DESCRIPTION
Earlier, the 7 videos were getting embedded while other 4 were redirecting externally. I have made changes to make sure the other 4 also renders within the browser. Below are attested screenshots:

cpu-hog-scenerio:
<img width="925" height="637" alt="image" src="https://github.com/user-attachments/assets/5f90bda5-e0fa-4887-acb9-e5cffefc3b75" />

memory hog scenario:
<img width="933" height="654" alt="image" src="https://github.com/user-attachments/assets/da2d9a91-8818-47a1-9563-0a8c0e780888" />

service disruption scenario(this one is rendering a bit weird, since it was recorded in a weird resolution by default):
<img width="931" height="709" alt="image" src="https://github.com/user-attachments/assets/1ee4d896-f357-4c57-b8f8-42e3dd021120" />

zone outage scenario:
<img width="943" height="664" alt="image" src="https://github.com/user-attachments/assets/ad5efc82-238e-4378-87c1-392b23a454ae" />


Fixes #365 