### PR TITLE
fix-broken-link -> Fix: broken link on application outage page

### DIFF
--- a/content/en/docs/scenarios/application-outage/_index.md
+++ b/content/en/docs/scenarios/application-outage/_index.md
@@ -9,7 +9,8 @@ weight: 3
 <krkn-hub-scenario id="application-outages">
 Scenario to block the traffic ( Ingress/Egress ) of an application matching the labels for the specified duration of time to understand the behavior of the service/other services which depend on it during downtime. This helps with planning the requirements accordingly, be it improving the timeouts or tweaking the alerts etc.
 </krkn-hub-scenario>
-You can add in your applications URL into the [health checks section](../../krkn/config.md#health-checks) of the config to track the downtime of your application during this scenario 
+
+You can add in your applications URL into the [health checks section](/docs/krkn/config/#health-checks) of the config to track the downtime of your application during this scenario 
 
 ### Rollback Scenario Support
 


### PR DESCRIPTION
## Description
This PR fixes a link that is currently not clickable on the documentation page.

**Changes:** 

- A missing empty line after a code tag caused the computer to display raw code instead of a clickable link to the reader.
- This PR adds the required empty line to make it clickable, and updated the web address to ensure users land on the correct page when they click it.

**Before:**
<img width="927" height="221" alt="Screenshot 2026-05-11 at 9 13 17 PM" src="https://github.com/user-attachments/assets/659304a0-8be4-45be-9235-dbe4bc267bea" />

**After:**
<img width="892" height="224" alt="Screenshot 2026-05-11 at 9 13 54 PM" src="https://github.com/user-attachments/assets/30e30dc1-deca-4fe3-a160-4f79535de2f1" />

