### PR TITLE
docs(krkn-hub/node-interface-down): fix parameter drift and stale defaults

### DIFF
--- a/content/en/docs/scenarios/network-chaos-ng-scenarios/node-interface-down/_tab-krkn-hub.md
+++ b/content/en/docs/scenarios/network-chaos-ng-scenarios/node-interface-down/_tab-krkn-hub.md
@@ -38,10 +38,11 @@ See list of variables that apply to all scenarios [here](/docs/scenarios/all-sce
 | NODE_SELECTOR                 | Label selector to choose target nodes. If not specified, a schedulable node will be chosen at random | "node-role.kubernetes.io/worker=" |
 | NODE_NAME                     | The node name to target (used when label selector is not set)        |                                      |
 | INSTANCE_COUNT                | Restricts the number of nodes selected by the label selector         | 1                                    |
-| EXECUTION                     | Execution mode for multiple nodes: `serial` or `parallel`            | serial                               |
+| EXECUTION                     | Execution mode for multiple nodes: `serial` or `parallel`            | parallel                               |
 | INTERFACES                    | Comma-separated list of interface names to bring down (e.g. `eth0` or `eth0,bond0`). Leave empty to auto-detect the default interface | "" |
 | NAMESPACE                     | Namespace where the chaos workload pod will be deployed              | default                              |
 | TAINTS                        | List of taints for which tolerations need to be created. Example: `["node-role.kubernetes.io/master:NoSchedule"]` | [] |
+| SERVICE_ACCOUNT               | Optional service account for the chaos workload pod                  | "" |
 
 
 **NOTE** In case of using custom metrics profile or alerts profile when `CAPTURE_METRICS` or `ENABLE_ALERTS` is enabled, mount the metrics profile from the host on which the container is run using podman/docker under `/home/krkn/kraken/config/metrics-aggregated.yaml` and `/home/krkn/kraken/config/alerts`. For example:

--- a/content/en/docs/scenarios/network-chaos-ng-scenarios/node-interface-down/_tab-krkn.md
+++ b/content/en/docs/scenarios/network-chaos-ng-scenarios/node-interface-down/_tab-krkn.md
@@ -10,7 +10,7 @@ Example scenario file: [node_interface_down.yaml](https://github.com/krkn-chaos/
   test_duration: 60
   label_selector: "node-role.kubernetes.io/worker="
   instance_count: 1
-  execution: serial
+  execution: parallel
   namespace: default
   # scenario specific settings
   target: ""

--- a/content/en/docs/scenarios/network-chaos-ng-scenarios/node-interface-down/_tab-krknctl.md
+++ b/content/en/docs/scenarios/network-chaos-ng-scenarios/node-interface-down/_tab-krknctl.md
@@ -15,7 +15,7 @@ Can also set any global variable listed [here](../../all-scenario-env-krknctl.md
 | `--node-name`        | string  | Node name to target (used when node-selector is not set)                                       | false    |                                                  |
 | `--namespace`        | string  | Namespace where the chaos workload pod will be deployed                                        | false    | default                                          |
 | `--instance-count`   | number  | Number of nodes to target from those matching the selector                                     | false    | 1                                                |
-| `--execution`        | enum    | Execution mode when targeting multiple nodes: `serial` or `parallel`                           | false    | serial                                           |
+| `--execution`        | enum    | Execution mode when targeting multiple nodes: `serial` or `parallel`                           | false    | parallel                                           |
 | `--interfaces`       | string  | Comma-separated list of interface names to bring down. Leave empty to auto-detect the default interface | false |                                             |
 | `--image`            | string  | The chaos workload container image                                                             | false    | quay.io/redhat-chaos/krkn-ng-tools:latest        |
 | `--taints`           | string  | List of taints for which tolerations need to be created                                        | false    |                                                  |


### PR DESCRIPTION
## Documentation Update
**Related Feature:** 
[krkn-hub/node-interface-down](https://github.com/krkn-chaos/krkn-hub/blob/main/node-interface-down/env.sh)

**Changes:** 

I updated the documentation for the Node Interface Down scenario to match the current state of the source code.

* Fixed `content/en/docs/scenarios/network-chaos-ng-scenarios/node-interface-down/_tab-krkn-hub.md`
* Added the missing `SERVICE_ACCOUNT` parameter to the documentation table.
* Corrected the default value of the `EXECUTION` parameter from `serial` to `parallel` to accurately reflect the upstream env.sh file.
