### PR TITLE
docs: correct container image scanning claim in security self-assessment

### DIFF
--- a/content/en/docs/security.md
+++ b/content/en/docs/security.md
@@ -113,7 +113,7 @@ Known Weakness. krkn-lib static code analysis should be added to the roadmap.
 
 #### Container image scanning
 
-Our base image on top of which all the tags are build is scanned on the building phase by [Snyk](https://snyk.io) CLI in the CI pipeline.
+Known Weakness. Container image scanning via Snyk CLI during the build phase has not yet been implemented in the CI pipeline and should be added to the roadmap.
 
 #### Input validation protocol
 Python's flexible typing has made user input validation a challenge for the Krkn core. To solve this, we've established a new validation protocol between the Krknctl CLI and our container images. By making Krknctl the main entry point for running Krkn, we can now rely on it to ensure all user input is robustly validated.


### PR DESCRIPTION
Fixes #397

## Documentation Update
**Related Feature:** Security self-assessment (`content/en/docs/security.md`)

**Changes:** The "Container image scanning" section in `security.md` currently claims:

> "Our base image on top of which all the tags are build is scanned on the building phase by Snyk CLI in the CI pipeline."

Checked `docker-image.yml` in the krkn repo and there is no Snyk scanning step anywhere in that workflow. The image gets built and pushed but no container scanning runs at any stage.

The security self-assessment is what contributors and adopters read to understand the project's actual security posture, so having an inaccurate claim there is misleading. Updated the section to follow the same "Known Weakness" pattern already used for static code analysis for Krkn and krkn-lib on lines 109 and 112, keeping it consistent with how the doc handles features not yet implemented.

<!-- docs-not-needed -->
