### PR TITLE
docs(network-chaos-ng): add pod_network_chaos and node_network_chaos scenario pages

### DIFF
--- a/content/en/docs/scenarios/network-chaos-ng-scenarios/_index.md
+++ b/content/en/docs/scenarios/network-chaos-ng-scenarios/_index.md
@@ -13,3 +13,5 @@ This scenario introduce a new infrastructure to refactor and port the current im
 - [Pod Network Filter](/docs/scenarios/network-chaos-ng-scenarios/pod-network-filter/_index.md)
 - [Node Network Filter](/docs/scenarios/network-chaos-ng-scenarios/node-network-filter/_index.md)
 - [Node Interface Down](/docs/scenarios/network-chaos-ng-scenarios/node-interface-down/_index.md)
+- [Pod Network Chaos](/docs/scenarios/network-chaos-ng-scenarios/pod-network-chaos/_index.md)
+- [Node Network Chaos](/docs/scenarios/network-chaos-ng-scenarios/node-network-chaos/_index.md)

--- a/content/en/docs/scenarios/network-chaos-ng-scenarios/node-network-chaos/_index.md
+++ b/content/en/docs/scenarios/network-chaos-ng-scenarios/node-network-chaos/_index.md
@@ -1,0 +1,24 @@
+---
+title: Node Network Chaos
+description:
+date: 2017-01-04
+---
+Injects network degradation (latency, packet loss, bandwidth restriction) into a target node's network interfaces using Linux `tc` (traffic control) rules. Unlike node-network-filter which blocks specific ports via iptables, this module shapes traffic at the interface level. Includes safety checks for existing `tc` rules on the node.
+
+## How to Run Node Network Chaos Scenarios
+
+Choose your preferred method to run node network chaos scenarios:
+
+{{< tabpane text=true >}}
+  {{< tab header="**Krkn**" lang="krkn" >}}
+{{< readfile file="_tab-krkn.md" >}}
+  {{< /tab >}}
+  {{< tab header="**Krkn-hub**" lang="krkn-hub" >}}
+{{< readfile file="_tab-krkn-hub.md" >}}
+  {{< /tab >}}
+  {{< tab header="**Krknctl**" lang="krknctl" >}}
+{{< readfile file="_tab-krknctl.md" >}}
+  {{< /tab >}}
+{{< /tabpane >}}
+
+Example scenario file: [node-network-chaos.yml](https://github.com/krkn-chaos/krkn/blob/main/scenarios/kube/node-network-chaos.yml)

--- a/content/en/docs/scenarios/network-chaos-ng-scenarios/node-network-chaos/_index.md
+++ b/content/en/docs/scenarios/network-chaos-ng-scenarios/node-network-chaos/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Node Network Chaos
-description:
+description: "Injects network degradation (latency, packet loss, bandwidth) into a target node's network interfaces using Linux tc rules."
 date: 2017-01-04
 ---
 Injects network degradation (latency, packet loss, bandwidth restriction) into a target node's network interfaces using Linux `tc` (traffic control) rules. Unlike node-network-filter which blocks specific ports via iptables, this module shapes traffic at the interface level. Includes safety checks for existing `tc` rules on the node.

--- a/content/en/docs/scenarios/network-chaos-ng-scenarios/node-network-chaos/_tab-krkn-hub.md
+++ b/content/en/docs/scenarios/network-chaos-ng-scenarios/node-network-chaos/_tab-krkn-hub.md
@@ -1,0 +1,3 @@
+{{% alert title="Not yet supported" color="warning" %}}
+`node_network_chaos` is not currently available as a krkn-hub container image. Use the Krkn tab to run this scenario directly.
+{{% /alert %}}

--- a/content/en/docs/scenarios/network-chaos-ng-scenarios/node-network-chaos/_tab-krkn.md
+++ b/content/en/docs/scenarios/network-chaos-ng-scenarios/node-network-chaos/_tab-krkn.md
@@ -15,7 +15,7 @@
   interfaces: []
   ingress: true
   egress: true
-  latency: 0s        # supported units: us (microseconds), ms, s
+  latency: ""         # empty string to skip; or e.g. 100ms (units: us, ms, s)
   loss: 10           # percentage (no % symbol)
   bandwidth: 1gbit   # supported units: bit, kbit, mbit, gbit, tbit
   force: false

--- a/content/en/docs/scenarios/network-chaos-ng-scenarios/node-network-chaos/_tab-krkn.md
+++ b/content/en/docs/scenarios/network-chaos-ng-scenarios/node-network-chaos/_tab-krkn.md
@@ -1,0 +1,81 @@
+### Configuration
+
+```yaml
+- id: node_network_chaos
+  image: "quay.io/krkn-chaos/krkn-network-chaos:latest"
+  wait_duration: 1
+  test_duration: 60
+  label_selector: ""
+  service_account: ""
+  instance_count: 1
+  execution: parallel
+  namespace: default
+  # scenario specific settings
+  target: "<node_name>"
+  interfaces: []
+  ingress: true
+  egress: true
+  latency: 0s        # supported units: us (microseconds), ms, s
+  loss: 10           # percentage (no % symbol)
+  bandwidth: 1gbit   # supported units: bit, kbit, mbit, gbit, tbit
+  force: false
+  taints: []
+```
+
+For the common module settings please refer to the [documentation](../network-chaos-ng-scenario-api.md#basenetworkchaosconfig-base-module-configuration).
+
+- `latency`: network latency to inject. Format: integer followed by `us` (microseconds), `ms` (milliseconds), or `s` (seconds). Example: `100ms`. Set to empty string to skip.
+- `loss`: packet loss percentage as a plain integer (no `%` symbol). Example: `10` means 10% packet loss. Set to empty string to skip.
+- `bandwidth`: bandwidth limit. Format: integer followed by `bit`, `kbit`, `mbit`, `gbit`, or `tbit`. Example: `100mbit`. Set to empty string to skip.
+- `interfaces`: list of network interface names to target. Leave empty to auto-detect the node's default interface.
+- `ingress`: apply rules to incoming traffic (default: `true`)
+- `egress`: apply rules to outgoing traffic (default: `true`)
+- `target`: the node name to target (used when `label_selector` is not set)
+- `force`: by default (`false`), if the target node already has `tc` rules configured, the scenario aborts with a warning to avoid damaging cluster networking. Set to `true` to override existing rules. A 10-second warning delay is inserted before proceeding. Use with caution.
+
+### Usage
+
+To enable node network chaos scenarios edit the kraken config file, go to the section `kraken -> chaos_scenarios` of the yaml structure
+and add a new element to the list named `network_chaos_ng_scenarios` then add the desired scenario
+pointing to the scenario yaml file.
+
+```yaml
+kraken:
+    ...
+    chaos_scenarios:
+        - network_chaos_ng_scenarios:
+            - scenarios/kube/node-network-chaos.yml
+```
+
+{{% alert title="Note" %}}
+You can specify multiple scenario files of the same type by adding additional paths to the list:
+```yaml
+kraken:
+    chaos_scenarios:
+        - network_chaos_ng_scenarios:
+            - scenarios/kube/node-network-chaos-1.yml
+            - scenarios/kube/node-network-chaos-2.yml
+```
+
+You can also combine multiple different scenario types in the same config.yaml file. Scenario types can be specified in any order, and you can include the same scenario type multiple times:
+```yaml
+kraken:
+    chaos_scenarios:
+        - network_chaos_ng_scenarios:
+            - scenarios/kube/node-network-chaos.yml
+        - pod_disruption_scenarios:
+            - scenarios/pod-kill.yaml
+        - node_scenarios:
+            - scenarios/node-reboot.yaml
+```
+{{% /alert %}}
+
+{{% alert title="Warning" color="warning" %}}
+When `force` is set to `false` (default), the scenario will check if the target node already has complex `tc` queueing disciplines configured. If existing rules are detected, the scenario aborts to prevent damaging cluster networking. Only set `force: true` if you understand the implications of overriding existing traffic control rules.
+{{% /alert %}}
+
+### Run
+
+```bash
+python run_kraken.py --config config/config.yaml
+```

--- a/content/en/docs/scenarios/network-chaos-ng-scenarios/node-network-chaos/_tab-krknctl.md
+++ b/content/en/docs/scenarios/network-chaos-ng-scenarios/node-network-chaos/_tab-krknctl.md
@@ -1,0 +1,3 @@
+{{% alert title="Not yet supported" color="warning" %}}
+`node_network_chaos` is not currently available via krknctl. Use the Krkn tab to run this scenario directly.
+{{% /alert %}}

--- a/content/en/docs/scenarios/network-chaos-ng-scenarios/pod-network-chaos/_index.md
+++ b/content/en/docs/scenarios/network-chaos-ng-scenarios/pod-network-chaos/_index.md
@@ -1,0 +1,24 @@
+---
+title: Pod Network Chaos
+description:
+date: 2017-01-04
+---
+Injects network degradation (latency, packet loss, bandwidth restriction) into a target pod's network interfaces using Linux `tc` (traffic control) rules. Unlike pod-network-filter which blocks specific ports via iptables, this module shapes traffic at the interface level.
+
+## How to Run Pod Network Chaos Scenarios
+
+Choose your preferred method to run pod network chaos scenarios:
+
+{{< tabpane text=true >}}
+  {{< tab header="**Krkn**" lang="krkn" >}}
+{{< readfile file="_tab-krkn.md" >}}
+  {{< /tab >}}
+  {{< tab header="**Krkn-hub**" lang="krkn-hub" >}}
+{{< readfile file="_tab-krkn-hub.md" >}}
+  {{< /tab >}}
+  {{< tab header="**Krknctl**" lang="krknctl" >}}
+{{< readfile file="_tab-krknctl.md" >}}
+  {{< /tab >}}
+{{< /tabpane >}}
+
+Example scenario file: [pod-network-chaos.yml](https://github.com/krkn-chaos/krkn/blob/main/scenarios/kube/pod-network-chaos.yml)

--- a/content/en/docs/scenarios/network-chaos-ng-scenarios/pod-network-chaos/_index.md
+++ b/content/en/docs/scenarios/network-chaos-ng-scenarios/pod-network-chaos/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Pod Network Chaos
-description:
+description: "Injects network degradation (latency, packet loss, bandwidth) into a target pod's network interfaces using Linux tc rules."
 date: 2017-01-04
 ---
 Injects network degradation (latency, packet loss, bandwidth restriction) into a target pod's network interfaces using Linux `tc` (traffic control) rules. Unlike pod-network-filter which blocks specific ports via iptables, this module shapes traffic at the interface level.

--- a/content/en/docs/scenarios/network-chaos-ng-scenarios/pod-network-chaos/_tab-krkn-hub.md
+++ b/content/en/docs/scenarios/network-chaos-ng-scenarios/pod-network-chaos/_tab-krkn-hub.md
@@ -1,0 +1,3 @@
+{{% alert title="Not yet supported" color="warning" %}}
+`pod_network_chaos` is not currently available as a krkn-hub container image. Use the Krkn tab to run this scenario directly.
+{{% /alert %}}

--- a/content/en/docs/scenarios/network-chaos-ng-scenarios/pod-network-chaos/_tab-krkn.md
+++ b/content/en/docs/scenarios/network-chaos-ng-scenarios/pod-network-chaos/_tab-krkn.md
@@ -1,0 +1,75 @@
+### Configuration
+
+```yaml
+- id: pod_network_chaos
+  image: "quay.io/krkn-chaos/krkn-network-chaos:latest"
+  wait_duration: 1
+  test_duration: 60
+  label_selector: ""
+  service_account: ""
+  instance_count: 1
+  execution: parallel
+  namespace: default
+  # scenario specific settings
+  target: "<pod_name>"
+  interfaces: []
+  ingress: true
+  egress: true
+  latency: 0s        # supported units: us (microseconds), ms, s
+  loss: 10           # percentage (no % symbol)
+  bandwidth: 1gbit   # supported units: bit, kbit, mbit, gbit, tbit
+  taints: []
+```
+
+For the common module settings please refer to the [documentation](../network-chaos-ng-scenario-api.md#basenetworkchaosconfig-base-module-configuration).
+
+- `latency`: network latency to inject. Format: integer followed by `us` (microseconds), `ms` (milliseconds), or `s` (seconds). Example: `100ms`. Set to empty string to skip.
+- `loss`: packet loss percentage as a plain integer (no `%` symbol). Example: `10` means 10% packet loss. Set to empty string to skip.
+- `bandwidth`: bandwidth limit. Format: integer followed by `bit`, `kbit`, `mbit`, `gbit`, or `tbit`. Example: `100mbit`. Set to empty string to skip.
+- `interfaces`: list of network interface names to target. Leave empty to auto-detect the pod's default interface.
+- `ingress`: apply rules to incoming traffic (default: `true`)
+- `egress`: apply rules to outgoing traffic (default: `true`)
+- `target`: the pod name to target (used when `label_selector` is not set)
+
+### Usage
+
+To enable pod network chaos scenarios edit the kraken config file, go to the section `kraken -> chaos_scenarios` of the yaml structure
+and add a new element to the list named `network_chaos_ng_scenarios` then add the desired scenario
+pointing to the scenario yaml file.
+
+```yaml
+kraken:
+    ...
+    chaos_scenarios:
+        - network_chaos_ng_scenarios:
+            - scenarios/kube/pod-network-chaos.yml
+```
+
+{{% alert title="Note" %}}
+You can specify multiple scenario files of the same type by adding additional paths to the list:
+```yaml
+kraken:
+    chaos_scenarios:
+        - network_chaos_ng_scenarios:
+            - scenarios/kube/pod-network-chaos-1.yml
+            - scenarios/kube/pod-network-chaos-2.yml
+```
+
+You can also combine multiple different scenario types in the same config.yaml file. Scenario types can be specified in any order, and you can include the same scenario type multiple times:
+```yaml
+kraken:
+    chaos_scenarios:
+        - network_chaos_ng_scenarios:
+            - scenarios/kube/pod-network-chaos.yml
+        - pod_disruption_scenarios:
+            - scenarios/pod-kill.yaml
+        - node_scenarios:
+            - scenarios/node-reboot.yaml
+```
+{{% /alert %}}
+
+### Run
+
+```bash
+python run_kraken.py --config config/config.yaml
+```

--- a/content/en/docs/scenarios/network-chaos-ng-scenarios/pod-network-chaos/_tab-krkn.md
+++ b/content/en/docs/scenarios/network-chaos-ng-scenarios/pod-network-chaos/_tab-krkn.md
@@ -15,7 +15,7 @@
   interfaces: []
   ingress: true
   egress: true
-  latency: 0s        # supported units: us (microseconds), ms, s
+  latency: ""         # empty string to skip; or e.g. 100ms (units: us, ms, s)
   loss: 10           # percentage (no % symbol)
   bandwidth: 1gbit   # supported units: bit, kbit, mbit, gbit, tbit
   taints: []

--- a/content/en/docs/scenarios/network-chaos-ng-scenarios/pod-network-chaos/_tab-krknctl.md
+++ b/content/en/docs/scenarios/network-chaos-ng-scenarios/pod-network-chaos/_tab-krknctl.md
@@ -1,0 +1,3 @@
+{{% alert title="Not yet supported" color="warning" %}}
+`pod_network_chaos` is not currently available via krknctl. Use the Krkn tab to run this scenario directly.
+{{% /alert %}}


### PR DESCRIPTION
## Summary

Closes #308 — two Network Chaos NG modules (`pod_network_chaos` and `node_network_chaos`) are implemented in the upstream krkn codebase but have no documentation on the website. This PR adds full documentation pages for both.

## Changes

- **`network-chaos-ng-scenarios/_index.md`**: Added links to the two new scenario pages
- **`pod-network-chaos/`**: New scenario page with full parameter table, YAML config example, usage instructions, and krkn-hub/krknctl tabs
- **`node-network-chaos/`**: New scenario page with full parameter table, YAML config example, usage instructions, and krkn-hub/krknctl tabs

## Verification

All parameters verified against upstream source:
- [`pod_network_chaos` scenario](https://github.com/krkn-chaos/krkn/blob/main/krkn/modules/network/pod_network_chaos.py)
- [`node_network_chaos` scenario](https://github.com/krkn-chaos/krkn/blob/main/krkn/modules/network/node_network_chaos.py)
- Example scenario files: [`pod-network-chaos.yml`](https://github.com/krkn-chaos/krkn/blob/main/scenarios/kube/pod-network-chaos.yml), [`node-network-chaos.yml`](https://github.com/krkn-chaos/krkn/blob/main/scenarios/kube/node-network-chaos.yml)

Follows the existing tabpane/readfile convention used by all other Network Chaos NG scenario pages.