### PR TITLE
feat: add scenarios filter bar

### DIFF
--- a/assets/scss/_custom_docs.scss
+++ b/assets/scss/_custom_docs.scss
@@ -1703,7 +1703,7 @@ table tbody tr:hover {
 // -----------------------------------------------------------------------------
 // Scenario filter (docs/scenarios)
 // -----------------------------------------------------------------------------
-.scenario-filter {
+.krkn-scenario-filter {
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
@@ -1714,18 +1714,18 @@ table tbody tr:hover {
   background: var(--krkn-surface);
 }
 
-.scenario-filter__row {
+.krkn-scenario-filter__row {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
   gap: 0.75rem;
 }
 
-.scenario-filter__row--search {
+.krkn-scenario-filter__row--search {
   gap: 0.5rem;
 }
 
-.scenario-filter__label {
+.krkn-scenario-filter__label {
   font-size: 0.7rem;
   text-transform: uppercase;
   letter-spacing: 0.06em;
@@ -1734,13 +1734,13 @@ table tbody tr:hover {
   min-width: 90px;
 }
 
-.scenario-filter__pills {
+.krkn-scenario-filter__pills {
   display: flex;
   flex-wrap: wrap;
   gap: 0.5rem;
 }
 
-.scenario-filter__btn {
+.krkn-scenario-filter__btn {
   appearance: none;
   border: 1px solid var(--krkn-border-subtle);
   background: var(--krkn-elevated);
@@ -1753,18 +1753,18 @@ table tbody tr:hover {
   transition: color 0.2s ease, background 0.2s ease, border-color 0.2s ease;
 }
 
-.scenario-filter__btn:hover {
+.krkn-scenario-filter__btn:hover {
   background: var(--krkn-nav-hover-bg);
   color: var(--krkn-text);
 }
 
-.scenario-filter__btn--active {
+.krkn-scenario-filter__btn--active {
   background: var(--krkn-secondary-alpha);
   border-color: var(--krkn-secondary);
   color: var(--krkn-text);
 }
 
-.scenario-filter__search {
+.krkn-scenario-filter__search {
   flex: 1 1 240px;
   min-width: 200px;
   padding: 0.45rem 0.75rem;
@@ -1775,17 +1775,17 @@ table tbody tr:hover {
   font-size: 0.9rem;
 }
 
-.scenario-filter__search::placeholder {
+.krkn-scenario-filter__search::placeholder {
   color: var(--krkn-text-subtle);
 }
 
-.scenario-filter__search:focus {
+.krkn-scenario-filter__search:focus {
   outline: none;
   border-color: var(--krkn-secondary);
   box-shadow: 0 0 0 2px var(--krkn-secondary-alpha);
 }
 
-.scenario-filter__reset {
+.krkn-scenario-filter__reset {
   border: 1px solid var(--krkn-border-subtle);
   background: transparent;
   color: var(--krkn-text-muted);
@@ -1797,13 +1797,13 @@ table tbody tr:hover {
   transition: color 0.2s ease, border-color 0.2s ease, background 0.2s ease;
 }
 
-.scenario-filter__reset:hover {
+.krkn-scenario-filter__reset:hover {
   color: var(--krkn-text);
   border-color: var(--krkn-border-prominent);
   background: var(--krkn-elevated);
 }
 
-.scenario-filter__empty {
+.krkn-scenario-filter__empty {
   margin-top: 0.5rem;
   padding: 0.75rem 1rem;
   border: 1px dashed var(--krkn-border-subtle);
@@ -1812,17 +1812,17 @@ table tbody tr:hover {
   font-size: 0.9rem;
 }
 
-.scenario-card--hidden,
-.scenario-category--hidden {
+.krkn-scenario-card--hidden,
+.krkn-scenario-category--hidden {
   display: none !important;
 }
 
 @media (max-width: 640px) {
-  .scenario-filter__label {
+  .krkn-scenario-filter__label {
     min-width: auto;
   }
 
-  .scenario-filter {
+  .krkn-scenario-filter {
     padding: 0.9rem 1rem;
   }
 }

--- a/assets/scss/_custom_docs.scss
+++ b/assets/scss/_custom_docs.scss
@@ -1699,3 +1699,130 @@ table tbody tr:hover {
     background: var(--krkn-surface) !important;
   }
 }
+
+// -----------------------------------------------------------------------------
+// Scenario filter (docs/scenarios)
+// -----------------------------------------------------------------------------
+.scenario-filter {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin: 1.5rem 0 2rem;
+  padding: 1rem 1.25rem;
+  border: 1px solid var(--krkn-border-subtle);
+  border-radius: 0.75rem;
+  background: var(--krkn-surface);
+}
+
+.scenario-filter__row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.scenario-filter__row--search {
+  gap: 0.5rem;
+}
+
+.scenario-filter__label {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--krkn-text-subtle);
+  font-weight: 600;
+  min-width: 90px;
+}
+
+.scenario-filter__pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.scenario-filter__btn {
+  appearance: none;
+  border: 1px solid var(--krkn-border-subtle);
+  background: var(--krkn-elevated);
+  color: var(--krkn-text-muted);
+  border-radius: 9999px;
+  padding: 0.35rem 0.85rem;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: color 0.2s ease, background 0.2s ease, border-color 0.2s ease;
+}
+
+.scenario-filter__btn:hover {
+  background: var(--krkn-nav-hover-bg);
+  color: var(--krkn-text);
+}
+
+.scenario-filter__btn--active {
+  background: var(--krkn-secondary-alpha);
+  border-color: var(--krkn-secondary);
+  color: var(--krkn-text);
+}
+
+.scenario-filter__search {
+  flex: 1 1 240px;
+  min-width: 200px;
+  padding: 0.45rem 0.75rem;
+  border-radius: 0.5rem;
+  border: 1px solid var(--krkn-border-subtle);
+  background: var(--krkn-elevated);
+  color: var(--krkn-text);
+  font-size: 0.9rem;
+}
+
+.scenario-filter__search::placeholder {
+  color: var(--krkn-text-subtle);
+}
+
+.scenario-filter__search:focus {
+  outline: none;
+  border-color: var(--krkn-secondary);
+  box-shadow: 0 0 0 2px var(--krkn-secondary-alpha);
+}
+
+.scenario-filter__reset {
+  border: 1px solid var(--krkn-border-subtle);
+  background: transparent;
+  color: var(--krkn-text-muted);
+  border-radius: 0.5rem;
+  padding: 0.4rem 0.75rem;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: color 0.2s ease, border-color 0.2s ease, background 0.2s ease;
+}
+
+.scenario-filter__reset:hover {
+  color: var(--krkn-text);
+  border-color: var(--krkn-border-prominent);
+  background: var(--krkn-elevated);
+}
+
+.scenario-filter__empty {
+  margin-top: 0.5rem;
+  padding: 0.75rem 1rem;
+  border: 1px dashed var(--krkn-border-subtle);
+  border-radius: 0.5rem;
+  color: var(--krkn-text-muted);
+  font-size: 0.9rem;
+}
+
+.scenario-card--hidden,
+.scenario-category--hidden {
+  display: none !important;
+}
+
+@media (max-width: 640px) {
+  .scenario-filter__label {
+    min-width: auto;
+  }
+
+  .scenario-filter {
+    padding: 0.9rem 1rem;
+  }
+}

--- a/content/en/docs/scenarios/_index.md
+++ b/content/en/docs/scenarios/_index.md
@@ -129,7 +129,29 @@ Many pod scenarios now support the `exclude_label` parameter to protect critical
 }
 </style>
 
-### Pod & Container Disruptions
+<div class="scenario-filter" id="scenario-filter">
+<div class="scenario-filter__row">
+<span class="scenario-filter__label">Category</span>
+<div class="scenario-filter__pills" role="group" aria-label="Filter by category">
+<button class="scenario-filter__btn scenario-filter__btn--active" data-filter="all" type="button" aria-pressed="true">All</button>
+<button class="scenario-filter__btn" data-filter="pod-container" type="button" aria-pressed="false">Pod &amp; Container</button>
+<button class="scenario-filter__btn" data-filter="node-cluster" type="button" aria-pressed="false">Node &amp; Cluster</button>
+<button class="scenario-filter__btn" data-filter="network" type="button" aria-pressed="false">Network</button>
+<button class="scenario-filter__btn" data-filter="application-service" type="button" aria-pressed="false">Application &amp; Service</button>
+<button class="scenario-filter__btn" data-filter="storage-data" type="button" aria-pressed="false">Storage &amp; Data</button>
+<button class="scenario-filter__btn" data-filter="system-time" type="button" aria-pressed="false">System &amp; Time</button>
+</div>
+</div>
+<div class="scenario-filter__row scenario-filter__row--search">
+<label class="scenario-filter__label" for="scenario-filter-search">Search</label>
+<input class="scenario-filter__search" id="scenario-filter-search" type="search" placeholder="Search scenarios..." autocomplete="off" />
+<button class="scenario-filter__reset" id="scenario-filter-reset" type="button">Reset</button>
+</div>
+<div class="scenario-filter__empty" id="scenario-filter-empty" hidden>No scenarios match your filters.</div>
+</div>
+
+<section class="scenario-category" data-category="pod-container">
+<h3 class="category-header">Pod &amp; Container Disruptions</h3>
 
 <div class="scenario-grid">
 
@@ -161,8 +183,10 @@ Many pod scenarios now support the `exclude_label` parameter to protect critical
 </div>
 
 </div>
+</section>
 
-### Node & Cluster Failures
+<section class="scenario-category" data-category="node-cluster">
+<h3 class="category-header">Node &amp; Cluster Failures</h3>
 
 <div class="scenario-grid">
 
@@ -241,8 +265,10 @@ Many pod scenarios now support the `exclude_label` parameter to protect critical
 
 
 </div>
+</section>
 
-### Network Disruptions
+<section class="scenario-category" data-category="network">
+<h3 class="category-header">Network Disruptions</h3>
 
 <div class="scenario-grid">
 
@@ -310,9 +336,11 @@ Many pod scenarios now support the `exclude_label` parameter to protect critical
 </div>
 
 </div>
+</section>
 
 
-### Application & Service Disruptions
+<section class="scenario-category" data-category="application-service">
+<h3 class="category-header">Application &amp; Service Disruptions</h3>
 
 <div class="scenario-grid">
 
@@ -363,8 +391,10 @@ Many pod scenarios now support the `exclude_label` parameter to protect critical
 
 
 </div>
+</section>
 
-### Storage & Data Disruptions
+<section class="scenario-category" data-category="storage-data">
+<h3 class="category-header">Storage &amp; Data Disruptions</h3>
 
 <div class="scenario-grid">
 
@@ -378,8 +408,10 @@ Many pod scenarios now support the `exclude_label` parameter to protect critical
 </div>
 
 </div>
+</section>
 
-### System & Time Disruptions
+<section class="scenario-category" data-category="system-time">
+<h3 class="category-header">System &amp; Time Disruptions</h3>
 
 <div class="scenario-grid">
 
@@ -393,3 +425,6 @@ Many pod scenarios now support the `exclude_label` parameter to protect critical
 </div>
 
 </div>
+</section>
+
+<script src="/js/scenario-filter.js" defer></script>

--- a/content/en/docs/scenarios/_index.md
+++ b/content/en/docs/scenarios/_index.md
@@ -124,33 +124,33 @@ Many pod scenarios now support the `exclude_label` parameter to protect critical
     color: var(--krkn-text);
 }
 
-.category-header:first-of-type {
+.scenario-category:first-of-type .category-header {
     margin-top: 2rem;
 }
 </style>
 
-<div class="scenario-filter" id="scenario-filter">
-<div class="scenario-filter__row">
-<span class="scenario-filter__label">Category</span>
-<div class="scenario-filter__pills" role="group" aria-label="Filter by category">
-<button class="scenario-filter__btn scenario-filter__btn--active" data-filter="all" type="button" aria-pressed="true">All</button>
-<button class="scenario-filter__btn" data-filter="pod-container" type="button" aria-pressed="false">Pod &amp; Container</button>
-<button class="scenario-filter__btn" data-filter="node-cluster" type="button" aria-pressed="false">Node &amp; Cluster</button>
-<button class="scenario-filter__btn" data-filter="network" type="button" aria-pressed="false">Network</button>
-<button class="scenario-filter__btn" data-filter="application-service" type="button" aria-pressed="false">Application &amp; Service</button>
-<button class="scenario-filter__btn" data-filter="storage-data" type="button" aria-pressed="false">Storage &amp; Data</button>
-<button class="scenario-filter__btn" data-filter="system-time" type="button" aria-pressed="false">System &amp; Time</button>
+<div class="krkn-scenario-filter" id="krkn-scenario-filter">
+<div class="krkn-scenario-filter__row">
+<span class="krkn-scenario-filter__label">Category</span>
+<div class="krkn-scenario-filter__pills" role="group" aria-label="Filter by category">
+<button class="krkn-scenario-filter__btn krkn-scenario-filter__btn--active" data-filter="all" type="button" aria-pressed="true">All</button>
+<button class="krkn-scenario-filter__btn" data-filter="pod-container" type="button" aria-pressed="false">Pod &amp; Container</button>
+<button class="krkn-scenario-filter__btn" data-filter="node-cluster" type="button" aria-pressed="false">Node &amp; Cluster</button>
+<button class="krkn-scenario-filter__btn" data-filter="network" type="button" aria-pressed="false">Network</button>
+<button class="krkn-scenario-filter__btn" data-filter="application-service" type="button" aria-pressed="false">Application &amp; Service</button>
+<button class="krkn-scenario-filter__btn" data-filter="storage-data" type="button" aria-pressed="false">Storage &amp; Data</button>
+<button class="krkn-scenario-filter__btn" data-filter="system-time" type="button" aria-pressed="false">System &amp; Time</button>
 </div>
 </div>
-<div class="scenario-filter__row scenario-filter__row--search">
-<label class="scenario-filter__label" for="scenario-filter-search">Search</label>
-<input class="scenario-filter__search" id="scenario-filter-search" type="search" placeholder="Search scenarios..." autocomplete="off" />
-<button class="scenario-filter__reset" id="scenario-filter-reset" type="button">Reset</button>
+<div class="krkn-scenario-filter__row krkn-scenario-filter__row--search">
+<label class="krkn-scenario-filter__label" for="krkn-scenario-filter-search">Search</label>
+<input class="krkn-scenario-filter__search" id="krkn-scenario-filter-search" type="search" placeholder="Search scenarios..." autocomplete="off" />
+<button class="krkn-scenario-filter__reset" id="krkn-scenario-filter-reset" type="button">Reset</button>
 </div>
-<div class="scenario-filter__empty" id="scenario-filter-empty" hidden>No scenarios match your filters.</div>
+<div class="krkn-scenario-filter__empty" id="krkn-scenario-filter-empty" hidden>No scenarios match your filters.</div>
 </div>
 
-<section class="scenario-category" data-category="pod-container">
+<section class="krkn-scenario-category" data-category="pod-container">
 <h3 class="category-header">Pod &amp; Container Disruptions</h3>
 
 <div class="scenario-grid">
@@ -185,7 +185,7 @@ Many pod scenarios now support the `exclude_label` parameter to protect critical
 </div>
 </section>
 
-<section class="scenario-category" data-category="node-cluster">
+<section class="krkn-scenario-category" data-category="node-cluster">
 <h3 class="category-header">Node &amp; Cluster Failures</h3>
 
 <div class="scenario-grid">
@@ -267,7 +267,7 @@ Many pod scenarios now support the `exclude_label` parameter to protect critical
 </div>
 </section>
 
-<section class="scenario-category" data-category="network">
+<section class="krkn-scenario-category" data-category="network">
 <h3 class="category-header">Network Disruptions</h3>
 
 <div class="scenario-grid">
@@ -339,7 +339,7 @@ Many pod scenarios now support the `exclude_label` parameter to protect critical
 </section>
 
 
-<section class="scenario-category" data-category="application-service">
+<section class="krkn-scenario-category" data-category="application-service">
 <h3 class="category-header">Application &amp; Service Disruptions</h3>
 
 <div class="scenario-grid">
@@ -393,7 +393,7 @@ Many pod scenarios now support the `exclude_label` parameter to protect critical
 </div>
 </section>
 
-<section class="scenario-category" data-category="storage-data">
+<section class="krkn-scenario-category" data-category="storage-data">
 <h3 class="category-header">Storage &amp; Data Disruptions</h3>
 
 <div class="scenario-grid">
@@ -410,7 +410,7 @@ Many pod scenarios now support the `exclude_label` parameter to protect critical
 </div>
 </section>
 
-<section class="scenario-category" data-category="system-time">
+<section class="krkn-scenario-category" data-category="system-time">
 <h3 class="category-header">System &amp; Time Disruptions</h3>
 
 <div class="scenario-grid">

--- a/static/js/scenario-filter.js
+++ b/static/js/scenario-filter.js
@@ -6,17 +6,17 @@
   'use strict';
 
   function init() {
-    var filterRoot = document.getElementById('scenario-filter');
+    var filterRoot = document.getElementById('krkn-scenario-filter');
     if (!filterRoot) return;
 
     var categoryButtons = Array.prototype.slice.call(
-      filterRoot.querySelectorAll('.scenario-filter__btn[data-filter]')
+      filterRoot.querySelectorAll('.krkn-scenario-filter__btn[data-filter]')
     );
-    var searchInput = document.getElementById('scenario-filter-search');
-    var resetBtn = document.getElementById('scenario-filter-reset');
-    var emptyState = document.getElementById('scenario-filter-empty');
+    var searchInput = document.getElementById('krkn-scenario-filter-search');
+    var resetBtn = document.getElementById('krkn-scenario-filter-reset');
+    var emptyState = document.getElementById('krkn-scenario-filter-empty');
     var categorySections = Array.prototype.slice.call(
-      document.querySelectorAll('.scenario-category')
+      document.querySelectorAll('.krkn-scenario-category')
     );
 
     if (categoryButtons.length === 0 || categorySections.length === 0) return;
@@ -37,7 +37,7 @@
     function setActiveButton(nextCategory) {
       categoryButtons.forEach(function (btn) {
         var isActive = btn.getAttribute('data-filter') === nextCategory;
-        btn.classList.toggle('scenario-filter__btn--active', isActive);
+        btn.classList.toggle('krkn-scenario-filter__btn--active', isActive);
         btn.setAttribute('aria-pressed', isActive ? 'true' : 'false');
       });
     }
@@ -53,9 +53,9 @@
         );
 
         if (!matchesCategory) {
-          section.classList.add('scenario-category--hidden');
+          section.classList.add('krkn-scenario-category--hidden');
           cards.forEach(function (card) {
-            card.classList.add('scenario-card--hidden');
+            card.classList.add('krkn-scenario-card--hidden');
           });
           return;
         }
@@ -63,14 +63,14 @@
         var sectionVisible = false;
         cards.forEach(function (card) {
           var matchesSearch = cardMatchesSearch(card, searchQuery);
-          card.classList.toggle('scenario-card--hidden', !matchesSearch);
+          card.classList.toggle('krkn-scenario-card--hidden', !matchesSearch);
           if (matchesSearch) {
             sectionVisible = true;
             visibleCount += 1;
           }
         });
 
-        section.classList.toggle('scenario-category--hidden', !sectionVisible);
+        section.classList.toggle('krkn-scenario-category--hidden', !sectionVisible);
       });
 
       if (emptyState) {

--- a/static/js/scenario-filter.js
+++ b/static/js/scenario-filter.js
@@ -1,0 +1,114 @@
+/**
+ * scenario-filter.js — Scenario page category + search filtering
+ * Filters scenario cards based on category pills and search input.
+ */
+(function () {
+  'use strict';
+
+  function init() {
+    var filterRoot = document.getElementById('scenario-filter');
+    if (!filterRoot) return;
+
+    var categoryButtons = Array.prototype.slice.call(
+      filterRoot.querySelectorAll('.scenario-filter__btn[data-filter]')
+    );
+    var searchInput = document.getElementById('scenario-filter-search');
+    var resetBtn = document.getElementById('scenario-filter-reset');
+    var emptyState = document.getElementById('scenario-filter-empty');
+    var categorySections = Array.prototype.slice.call(
+      document.querySelectorAll('.scenario-category')
+    );
+
+    if (categoryButtons.length === 0 || categorySections.length === 0) return;
+
+    var activeCategory = 'all';
+    var searchQuery = '';
+
+    function normalize(text) {
+      return (text || '').toLowerCase();
+    }
+
+    function cardMatchesSearch(card, query) {
+      if (!query) return true;
+      var text = normalize(card.textContent);
+      return text.indexOf(query) !== -1;
+    }
+
+    function setActiveButton(nextCategory) {
+      categoryButtons.forEach(function (btn) {
+        var isActive = btn.getAttribute('data-filter') === nextCategory;
+        btn.classList.toggle('scenario-filter__btn--active', isActive);
+        btn.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+      });
+    }
+
+    function applyFilters() {
+      var visibleCount = 0;
+
+      categorySections.forEach(function (section) {
+        var category = section.getAttribute('data-category');
+        var matchesCategory = activeCategory === 'all' || category === activeCategory;
+        var cards = Array.prototype.slice.call(
+          section.querySelectorAll('.scenario-card')
+        );
+
+        if (!matchesCategory) {
+          section.classList.add('scenario-category--hidden');
+          cards.forEach(function (card) {
+            card.classList.add('scenario-card--hidden');
+          });
+          return;
+        }
+
+        var sectionVisible = false;
+        cards.forEach(function (card) {
+          var matchesSearch = cardMatchesSearch(card, searchQuery);
+          card.classList.toggle('scenario-card--hidden', !matchesSearch);
+          if (matchesSearch) {
+            sectionVisible = true;
+            visibleCount += 1;
+          }
+        });
+
+        section.classList.toggle('scenario-category--hidden', !sectionVisible);
+      });
+
+      if (emptyState) {
+        emptyState.hidden = visibleCount > 0;
+      }
+    }
+
+    categoryButtons.forEach(function (btn) {
+      btn.addEventListener('click', function () {
+        activeCategory = btn.getAttribute('data-filter') || 'all';
+        setActiveButton(activeCategory);
+        applyFilters();
+      });
+    });
+
+    if (searchInput) {
+      searchInput.addEventListener('input', function () {
+        searchQuery = normalize(searchInput.value).trim();
+        applyFilters();
+      });
+    }
+
+    if (resetBtn) {
+      resetBtn.addEventListener('click', function () {
+        activeCategory = 'all';
+        searchQuery = '';
+        if (searchInput) searchInput.value = '';
+        setActiveButton(activeCategory);
+        applyFilters();
+      });
+    }
+
+    applyFilters();
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();


### PR DESCRIPTION
## Description

The scenarios page has 20+ chaos scenarios and no way to filter them.
you just scroll. This PR adds a simple filter bar so users can
actually find what they're looking for.

---

## Changes

**New file:**
- `static/js/scenario-filter.js` — vanilla JS filtering logic

**Modified:**
- `content/en/docs/scenarios/_index.md` — added filter bar + wrapped
  sections in `data-category` attributes
- `assets/scss/_custom_docs.scss` — styling using existing `--krkn-*`
  CSS variables

---

## What it does

- Category pills — Pod & Container, Node & Cluster, Network,
  Application & Service, Storage & Data, System & Time
- Live search — filters cards as you type
- Reset button — clears everything in one click
- Empty state — shows a message when nothing matches
- Accessible — proper aria-pressed and role attributes
- Mobile friendly — responsive at 640px breakpoint
- No external dependencies — pure vanilla JS

If JS is disabled, all scenarios stay visible — no breaking changes.

---

## Testing

- [x] Category filter works independently
- [x] Search works independently
- [x] Both work together (category + search combined)
- [x] Reset clears both filters
- [x] Empty state shows correctly
- [x] Mobile layout looks good
- [x] Hugo builds without errors

---

## Screenshots

### Default view
<img width="958" height="454" alt="image" src="https://github.com/user-attachments/assets/f3461b17-3713-4c7c-a5c3-ed886abdb02d" />


### Category filtered (e.g., Network)
<img width="958" height="454" alt="image" src="https://github.com/user-attachments/assets/a84676ad-ba50-4838-8443-c5897943566e" />


### Search in action
<img width="959" height="452" alt="image" src="https://github.com/user-attachments/assets/25992d4d-412d-4f4c-b37b-dca862c0fc43" />

---

