### PR TITLE
feat(bot): LLM-powered doc sync bot for automated krkn-ai documentation updates

### DIFF
--- a/.github/scripts/doc_sync/doc_sync.py
+++ b/.github/scripts/doc_sync/doc_sync.py
@@ -1,0 +1,210 @@
+"""
+Doc Sync Bot for krkn-chaos/website.
+
+Detects doc-impacting changes in krkn-chaos/krkn-ai merged PRs and creates
+draft PRs on the website repo with LLM-generated documentation updates.
+"""
+import argparse, base64, json, os, subprocess, sys
+from pathlib import Path
+
+import anthropic, requests
+
+UPSTREAM_REPO = "krkn-chaos/krkn-ai"
+WEBSITE_REPO = "krkn-chaos/website"
+DOCS_BASE = "content/en/docs/krkn_ai/config"
+MARKER_TPL = "<!-- doc-sync-bot: upstream-pr={} -->"
+
+# krkn-ai paths -> website docs they affect
+FILE_TO_DOCS = {
+    "krkn_ai/models/config.py": [
+        f"{DOCS_BASE}/scenarios.md", f"{DOCS_BASE}/fitness_function.md",
+        f"{DOCS_BASE}/evolutionary_algorithm.md", f"{DOCS_BASE}/stopping_criteria.md",
+        f"{DOCS_BASE}/elastic_search.md", f"{DOCS_BASE}/health_check.md",
+        f"{DOCS_BASE}/output.md",
+    ],
+    "krkn_ai/cli/": [f"{DOCS_BASE}/scenarios.md"],
+    "README.md": ["content/en/docs/krkn_ai/_index.md"],
+    "docs/": [f"{DOCS_BASE}/"],
+}
+
+
+def gh_api(endpoint, token, method="GET", json_data=None):
+    """GitHub API helper."""
+    r = requests.request(
+        method, f"https://api.github.com{endpoint}",
+        headers={"Authorization": f"token {token}", "Accept": "application/vnd.github.v3+json"},
+        json=json_data, timeout=30,
+    )
+    r.raise_for_status()
+    return r.json() if r.content else None
+
+
+def get_doc_impacting_files(pr_number, token):
+    """Return PR files that match doc-impacting paths."""
+    files = gh_api(f"/repos/{UPSTREAM_REPO}/pulls/{pr_number}/files", token)
+    prefixes = list(FILE_TO_DOCS.keys())
+    return [f for f in files if any(f["filename"].startswith(p) for p in prefixes)]
+
+
+def pr_already_synced(pr_number, token):
+    """Idempotency check: does a doc-sync PR already exist for this upstream PR?"""
+    marker = MARKER_TPL.format(pr_number)
+    for state in ("open", "closed"):
+        prs = gh_api(f"/repos/{WEBSITE_REPO}/pulls?state={state}&per_page=30", token)
+        if any(marker in (pr.get("body") or "") for pr in prs):
+            return True
+    return False
+
+
+def find_recent_merged_prs(token):
+    """Find recently merged krkn-ai PRs touching doc-impacting files."""
+    prs = gh_api(f"/repos/{UPSTREAM_REPO}/pulls?state=closed&sort=updated&per_page=10", token)
+    return [p["number"] for p in prs if p.get("merged_at") and get_doc_impacting_files(p["number"], token)][:5]
+
+
+def get_website_doc(path, token):
+    """Fetch a doc file from the website repo."""
+    try:
+        data = gh_api(f"/repos/{WEBSITE_REPO}/contents/{path}?ref=main", token)
+        return base64.b64decode(data["content"]).decode()
+    except requests.HTTPError:
+        return None
+
+
+def affected_docs(changed_files):
+    """Map changed upstream files to website doc paths."""
+    docs = set()
+    for f in changed_files:
+        for prefix, targets in FILE_TO_DOCS.items():
+            if f["filename"].startswith(prefix):
+                docs.update(t for t in targets if not t.endswith("/"))
+    return list(docs)
+
+
+def generate_update(diff_patch, current_doc, doc_path, client):
+    """Use Claude to generate an updated doc from the diff."""
+    prompt = f"""You are updating documentation for the krkn-chaos project.
+The website uses Hugo/Docsy with markdown files containing YAML frontmatter.
+
+Given the upstream code diff below, update the documentation file to reflect the changes.
+
+Rules:
+- Preserve YAML frontmatter exactly as-is
+- Preserve existing markdown structure and formatting style
+- Only add/modify/remove content directly affected by the diff
+- Keep parameter tables in the same markdown table format
+- If the diff adds a new config field/scenario, add it to the relevant section
+- If the diff removes something, remove it from the doc
+- Return ONLY the complete updated markdown file, no explanation
+
+--- DIFF ---
+{diff_patch}
+
+--- CURRENT DOC ({doc_path}) ---
+{current_doc}"""
+
+    resp = client.messages.create(
+        model="claude-sonnet-4-20250514", max_tokens=4096,
+        messages=[{"role": "user", "content": prompt}],
+    )
+    return resp.content[0].text
+
+
+def create_pr(pr_number, updated_docs, changed_files, token):
+    """Create branch, commit updated docs, and open a draft PR."""
+    branch = f"doc-sync/krkn-ai-pr-{pr_number}"
+    repo_dir = os.environ.get("GITHUB_WORKSPACE", ".")
+    env = {**os.environ, "GIT_AUTHOR_NAME": "doc-sync-bot", "GIT_AUTHOR_EMAIL": "doc-sync-bot@krkn-chaos.dev"}
+
+    subprocess.run(["git", "checkout", "-b", branch], cwd=repo_dir, check=True)
+    for path, content in updated_docs.items():
+        p = Path(repo_dir) / path
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content)
+    subprocess.run(["git", "add", "."], cwd=repo_dir, check=True)
+    subprocess.run(["git", "commit", "-m", f"docs: sync from krkn-ai PR #{pr_number}"], cwd=repo_dir, check=True, env=env)
+    subprocess.run(["git", "push", "origin", branch], cwd=repo_dir, check=True)
+
+    upstream_files = ", ".join(f"`{f['filename']}`" for f in changed_files)
+    website_files = ", ".join(f"`{p}`" for p in updated_docs)
+    body = f"""## Doc Sync: Auto-update from krkn-ai PR #{pr_number}
+
+This PR was automatically generated by the **Doc Sync Bot** to keep website
+documentation in sync with upstream code changes.
+
+**Upstream change:** {UPSTREAM_REPO}#{pr_number}
+**Changed upstream files:** {upstream_files}
+**Updated website docs:** {website_files}
+
+> Please review the generated changes carefully. The bot uses an LLM to
+> interpret code changes and update documentation accordingly.
+
+{MARKER_TPL.format(pr_number)}
+"""
+    data = gh_api(f"/repos/{WEBSITE_REPO}/pulls", token, "POST", {
+        "title": f"docs: sync from krkn-ai PR #{pr_number}",
+        "body": body, "head": branch, "base": "main", "draft": True,
+    })
+    return data["html_url"]
+
+
+def process_pr(pr_number, token):
+    """Process a single upstream PR end-to-end."""
+    print(f"Processing krkn-ai PR #{pr_number}...")
+    if pr_already_synced(pr_number, token):
+        print(f"  Skip: PR already synced"); return
+    changed = get_doc_impacting_files(pr_number, token)
+    if not changed:
+        print(f"  Skip: no doc-impacting files"); return
+    docs = affected_docs(changed)
+    if not docs:
+        print(f"  Skip: no mappable docs"); return
+
+    diff = "\n".join(f"--- {f['filename']} ---\n{f.get('patch', '(binary)')}" for f in changed)
+    api_key = os.environ.get("ANTHROPIC_API_KEY")
+    if not api_key:
+        print("  Error: ANTHROPIC_API_KEY not set"); return
+    client = anthropic.Anthropic(api_key=api_key)
+
+    updated = {}
+    for doc_path in docs:
+        current = get_website_doc(doc_path, token)
+        if not current:
+            print(f"  Warning: cannot fetch {doc_path}"); continue
+        try:
+            result = generate_update(diff, current, doc_path, client)
+            if result and result.strip() != current.strip():
+                updated[doc_path] = result
+                print(f"  Updated: {doc_path}")
+        except Exception as e:
+            print(f"  Error on {doc_path}: {e}"); continue
+
+    if not updated:
+        print("  No updates generated"); return
+    url = create_pr(pr_number, updated, changed, token)
+    print(f"  Draft PR created: {url}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Doc Sync Bot for krkn-chaos")
+    parser.add_argument("--upstream-pr", type=int, help="Specific krkn-ai PR number")
+    args = parser.parse_args()
+
+    token = os.environ.get("GITHUB_TOKEN")
+    if not token:
+        print("Error: GITHUB_TOKEN not set"); sys.exit(1)
+
+    pr_number = args.upstream_pr or (int(v) if (v := os.environ.get("UPSTREAM_PR", "").strip()) else None)
+    if pr_number:
+        process_pr(pr_number, token); return
+
+    print("Polling for recent merged PRs...")
+    for num in find_recent_merged_prs(token):
+        try:
+            process_pr(num, token)
+        except Exception as e:
+            print(f"  Error on PR #{num}: {e}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/doc_sync/doc_sync.py
+++ b/.github/scripts/doc_sync/doc_sync.py
@@ -1,69 +1,116 @@
-"""
-Doc Sync Bot for krkn-chaos/website.
-
-Detects doc-impacting changes in krkn-chaos/krkn-ai merged PRs and creates
-draft PRs on the website repo with LLM-generated documentation updates.
-"""
-import argparse, base64, json, os, subprocess, sys
+"""Doc Sync Bot: creates website PRs from upstream krkn-chaos doc-impacting changes."""
+import argparse
+import base64
+import glob
+import os
+import subprocess
+import sys
 from pathlib import Path
 
-import anthropic, requests
+import anthropic
+import requests
 
-UPSTREAM_REPO = "krkn-chaos/krkn-ai"
 WEBSITE_REPO = "krkn-chaos/website"
 DOCS_BASE = "content/en/docs/krkn_ai/config"
-MARKER_TPL = "<!-- doc-sync-bot: upstream-pr={} -->"
+MARKER_TPL = "<!-- doc-sync-bot: upstream-pr={repo}#{number} -->"
+ALLOWED_PREFIX = "content/en/docs/"
 
-# krkn-ai paths -> website docs they affect
-FILE_TO_DOCS = {
-    "krkn_ai/models/config.py": [
-        f"{DOCS_BASE}/scenarios.md", f"{DOCS_BASE}/fitness_function.md",
-        f"{DOCS_BASE}/evolutionary_algorithm.md", f"{DOCS_BASE}/stopping_criteria.md",
-        f"{DOCS_BASE}/elastic_search.md", f"{DOCS_BASE}/health_check.md",
-        f"{DOCS_BASE}/output.md",
-    ],
-    "krkn_ai/cli/": [f"{DOCS_BASE}/scenarios.md"],
-    "README.md": ["content/en/docs/krkn_ai/_index.md"],
-    "docs/": [f"{DOCS_BASE}/"],
+UPSTREAM_REPOS = {
+    "krkn-chaos/krkn-ai": {
+        "krkn_ai/models/config.py": [
+            f"{DOCS_BASE}/scenarios.md",
+            f"{DOCS_BASE}/fitness_function.md",
+            f"{DOCS_BASE}/evolutionary_algorithm.md",
+            f"{DOCS_BASE}/stopping_criteria.md",
+            f"{DOCS_BASE}/elastic_search.md",
+            f"{DOCS_BASE}/health_check.md",
+            f"{DOCS_BASE}/output.md",
+        ],
+        "krkn_ai/cli/": [f"{DOCS_BASE}/scenarios.md"],
+        "krkn_ai/scenarios/": [f"{DOCS_BASE}/scenarios.md"],
+        "README.md": ["content/en/docs/krkn_ai/_index.md"],
+        "docs/": [f"{DOCS_BASE}/"],
+    },
+    # TODO Phase 2: add krkn, krkn-hub, krknctl mappings
 }
 
 
 def gh_api(endpoint, token, method="GET", json_data=None):
     """GitHub API helper."""
     r = requests.request(
-        method, f"https://api.github.com{endpoint}",
+        method,
+        f"https://api.github.com{endpoint}",
         headers={"Authorization": f"token {token}", "Accept": "application/vnd.github.v3+json"},
-        json=json_data, timeout=30,
+        json=json_data,
+        timeout=30,
     )
     r.raise_for_status()
     return r.json() if r.content else None
 
 
-def get_doc_impacting_files(pr_number, token):
+def gh_paginated(endpoint, token, per_page=100):
+    """Paginated GitHub API helper."""
+    items, page = [], 1
+    while True:
+        sep = "&" if "?" in endpoint else "?"
+        data = gh_api(f"{endpoint}{sep}per_page={per_page}&page={page}", token)
+        if not data:
+            break
+        items.extend(data)
+        if len(data) < per_page:
+            break
+        page += 1
+    return items
+
+
+def safe_path(path):
+    """Validate path is within allowed doc directories."""
+    n = os.path.normpath(path)
+    return ".." not in n and not n.startswith("/") and n.startswith(ALLOWED_PREFIX)
+
+
+def expand_targets(targets):
+    """Expand directory targets (ending with /) to actual .md files."""
+    workspace = os.environ.get("GITHUB_WORKSPACE", ".")
+    out = []
+    for t in targets:
+        if t.endswith("/"):
+            out.extend(
+                os.path.relpath(f, workspace)
+                for f in glob.glob(os.path.join(workspace, t, "*.md"))
+            )
+        else:
+            out.append(t)
+    return out
+
+
+def get_impacting_files(repo, pr_number, mapping, token):
     """Return PR files that match doc-impacting paths."""
-    files = gh_api(f"/repos/{UPSTREAM_REPO}/pulls/{pr_number}/files", token)
-    prefixes = list(FILE_TO_DOCS.keys())
+    files = gh_paginated(f"/repos/{repo}/pulls/{pr_number}/files", token)
+    prefixes = list(mapping.keys())
     return [f for f in files if any(f["filename"].startswith(p) for p in prefixes)]
 
 
-def pr_already_synced(pr_number, token):
-    """Idempotency check: does a doc-sync PR already exist for this upstream PR?"""
-    marker = MARKER_TPL.format(pr_number)
-    for state in ("open", "closed"):
-        prs = gh_api(f"/repos/{WEBSITE_REPO}/pulls?state={state}&per_page=30", token)
-        if any(marker in (pr.get("body") or "") for pr in prs):
-            return True
-    return False
+def pr_already_synced(repo, pr_number, token):
+    """Idempotency check via GitHub Search API."""
+    marker = MARKER_TPL.format(repo=repo, number=pr_number)
+    q = f"repo:{WEBSITE_REPO} is:pr \"{marker}\" in:body"
+    data = gh_api(f"/search/issues?q={requests.utils.quote(q)}", token)
+    return data.get("total_count", 0) > 0
 
 
-def find_recent_merged_prs(token):
-    """Find recently merged krkn-ai PRs touching doc-impacting files."""
-    prs = gh_api(f"/repos/{UPSTREAM_REPO}/pulls?state=closed&sort=updated&per_page=10", token)
-    return [p["number"] for p in prs if p.get("merged_at") and get_doc_impacting_files(p["number"], token)][:5]
+def find_recent_merged(repo, mapping, token):
+    """Find recently merged PRs touching doc-impacting files."""
+    prs = gh_api(f"/repos/{repo}/pulls?state=closed&sort=updated&per_page=10", token)
+    return [
+        p["number"]
+        for p in prs
+        if p.get("merged_at") and get_impacting_files(repo, p["number"], mapping, token)
+    ][:5]
 
 
 def get_website_doc(path, token):
-    """Fetch a doc file from the website repo."""
+    """Fetch a doc file from the website repo main branch."""
     try:
         data = gh_api(f"/repos/{WEBSITE_REPO}/contents/{path}?ref=main", token)
         return base64.b64decode(data["content"]).decode()
@@ -71,14 +118,14 @@ def get_website_doc(path, token):
         return None
 
 
-def affected_docs(changed_files):
+def affected_docs(changed_files, mapping):
     """Map changed upstream files to website doc paths."""
     docs = set()
     for f in changed_files:
-        for prefix, targets in FILE_TO_DOCS.items():
+        for prefix, targets in mapping.items():
             if f["filename"].startswith(prefix):
-                docs.update(t for t in targets if not t.endswith("/"))
-    return list(docs)
+                docs.update(expand_targets(targets))
+    return [d for d in docs if safe_path(d)]
 
 
 def generate_update(diff_patch, current_doc, doc_path, client):
@@ -86,124 +133,156 @@ def generate_update(diff_patch, current_doc, doc_path, client):
     prompt = f"""You are updating documentation for the krkn-chaos project.
 The website uses Hugo/Docsy with markdown files containing YAML frontmatter.
 
-Given the upstream code diff below, update the documentation file to reflect the changes.
+Given the upstream code diff, update the documentation file accurately.
 
-Rules:
-- Preserve YAML frontmatter exactly as-is
-- Preserve existing markdown structure and formatting style
-- Only add/modify/remove content directly affected by the diff
-- Keep parameter tables in the same markdown table format
-- If the diff adds a new config field/scenario, add it to the relevant section
-- If the diff removes something, remove it from the doc
-- Return ONLY the complete updated markdown file, no explanation
+STRICT RULES:
+1. Preserve the YAML frontmatter block (between --- markers) EXACTLY as-is
+2. Preserve existing structure, heading hierarchy, and formatting
+3. Only add/modify/remove content DIRECTLY affected by the diff
+4. Keep parameter tables in the same markdown table format
+5. Do NOT add sections, warnings, or notes not supported by the diff
+6. Do NOT change wording in sections unrelated to the diff
+7. Return ONLY the complete updated markdown file, nothing else
 
---- DIFF ---
+--- UPSTREAM CODE DIFF ---
 {diff_patch}
 
 --- CURRENT DOC ({doc_path}) ---
 {current_doc}"""
-
     resp = client.messages.create(
-        model="claude-sonnet-4-20250514", max_tokens=4096,
+        model="claude-sonnet-4-20250514",
+        max_tokens=4096,
         messages=[{"role": "user", "content": prompt}],
     )
     return resp.content[0].text
 
 
-def create_pr(pr_number, updated_docs, changed_files, token):
+def create_pr(repo, pr_number, updated_docs, changed_files, token, dry_run=False):
     """Create branch, commit updated docs, and open a draft PR."""
-    branch = f"doc-sync/krkn-ai-pr-{pr_number}"
-    repo_dir = os.environ.get("GITHUB_WORKSPACE", ".")
-    env = {**os.environ, "GIT_AUTHOR_NAME": "doc-sync-bot", "GIT_AUTHOR_EMAIL": "doc-sync-bot@krkn-chaos.dev"}
+    repo_short = repo.split("/")[-1]
+    branch = f"doc-sync/{repo_short}-pr-{pr_number}"
+    workspace = os.environ.get("GITHUB_WORKSPACE", ".")
 
-    subprocess.run(["git", "checkout", "-b", branch], cwd=repo_dir, check=True)
+    if dry_run:
+        for path, content in updated_docs.items():
+            print(f"  [dry-run] {path} ({len(content)} bytes)")
+        return "(dry-run)"
+
+    subprocess.run(["git", "checkout", "-b", branch], cwd=workspace, check=True)
     for path, content in updated_docs.items():
-        p = Path(repo_dir) / path
+        if not safe_path(path):
+            print(f"  SECURITY: rejected path: {path}")
+            continue
+        p = Path(workspace) / path
         p.parent.mkdir(parents=True, exist_ok=True)
         p.write_text(content)
-    subprocess.run(["git", "add", "."], cwd=repo_dir, check=True)
-    subprocess.run(["git", "commit", "-m", f"docs: sync from krkn-ai PR #{pr_number}"], cwd=repo_dir, check=True, env=env)
-    subprocess.run(["git", "push", "origin", branch], cwd=repo_dir, check=True)
+    subprocess.run(["git", "add", "."], cwd=workspace, check=True)
+    subprocess.run(
+        ["git", "commit", "-m", f"docs: sync from {repo_short} PR #{pr_number}"],
+        cwd=workspace,
+        check=True,
+    )
+    subprocess.run(["git", "push", "origin", branch], cwd=workspace, check=True)
 
+    marker = MARKER_TPL.format(repo=repo, number=pr_number)
     upstream_files = ", ".join(f"`{f['filename']}`" for f in changed_files)
     website_files = ", ".join(f"`{p}`" for p in updated_docs)
-    body = f"""## Doc Sync: Auto-update from krkn-ai PR #{pr_number}
-
-This PR was automatically generated by the **Doc Sync Bot** to keep website
-documentation in sync with upstream code changes.
-
-**Upstream change:** {UPSTREAM_REPO}#{pr_number}
-**Changed upstream files:** {upstream_files}
-**Updated website docs:** {website_files}
-
-> Please review the generated changes carefully. The bot uses an LLM to
-> interpret code changes and update documentation accordingly.
-
-{MARKER_TPL.format(pr_number)}
-"""
-    data = gh_api(f"/repos/{WEBSITE_REPO}/pulls", token, "POST", {
-        "title": f"docs: sync from krkn-ai PR #{pr_number}",
-        "body": body, "head": branch, "base": "main", "draft": True,
-    })
+    body = (
+        f"## Doc Sync: Auto-update from {repo_short} PR #{pr_number}\n\n"
+        f"**Upstream:** {repo}#{pr_number}\n"
+        f"**Changed:** {upstream_files}\n"
+        f"**Updated:** {website_files}\n\n"
+        f"> Review carefully. Generated by LLM from code diff.\n\n{marker}\n"
+    )
+    data = gh_api(
+        f"/repos/{WEBSITE_REPO}/pulls",
+        token,
+        "POST",
+        {"title": f"docs: sync from {repo_short} PR #{pr_number}", "body": body, "head": branch, "base": "main", "draft": True},
+    )
     return data["html_url"]
 
 
-def process_pr(pr_number, token):
+def process_pr(repo, pr_number, mapping, token, dry_run=False):
     """Process a single upstream PR end-to-end."""
-    print(f"Processing krkn-ai PR #{pr_number}...")
-    if pr_already_synced(pr_number, token):
-        print(f"  Skip: PR already synced"); return
-    changed = get_doc_impacting_files(pr_number, token)
+    print(f"Processing {repo} PR #{pr_number}...")
+    if pr_already_synced(repo, pr_number, token):
+        print("  Skip: already synced")
+        return
+    changed = get_impacting_files(repo, pr_number, mapping, token)
     if not changed:
-        print(f"  Skip: no doc-impacting files"); return
-    docs = affected_docs(changed)
+        print("  Skip: no doc-impacting files")
+        return
+    docs = affected_docs(changed, mapping)
     if not docs:
-        print(f"  Skip: no mappable docs"); return
+        print("  Skip: no mappable docs")
+        return
 
     diff = "\n".join(f"--- {f['filename']} ---\n{f.get('patch', '(binary)')}" for f in changed)
     api_key = os.environ.get("ANTHROPIC_API_KEY")
     if not api_key:
-        print("  Error: ANTHROPIC_API_KEY not set"); return
+        print("ERROR: ANTHROPIC_API_KEY not set")
+        sys.exit(1)
     client = anthropic.Anthropic(api_key=api_key)
 
     updated = {}
     for doc_path in docs:
-        current = get_website_doc(doc_path, token)
+        current = get_website_doc(doc_path, token) if not dry_run else f"(would fetch {doc_path})"
         if not current:
-            print(f"  Warning: cannot fetch {doc_path}"); continue
+            print(f"  Warning: cannot fetch {doc_path}")
+            continue
+        if dry_run:
+            updated[doc_path] = "(dry-run content)"
+            continue
         try:
             result = generate_update(diff, current, doc_path, client)
             if result and result.strip() != current.strip():
                 updated[doc_path] = result
                 print(f"  Updated: {doc_path}")
         except Exception as e:
-            print(f"  Error on {doc_path}: {e}"); continue
+            print(f"  Error on {doc_path}: {e}")
+            continue
 
     if not updated:
-        print("  No updates generated"); return
-    url = create_pr(pr_number, updated, changed, token)
-    print(f"  Draft PR created: {url}")
+        print("  No updates generated")
+        return
+    url = create_pr(repo, pr_number, updated, changed, token, dry_run=dry_run)
+    print(f"  PR: {url}")
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Doc Sync Bot for krkn-chaos")
-    parser.add_argument("--upstream-pr", type=int, help="Specific krkn-ai PR number")
+    parser = argparse.ArgumentParser(description="Doc Sync Bot")
+    parser.add_argument("--upstream-pr", help="repo:number or just number (defaults to krkn-ai)")
+    parser.add_argument("--dry-run", action="store_true", help="No PRs created, print actions only")
     args = parser.parse_args()
 
     token = os.environ.get("GITHUB_TOKEN")
     if not token:
-        print("Error: GITHUB_TOKEN not set"); sys.exit(1)
+        print("ERROR: GITHUB_TOKEN not set")
+        sys.exit(1)
 
-    pr_number = args.upstream_pr or (int(v) if (v := os.environ.get("UPSTREAM_PR", "").strip()) else None)
-    if pr_number:
-        process_pr(pr_number, token); return
+    pr_input = args.upstream_pr or os.environ.get("UPSTREAM_PR", "").strip()
+    if pr_input:
+        if ":" in pr_input:
+            repo_short, num_str = pr_input.split(":", 1)
+            repo = f"krkn-chaos/{repo_short}"
+        else:
+            repo, num_str = "krkn-chaos/krkn-ai", pr_input
+        mapping = UPSTREAM_REPOS.get(repo)
+        if not mapping:
+            print(f"ERROR: no mapping for {repo}")
+            sys.exit(1)
+        process_pr(repo, int(num_str), mapping, token, dry_run=args.dry_run)
+        return
 
-    print("Polling for recent merged PRs...")
-    for num in find_recent_merged_prs(token):
-        try:
-            process_pr(num, token)
-        except Exception as e:
-            print(f"  Error on PR #{num}: {e}")
+    print("Polling upstream repos for recent merged PRs...")
+    for repo, mapping in UPSTREAM_REPOS.items():
+        print(f"  Checking {repo}...")
+        for num in find_recent_merged(repo, mapping, token):
+            try:
+                process_pr(repo, num, mapping, token, dry_run=args.dry_run)
+            except Exception as e:
+                print(f"  Error on {repo}#{num}: {e}")
 
 
 if __name__ == "__main__":

--- a/.github/scripts/doc_sync/requirements.txt
+++ b/.github/scripts/doc_sync/requirements.txt
@@ -1,0 +1,2 @@
+anthropic>=0.25.0
+requests>=2.31.0

--- a/.github/scripts/doc_sync/requirements.txt
+++ b/.github/scripts/doc_sync/requirements.txt
@@ -1,2 +1,2 @@
-anthropic>=0.25.0
-requests>=2.31.0
+anthropic==0.101.0
+requests==2.32.5

--- a/.github/workflows/doc-sync.yml
+++ b/.github/workflows/doc-sync.yml
@@ -1,0 +1,59 @@
+# Doc Sync Bot - Automated documentation sync from krkn-ai changes
+#
+# This workflow lives in the website repo and polls krkn-ai for merged PRs
+# that touch documentation-impacting files. It uses an LLM (Claude) to
+# generate updated documentation and opens a draft PR for review.
+#
+# In production, this could alternatively be triggered via repository_dispatch
+# from a workflow in krkn-ai that fires on merge to main. The polling approach
+# is used here to keep the PoC self-contained in one repo.
+#
+# Required secrets:
+#   - ANTHROPIC_API_KEY: API key for Claude (doc generation)
+#   - GITHUB_TOKEN: automatically provided, needs contents:write + pull-requests:write
+
+name: Doc Sync Bot
+
+on:
+  workflow_dispatch:
+    inputs:
+      upstream_pr:
+        description: 'krkn-ai PR number to sync docs for (leave empty for auto-detect)'
+        required: false
+        type: string
+  schedule:
+    - cron: '0 */6 * * *'  # Every 6 hours, check for new merged PRs
+
+jobs:
+  doc-sync:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout website repo
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: pip install -r .github/scripts/doc_sync/requirements.txt
+
+      - name: Configure git
+        run: |
+          git config user.name "doc-sync-bot"
+          git config user.email "doc-sync-bot@krkn-chaos.dev"
+
+      - name: Run doc sync
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          UPSTREAM_PR: ${{ inputs.upstream_pr || '' }}
+        run: python .github/scripts/doc_sync/doc_sync.py

--- a/.github/workflows/doc-sync.yml
+++ b/.github/workflows/doc-sync.yml
@@ -1,16 +1,13 @@
-# Doc Sync Bot - Automated documentation sync from krkn-ai changes
+# Doc Sync Bot - Automated documentation sync from upstream krkn-chaos changes
 #
-# This workflow lives in the website repo and polls krkn-ai for merged PRs
-# that touch documentation-impacting files. It uses an LLM (Claude) to
-# generate updated documentation and opens a draft PR for review.
-#
-# In production, this could alternatively be triggered via repository_dispatch
-# from a workflow in krkn-ai that fires on merge to main. The polling approach
-# is used here to keep the PoC self-contained in one repo.
+# Polls upstream repos for merged PRs that touch documentation-impacting files.
+# Uses an LLM (Claude) to generate updated docs and opens a draft PR for review.
 #
 # Required secrets:
 #   - ANTHROPIC_API_KEY: API key for Claude (doc generation)
 #   - GITHUB_TOKEN: automatically provided, needs contents:write + pull-requests:write
+#
+# TODO: Add issue_comment trigger for comment-driven refinement workflow (Phase 2)
 
 name: Doc Sync Bot
 
@@ -18,11 +15,15 @@ on:
   workflow_dispatch:
     inputs:
       upstream_pr:
-        description: 'krkn-ai PR number to sync docs for (leave empty for auto-detect)'
+        description: 'Upstream PR number to sync (format: repo:number, e.g. krkn-ai:42)'
         required: false
         type: string
   schedule:
-    - cron: '0 */6 * * *'  # Every 6 hours, check for new merged PRs
+    - cron: '0 */6 * * *'
+
+concurrency:
+  group: doc-sync-bot
+  cancel-in-progress: false
 
 jobs:
   doc-sync:
@@ -33,13 +34,13 @@ jobs:
 
     steps:
       - name: Checkout website repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.11'
 


### PR DESCRIPTION
## Summary

Proof-of-concept implementation for #320: an automated documentation sync bot that keeps the website in sync with upstream `krkn-ai` code changes using LLM-powered content generation.

## Architecture

```
┌─────────────────────────────────────────────────────────────┐
│  Trigger: schedule (every 6h) or workflow_dispatch           │
└──────────────────────────┬──────────────────────────────────┘
                           │
                           ▼
┌─────────────────────────────────────────────────────────────┐
│  1. DETECT: Poll krkn-ai for merged PRs touching            │
│     doc-impacting paths (models/config.py, cli/, docs/)     │
└──────────────────────────┬──────────────────────────────────┘
                           │
                           ▼
┌─────────────────────────────────────────────────────────────┐
│  2. MAP: Determine which website docs are affected          │
│     (scenarios.md, fitness_function.md, etc.)               │
└──────────────────────────┬──────────────────────────────────┘
                           │
                           ▼
┌─────────────────────────────────────────────────────────────┐
│  3. GENERATE: Claude API analyzes the diff + current doc    │
│     and produces updated Hugo/Docsy markdown                │
└──────────────────────────┬──────────────────────────────────┘
                           │
                           ▼
┌─────────────────────────────────────────────────────────────┐
│  4. PR: Open a draft PR with changes, linking upstream PR   │
└─────────────────────────────────────────────────────────────┘
```

## How It Works

1. **Trigger**: Runs on a 6-hour schedule or manually via `workflow_dispatch` with a specific PR number
2. **Detection**: Queries GitHub API for recently merged krkn-ai PRs, filters for files that impact documentation (config models, CLI commands, README, docs/)
3. **Mapping**: Uses a declarative file-to-doc mapping to determine which website pages need updating
4. **Generation**: Sends the PR diff + current doc content to Claude with a structured prompt that preserves Hugo frontmatter and existing formatting conventions
5. **Idempotency**: Searches existing PRs for an HTML comment marker (`<!-- doc-sync-bot: upstream-pr=N -->`) to avoid duplicates
6. **Output**: Creates a draft PR with a clear body linking the upstream change, listing affected files, and flagging it for human review

## Key Design Decisions

- **Self-contained in website repo**: The bot polls krkn-ai rather than requiring a workflow in krkn-ai, making it deployable without upstream write access
- **LLM for content generation**: Rather than brittle regex/template approaches, Claude understands the semantic meaning of code changes and generates contextually appropriate documentation updates
- **Draft PRs only**: All generated content requires human review before merge
- **Graceful failure**: If the LLM API fails or produces no meaningful changes, the workflow exits cleanly without failing

## Files Added

| File | Purpose |
|------|---------|
| `.github/workflows/doc-sync.yml` | GitHub Actions workflow (trigger + orchestration) |
| `.github/scripts/doc_sync/doc_sync.py` | Core bot logic (detection, mapping, generation, PR creation) |
| `.github/scripts/doc_sync/requirements.txt` | Python dependencies (anthropic, requests) |

## Required Secrets

| Secret | Purpose |
|--------|---------|
| `ANTHROPIC_API_KEY` | Claude API access for doc generation |
| `GITHUB_TOKEN` | Provided automatically; needs `contents:write` + `pull-requests:write` |

## Path to Full Implementation

This PoC demonstrates the core concept. For production:
- Add `repository_dispatch` trigger from krkn-ai (fires on merge to main)
- Extend file-to-doc mapping to cover all krkn-chaos repos (krkn, krkn-hub, krknctl)
- Add support for tabbed scenario pages (`_tab-krkn.md`, `_tab-krkn-hub.md`, `_tab-krknctl.md`)
- Add PR comment interaction (refine generated docs via review comments)
- Add caching to avoid redundant LLM calls for unchanged docs
- Consider using a fine-tuned model or RAG with existing docs for higher accuracy

## Testing

Can be tested manually via `workflow_dispatch` with any merged krkn-ai PR number (e.g., a recent PR that modified `krkn_ai/models/config.py`).

Closes #320