### PR TITLE
scroll-margin -> fix: Minor scroll-margin adjustment for anchor navigation

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -223,6 +223,7 @@ h6,
 .h6 {
   color: var(--krkn-text) !important;
   font-family: 'Satoshi', sans-serif;
+  scroll-margin-top: 6.5rem;
 }
 
 // Force body text colors in Docsy containers


### PR DESCRIPTION
## Description
Noticed a small navigational annoyance while testing: clicking anchor links in the table of contents causes the sticky header to cover section titles.

**Changes:** 
Made a quick, 1-line SCSS adjustment to inject scroll-margin-top on headings. Just a minor cleanup to keep headers visible during viewport scrolling.