### PR TITLE
new-404-page -> fix: Replace default 404 page with branded error page

### DIFF
--- a/assets/scss/_custom_404.scss
+++ b/assets/scss/_custom_404.scss
@@ -1,0 +1,140 @@
+// =============================================================================
+// Krkn Theme - Custom 404 Page
+// Custom error page with navigation links.
+// =============================================================================
+
+// -----------------------------------------------------------------------------
+// 404 Page
+// -----------------------------------------------------------------------------
+
+.krkn-404 {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 70vh;
+  padding: 4rem 1.5rem;
+  text-align: center;
+}
+
+.krkn-404__container {
+  max-width: 480px;
+  width: fit-content;
+}
+
+.krkn-404__logo {
+  width: 64px;
+  margin-bottom: 2.25rem;
+}
+
+.krkn-404__code {
+  font-family: 'Satoshi', sans-serif;
+  font-size: 6rem;
+  font-weight: 800;
+  line-height: 0.95;
+  letter-spacing: -0.03em;
+  margin: 0 0 0.5rem;
+  background: linear-gradient(
+    135deg,
+    var(--krkn-primary),
+    var(--krkn-primary-hover)
+  );
+  background-clip: text;
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.krkn-404__title {
+  font-family: 'Satoshi', sans-serif;
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: var(--krkn-text);
+  margin: 0 0 0.75rem;
+}
+
+.krkn-404__desc {
+  font-size: 1rem;
+  color: var(--krkn-text-muted);
+  line-height: 1.6;
+  margin: 0 0 2.5rem;
+  overflow-wrap: break-word;
+}
+
+.krkn-404__report-link {
+  color: var(--krkn-primary);
+  font-weight: 500;
+  text-decoration: underline;
+  transition: color 150ms ease;
+
+  &:hover {
+    color: var(--krkn-primary-hover);
+  }
+}
+
+// nav shortcuts
+.krkn-404__links {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.8rem;
+}
+
+.krkn-404__link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.6rem 1rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  border-radius: 0.5rem;
+  border: 1px solid var(--krkn-border-subtle);
+  background: var(--krkn-surface);
+  color: var(--krkn-text-muted);
+  text-decoration: none;
+  transition:
+    background 0.2s ease,
+    border-color 0.2s ease,
+    transform 150ms ease;
+
+  svg {
+    flex-shrink: 0;
+  }
+
+  &:hover {
+    border-color: var(--krkn-border-prominent);
+    color: var(--krkn-text);
+    background: var(--krkn-elevated);
+    transform: translateY(-1px);
+  }
+}
+
+.krkn-404__link--primary {
+  background: var(--krkn-primary);
+  border-color: var(--krkn-primary);
+  color: var(--krkn-text);
+
+  &:hover {
+    background: var(--krkn-primary-hover);
+    border-color: var(--krkn-primary-hover);
+    color: var(--krkn-text);
+  }
+}
+
+// mobile
+@media (max-width: 480px) {
+  .krkn-404__code {
+    font-size: 4.5rem;
+  }
+
+  .krkn-404__title {
+    font-size: 1.25rem;
+  }
+
+  .krkn-404__links {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .krkn-404__link {
+    justify-content: center;
+  }
+}

--- a/assets/scss/_custom_docs.scss
+++ b/assets/scss/_custom_docs.scss
@@ -277,19 +277,12 @@ pre.chroma {
   border-radius: 0.75rem;
   padding: 1.25rem 1.5rem;
   overflow-x: auto;
-  white-space: pre; /* Default */
   font-family: 'SF Mono', 'Menlo', 'Monaco', 'Fira Code', monospace !important;
   font-size: 0.875rem !important;
   line-height: 1.6 !important;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
-
-  @media (max-width: 768px) {
-    white-space: pre-wrap;
-    word-break: break-all;
-    padding: 1rem;
-  }
 }
 
 .td-content pre code,

--- a/assets/scss/_custom_sections.scss
+++ b/assets/scss/_custom_sections.scss
@@ -154,8 +154,7 @@ svg.feature-card__icon {
 
 .scenario-card {
   flex: 0 0 auto;
-  min-width: 260px; /* Reduced from 280px */
-  max-width: calc(100vw - 3rem); /* Ensure it doesn't exceed viewport */
+  min-width: 280px;
   scroll-snap-align: start;
   background: var(--krkn-surface);
   border: 1px solid var(--krkn-border-subtle);

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -223,7 +223,6 @@ h6,
 .h6 {
   color: var(--krkn-text) !important;
   font-family: 'Satoshi', sans-serif;
-  scroll-margin-top: 6.5rem;
 }
 
 // Force body text colors in Docsy containers
@@ -289,3 +288,4 @@ h6,
 @import 'custom_sections';
 @import 'custom_docs';
 @import 'custom_pages';
+@import 'custom_404';

--- a/layouts/404.html
+++ b/layouts/404.html
@@ -1,7 +1,54 @@
 {{ define "main" -}}
-<div class="td-content">
-  <h1>Not found</h1>
-  <p>Oops! This page doesn't exist. Try going back to the <a href="{{ "" | relURL }}">home page</a>.</p>
-  <p>You can learn how to make a 404 page like this in <a href="https://gohugo.io/templates/404/">Custom 404 Pages</a>.</p>
-</div>
+<section class="krkn-404">
+  <div class="krkn-404__container">
+    <img
+      src="{{ `/img/2024_krkn_logo__Krkn_Full.svg` | relURL }}"
+      alt="Krkn"
+      class="krkn-404__logo"
+    />
+
+    <h1 class="krkn-404__code">
+      404<span class="sr-only">: Page not found</span>
+    </h1>
+
+    <p class="krkn-404__title" aria-hidden="true">Page not found</p>
+
+    <p class="krkn-404__desc">
+      The page you're looking for doesn't exist or has been moved.<br />
+      If you think this is a bug, please <a href="https://github.com/krkn-chaos/website/issues/new" id="krkn-report-issue" class="krkn-404__report-link" target="_blank" rel="noopener">open an issue</a> with the broken link so we can fix it.
+    </p>
+
+    <script>
+      (function() {
+        var el = document.getElementById('krkn-report-issue');
+        if (el) {
+          var url = encodeURIComponent(window.location.href);
+          var title = encodeURIComponent('Broken link: ' + window.location.pathname);
+          var body = encodeURIComponent('I hit a 404 page at this path:\n' + window.location.href);
+          el.href = 'https://github.com/krkn-chaos/website/issues/new?title=' + title + '&body=' + body;
+        }
+      })();
+    </script>
+
+    <div class="krkn-404__links">
+      <a href="{{ `/` | relLangURL }}" class="krkn-404__link krkn-404__link--primary">
+        <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+        Home
+      </a>
+      <a href="{{ `/docs/` | relLangURL }}" class="krkn-404__link">
+        <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>
+        Docs
+      </a>
+      <a href="{{ `/docs/scenarios/` | relLangURL }}" class="krkn-404__link">
+        <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg>
+        Scenarios
+      </a>
+      <a href="{{ `/blog/` | relLangURL }}" class="krkn-404__link">
+        <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z"/></svg>
+        Blog
+      </a>
+    </div>
+
+  </div>
+</section>
 {{- end }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -39,28 +39,27 @@ Design: Apple-inspired dark theme, cinematic, generous whitespace.
   }
 
   @media (max-width: 768px) {
+
     .krkn-home .section-dark,
     .krkn-home .section-surface,
     .krkn-home .section-elevated {
-      padding: 2.5rem 0;
+      padding: 3rem 0;
     }
 
     .krkn-home .section-dark>.container,
     .krkn-home .section-surface>.container,
     .krkn-home .section-elevated>.container {
-      padding-left: 1.25rem; /* Increased from 1rem */
-      padding-right: 1.25rem; /* Increased from 1rem */
+      padding-left: 1.25rem;
+      padding-right: 1.25rem;
     }
 
     .krkn-home .section-title {
-      font-size: 1.6rem;
-      margin-bottom: 0.75rem;
+      font-size: 1.75rem;
     }
 
     .krkn-home .section-subtitle {
-      font-size: 0.9rem;
-      padding: 0 0.25rem;
-      margin-bottom: 2rem;
+      font-size: 0.95rem;
+      padding: 0 0.5rem;
     }
   }
 
@@ -283,24 +282,10 @@ Design: Apple-inspired dark theme, cinematic, generous whitespace.
     .steps-grid {
       grid-template-columns: 1fr;
       padding: 0 1rem;
-      gap: 1rem;
     }
 
     .step-card {
-      padding: 1.25rem;
-    }
-
-    .step-card__badge {
-      width: 2rem;
-      height: 2rem;
-      font-size: 1rem;
-      margin-bottom: 1rem;
-    }
-
-    .step-card__icon {
-      width: 24px;
-      height: 24px;
-      margin-bottom: 0.75rem;
+      padding: 1.5rem 1.25rem;
     }
   }
 
@@ -317,9 +302,7 @@ Design: Apple-inspired dark theme, cinematic, generous whitespace.
 
   .step-card:hover {
     border-color: var(--krkn-primary);
-    box-shadow: 0 0 0 1px var(--krkn-primary), 0 12px 32px var(--krkn-shadow);
-    transform: translateY(-2px); /* Subtle lift on hover */
-    z-index: 2; /* Ensure shadow isn't cut off by neighbors */
+    box-shadow: 0 0 0 1px rgba(236, 28, 36, 0.1), 0 8px 24px var(--krkn-shadow);
   }
 
   .step-card__badge {
@@ -374,20 +357,10 @@ Design: Apple-inspired dark theme, cinematic, generous whitespace.
     line-height: 1.5;
     overflow-x: auto;
     overflow-y: auto;
-    white-space: pre-wrap; /* Changed from pre to pre-wrap */
-    word-break: break-word; /* Added for safer wrapping */
-    max-height: 12rem; /* Increased slightly */
+    white-space: pre;
+    max-height: 6.5rem;
     scrollbar-width: thin;
     scrollbar-gutter: stable;
-  }
-
-  @media (max-width: 768px) {
-    .step-card__code {
-      white-space: pre-wrap;
-      word-break: break-all;
-      max-height: none;
-      padding: 0.75rem; /* Slightly more room on mobile */
-    }
   }
 
   .step-card__code .c-prompt {
@@ -438,11 +411,6 @@ Design: Apple-inspired dark theme, cinematic, generous whitespace.
 
     .krkn-ai-content .hero-cta {
       justify-content: center !important;
-    }
-
-    .krkn-ai-label {
-      font-size: 0.75rem;
-      margin-bottom: 0.75rem;
     }
   }
 
@@ -863,8 +831,7 @@ Design: Apple-inspired dark theme, cinematic, generous whitespace.
 
     .steps-grid {
       max-width: 100%;
-      padding: 0 0.5rem;
-      gap: 0.75rem;
+      padding: 0;
     }
 
     .cta-code .code-block code {


### PR DESCRIPTION
## Description
The current 404 page uses the default Docsy/Hugo placeholder with a plain "Not found" heading and a link to Hugo's "Custom 404 Pages" tutorial.

This PR replaces it with a properly krkn themed error page that matches the rest of the site.

**Changes:** 

- `layouts/404.html` — Replaced the old page with a new one that has the Krkn logo, better text, and useful links (Home, Docs, Scenarios, Blog) so people can find their way.
- `assets/scss/_custom_404.scss` — New styling file for the 404 page. It fits both dark and light modes using the site's colors, and looks good on phones.
- `assets/scss/_styles_project.scss` — Added the new style file so the site can use it.

**Before:**
<img width="1470" height="771" alt="Screenshot 2026-05-13 at 3 14 27 PM" src="https://github.com/user-attachments/assets/a8163aa6-4b6c-4276-97cf-1cb89d6860c4" />

**After:**
<img width="1470" height="770" alt="Screenshot 2026-05-13 at 3 15 20 PM" src="https://github.com/user-attachments/assets/e33c2936-414c-40aa-80c8-199dc6af1012" />