### PR TITLE
docs: add rollback scenario page [krkn-hub/rollback]

### DIFF
--- a/content/en/docs/scenarios/_index.md
+++ b/content/en/docs/scenarios/_index.md
@@ -419,6 +419,21 @@ Many pod scenarios now support the `exclude_label` parameter to protect critical
 </div>
 </section>
 
+### Cluster Utilities
+
+<div class="scenario-grid">
+
+<div class="scenario-card">
+<h3><a href="rollback/">Rollback</a></h3>
+<span class="scenario-badge">rollback</span>
+<p class="scenario-description">Rolls back the side effects of a previous krkn chaos run using its run UUID</p>
+<div class="cloud-badges">
+<span class="cloud-badge cloud-badge--agnostic">Cloud Agnostic</span>
+</div>
+</div>
+
+</div>
+
 <section class="scenario-category" data-category="system-time">
 <h3 class="category-header">System &amp; Time Disruptions</h3>
 

--- a/content/en/docs/scenarios/rollback/_index.md
+++ b/content/en/docs/scenarios/rollback/_index.md
@@ -1,0 +1,24 @@
+---
+title: Rollback
+description: Roll back the side effects of a previous krkn chaos run
+date: 2024-01-01
+weight: 10
+---
+
+The rollback scenario undoes the side effects left behind by a previous krkn chaos run. Given the UUID of a completed run, it restores the cluster to the state it was in before that run executed.
+
+This is useful when a chaos experiment leaves the cluster in an unclean state, or when you need to quickly recover after testing without waiting for natural recovery.
+
+## How to Run
+
+{{< tabpane text=true >}}
+  {{< tab header="**Krkn**" lang="krkn" >}}
+{{< readfile file="_tab-krkn.md" >}}
+  {{< /tab >}}
+  {{< tab header="**Krkn-hub**" lang="krkn-hub" >}}
+{{< readfile file="_tab-krkn-hub.md" >}}
+  {{< /tab >}}
+  {{< tab header="**Krknctl**" lang="krknctl" >}}
+{{< readfile file="_tab-krknctl.md" >}}
+  {{< /tab >}}
+{{< /tabpane >}}

--- a/content/en/docs/scenarios/rollback/_tab-krkn-hub.md
+++ b/content/en/docs/scenarios/rollback/_tab-krkn-hub.md
@@ -1,0 +1,72 @@
+Rolls back the chaos injected by a previous krkn run identified by the provided run UUID.
+
+#### Run
+
+If enabling [Cerberus](/docs/cerberus/) to monitor the cluster and pass/fail the scenario post chaos, refer [docs](/docs/cerberus/). Make sure to start it before injecting the chaos and set `CERBERUS_ENABLED` environment variable for the chaos injection container to autoconnect.
+
+```bash
+export RUN_UUID=<uuid-of-the-krkn-run>
+$ podman run \
+  --name=<container_name> \
+  --net=host \
+  --pull=always \
+  --env-host=true \
+  -v <path-to-kube-config>:/home/krkn/.kube/config:Z \
+  -d containers.krkn-chaos.dev/krkn-chaos/krkn-hub:rollback
+$ podman logs -f <container_name or container_id> # Streams Kraken logs
+$ podman inspect <container-name or container-id> \
+  --format "{{.State.ExitCode}}" # Outputs exit code which can considered as pass/fail for the scenario
+```
+
+{{% alert title="Note" %}} --env-host: This option is not available with the remote Podman client, including Mac and Windows (excluding WSL2) machines.
+Without the --env-host option you will have to set each environment variable on the podman command line like `-e <VARIABLE>=<value>`
+{{% /alert %}}
+
+```bash
+$ docker run $(./get_docker_params.sh) \
+  --name=<container_name> \
+  --net=host \
+  --pull=always \
+  -e RUN_UUID=<uuid-of-the-krkn-run> \
+  -v <path-to-kube-config>:/home/krkn/.kube/config:Z \
+  -d containers.krkn-chaos.dev/krkn-chaos/krkn-hub:rollback
+$ docker logs -f <container_name or container_id> # Streams Kraken logs
+$ docker inspect <container-name or container-id> \
+  --format "{{.State.ExitCode}}" # Outputs exit code which can considered as pass/fail for the scenario
+```
+
+{{% alert title="Tip" %}}
+Because the container runs with a non-root user, ensure the kube config is globally readable before mounting it in the container. You can achieve this with the following commands:
+
+```bash
+kubectl config view --flatten > ~/kubeconfig && chmod 444 ~/kubeconfig
+docker run $(./get_docker_params.sh) \
+  --name=<container_name> \
+  --net=host \
+  --pull=always \
+  -e RUN_UUID=<uuid-of-the-krkn-run> \
+  -v ~/kubeconfig:/home/krkn/.kube/config:Z \
+  -d containers.krkn-chaos.dev/krkn-chaos/krkn-hub:rollback
+```
+{{% /alert %}}
+
+#### Supported parameters
+
+The following environment variables can be set on the host running the container to configure the rollback:
+
+Example if --env-host is used:
+```bash
+export <parameter_name>=<value>
+```
+
+OR on the command line:
+
+```bash
+-e <VARIABLE>=<value>
+```
+
+Parameter | Description | Type | Default
+--------- | ----------- | ---- | -------
+RUN_UUID | UUID of the krkn run to roll back. The container exits if this is not set. | string | ""
+
+{{% alert title="Note" %}} In case of using custom metrics profile or alerts profile when `CAPTURE_METRICS` or `ENABLE_ALERTS` is enabled, mount the metrics profile from the host on which the container is run using podman/docker under `/home/krkn/kraken/config/metrics-aggregated.yaml` and `/home/krkn/kraken/config/alerts`.{{% /alert %}}

--- a/content/en/docs/scenarios/rollback/_tab-krkn.md
+++ b/content/en/docs/scenarios/rollback/_tab-krkn.md
@@ -1,0 +1,28 @@
+### Configuration Options
+
+Add the following to your `config/config.yaml` to enable auto rollback:
+
+**auto_rollback:** When set to `True`, krkn will automatically roll back changes made by a scenario if it fails.
+
+**rollback_versions_directory:** Directory to store rollback version files. Leave empty to use a secure temporary directory.
+
+```yaml
+kraken:
+    kubeconfig_path: ~/.kube/config
+    auto_rollback: True
+    rollback_versions_directory:           # leave empty to use a secure temp directory
+```
+
+### Run
+
+List available rollback versions:
+
+```bash
+python run_kraken.py list-rollback
+```
+
+Execute rollback for a specific run:
+
+```bash
+python run_kraken.py execute-rollback --run-uuid <uuid-of-the-krkn-run>
+```

--- a/content/en/docs/scenarios/rollback/_tab-krknctl.md
+++ b/content/en/docs/scenarios/rollback/_tab-krknctl.md
@@ -1,0 +1,16 @@
+```bash
+krknctl run rollback [--<parameter> <value>]
+```
+
+Can also set any global variable listed [here](../all-scenario-env-krknctl.md)
+
+
+Scenario specific parameters:
+| Parameter | Description | Type | Required | Default |
+| --------- | ----------- | ---- | :------: | ------- |
+`--run-uuid` | Krkn Run UUID that needs to be rolled back | string | Yes | |
+
+To see all available scenario options
+```bash
+krknctl run rollback --help
+```

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1311,6 +1311,20 @@ $ krknctl run pod-scenarios --kubeconfig ~/.kube/config
           </ul>
         </div>
 
+        <!-- Cluster Utilities -->
+        <div class="scenario-category reveal" data-delay="400">
+          <div class="scenario-category__header">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+              stroke-width="1.5">
+              <path d="M3 12h18M3 6h18M3 18h18" />
+            </svg>
+            <h3>Cluster Utilities</h3>
+          </div>
+          <ul class="scenario-category__list">
+            <li><a href="/docs/scenarios/rollback/">Rollback</a></li>
+          </ul>
+        </div>
+
       </div>
 
       <div style="text-align:center;margin-top:2.5rem" class="reveal" data-delay="350">


### PR DESCRIPTION
## Documentation Update
**Related Feature:** [krkn-chaos/krkn-hub#323](https://github.com/krkn-chaos/krkn-hub/pull/323)

**Changes:** 

The rollback scenario was added to krkn-hub back in May but the website never got a corresponding docs page for it. Anyone looking up rollback on [krkn-chaos.dev](https://krkn-chaos.dev) would find nothing, even though the container is built and published.

This PR adds the missing scenario page under `content/en/docs/scenarios/rollback/` with the krkn-hub tab covering run commands and the `RUN_UUID` parameter, and the krknctl tab derived from the existing `krknctl-input.json`.

It also adds a new Cluster Utilities category to the scenarios landing page and the homepage so rollback shows up in navigation alongside the other scenarios.

Closed my previous [PR](https://github.com/krkn-chaos/website/pull/406) because of some issue in my fork. 

But added the points raised by the bot, Thanks!