### PR TITLE
docs(network-chaos-ng): add documentation for vmi_network_chaos scenario

### DIFF
--- a/content/en/docs/scenarios/network-chaos-ng-scenarios/_index.md
+++ b/content/en/docs/scenarios/network-chaos-ng-scenarios/_index.md
@@ -15,3 +15,4 @@ This scenario introduce a new infrastructure to refactor and port the current im
 - [Node Interface Down](/docs/scenarios/network-chaos-ng-scenarios/node-interface-down/_index.md)
 - [Pod Network Chaos](/docs/scenarios/network-chaos-ng-scenarios/pod-network-chaos/_index.md)
 - [Node Network Chaos](/docs/scenarios/network-chaos-ng-scenarios/node-network-chaos/_index.md)
+- [VMI Network Chaos](/docs/scenarios/network-chaos-ng-scenarios/vmi-network-chaos/_index.md)

--- a/content/en/docs/scenarios/network-chaos-ng-scenarios/vmi-network-chaos/_index.md
+++ b/content/en/docs/scenarios/network-chaos-ng-scenarios/vmi-network-chaos/_index.md
@@ -1,0 +1,25 @@
+---
+title: VMI Network Chaos
+description: "Injects network degradation (latency, packet loss, bandwidth) into KubeVirt VMI tap interfaces using Linux tc rules inside the virt-launcher network namespace."
+date: 2017-01-04
+weight: 6
+---
+Injects network degradation (latency, packet loss, bandwidth restriction) into KubeVirt Virtual Machine Instance (VMI) network interfaces. The scenario deploys a privileged pod on the VMI's node, enters the virt-launcher network namespace via `nsenter`, and applies Linux `tc` (traffic control) rules to the VMI's tap interface. Traffic shaping targets the tap device directly rather than the underlying bridge interface, isolating the impact to the VMI without affecting OVN or host-level network control traffic.
+
+## How to Run VMI Network Chaos Scenarios
+
+Choose your preferred method to run VMI network chaos scenarios:
+
+{{< tabpane text=true >}}
+  {{< tab header="**Krkn**" lang="krkn" >}}
+{{< readfile file="_tab-krkn.md" >}}
+  {{< /tab >}}
+  {{< tab header="**Krkn-hub**" lang="krkn-hub" >}}
+{{< readfile file="_tab-krkn-hub.md" >}}
+  {{< /tab >}}
+  {{< tab header="**Krknctl**" lang="krknctl" >}}
+{{< readfile file="_tab-krknctl.md" >}}
+  {{< /tab >}}
+{{< /tabpane >}}
+
+Example scenario file: [virt_network_chaos.yaml](https://github.com/krkn-chaos/krkn/blob/main/scenarios/openshift/virt_network_chaos.yaml)

--- a/content/en/docs/scenarios/network-chaos-ng-scenarios/vmi-network-chaos/_tab-krkn-hub.md
+++ b/content/en/docs/scenarios/network-chaos-ng-scenarios/vmi-network-chaos/_tab-krkn-hub.md
@@ -1,0 +1,3 @@
+{{% alert title="Not yet supported" color="warning" %}}
+`vmi_network_chaos` is not currently available as a krkn-hub container image. Use the Krkn tab to run this scenario directly.
+{{% /alert %}}

--- a/content/en/docs/scenarios/network-chaos-ng-scenarios/vmi-network-chaos/_tab-krkn.md
+++ b/content/en/docs/scenarios/network-chaos-ng-scenarios/vmi-network-chaos/_tab-krkn.md
@@ -1,0 +1,81 @@
+### Configuration
+
+```yaml
+- id: vmi_network_chaos
+  image: "quay.io/krkn-chaos/krkn-network-chaos:latest"
+  wait_duration: 300
+  test_duration: 120
+  label_selector: ""
+  service_account: ""
+  taints: []
+  namespace: "default"
+  instance_count: 1
+  execution: serial
+  # scenario specific settings
+  target: ".*"        # regex matching VMI names in the specified namespace
+  interfaces: []      # leave empty to auto-detect the tap interface
+  ingress: true
+  egress: true
+  latency: "100ms"    # empty string to skip; or e.g. 100ms (units: us, ms, s)
+  loss: 10            # percentage (no % symbol)
+  bandwidth: "100mbit" # supported units: bit, kbit, mbit, gbit, tbit
+```
+
+For the common module settings please refer to the [documentation](../network-chaos-ng-scenario-api.md#basenetworkchaosconfig-base-module-configuration).
+
+- `namespace`: **required** — the Kubernetes namespace where the target VMIs are running. Unlike other network chaos modules, this field cannot be empty.
+- `target`: regex pattern matching VMI names within the specified namespace. Defaults to `.*` (all VMIs in the namespace).
+- `latency`: network latency to inject. Format: integer followed by `us` (microseconds), `ms` (milliseconds), or `s` (seconds). Example: `100ms`. Set to empty string to skip.
+- `loss`: packet loss percentage as a plain integer (no `%` symbol). Example: `10` means 10% packet loss. Set to empty string to skip.
+- `bandwidth`: bandwidth limit. Format: integer followed by `bit`, `kbit`, `mbit`, `gbit`, or `tbit`. Example: `100mbit`. Set to empty string to skip.
+- `interfaces`: list of tap interface names to target inside the virt-launcher network namespace. Leave empty to auto-detect the VMI's tap interface.
+- `ingress`: apply rules to incoming traffic (default: `true`)
+- `egress`: apply rules to outgoing traffic (default: `true`)
+- `execution`: `serial` (default for VMI scenarios) or `parallel`. Use `serial` when targeting multiple VMIs to avoid resource contention on shared nodes.
+
+### Usage
+
+To enable VMI network chaos scenarios edit the kraken config file, go to the section `kraken -> chaos_scenarios` of the yaml structure
+and add a new element to the list named `network_chaos_ng_scenarios` then add the desired scenario
+pointing to the scenario yaml file.
+
+```yaml
+kraken:
+    ...
+    chaos_scenarios:
+        - network_chaos_ng_scenarios:
+            - scenarios/openshift/virt_network_chaos.yaml
+```
+
+{{% alert title="Note" %}}
+You can specify multiple scenario files of the same type by adding additional paths to the list:
+```yaml
+kraken:
+    chaos_scenarios:
+        - network_chaos_ng_scenarios:
+            - scenarios/openshift/virt_network_chaos-1.yaml
+            - scenarios/openshift/virt_network_chaos-2.yaml
+```
+
+You can also combine multiple different scenario types in the same config.yaml file. Scenario types can be specified in any order, and you can include the same scenario type multiple times:
+```yaml
+kraken:
+    chaos_scenarios:
+        - network_chaos_ng_scenarios:
+            - scenarios/openshift/virt_network_chaos.yaml
+        - pod_disruption_scenarios:
+            - scenarios/pod-kill.yaml
+        - node_scenarios:
+            - scenarios/node-reboot.yaml
+```
+{{% /alert %}}
+
+{{% alert title="Warning" color="warning" %}}
+The VMI must be in `Running` phase and its `virt-launcher` pod must have an active `compute` container before the scenario runs. The scenario will abort if the VMI is not schedulable or if the compute container is not ready.
+{{% /alert %}}
+
+### Run
+
+```bash
+python run_kraken.py --config config/config.yaml
+```

--- a/content/en/docs/scenarios/network-chaos-ng-scenarios/vmi-network-chaos/_tab-krknctl.md
+++ b/content/en/docs/scenarios/network-chaos-ng-scenarios/vmi-network-chaos/_tab-krknctl.md
@@ -1,0 +1,3 @@
+{{% alert title="Not yet supported" color="warning" %}}
+`vmi_network_chaos` is not currently available via krknctl. Use the Krkn tab to run this scenario directly.
+{{% /alert %}}


### PR DESCRIPTION
## Description

Adds documentation for the `vmi_network_chaos` scenario module introduced in [krkn#1260](https://github.com/krkn-chaos/krkn/pull/1260). The module was registered in the factory and fully implemented but had no corresponding docs page.

Closes krkn-chaos/website#411

## Changes

- Added `content/en/docs/scenarios/network-chaos-ng-scenarios/vmi-network-chaos/_index.md` with scenario description
- Added `_tab-krkn.md` covering configuration parameters and usage
- Added `_tab-krkn-hub.md` and `_tab-krknctl.md` with unsupported notices (consistent with pod-network-chaos and node-network-chaos)
- Updated `network-chaos-ng-scenarios/_index.md` to list VMI Network Chaos under Available Scenarios

## Documentation Needed

- [ ] Documentation needed