### PR TITLE
docs(network-chaos-ng): add missing weight field to scenario page frontmatter

### DIFF
--- a/content/en/docs/scenarios/network-chaos-ng-scenarios/node-interface-down/_index.md
+++ b/content/en/docs/scenarios/network-chaos-ng-scenarios/node-interface-down/_index.md
@@ -2,6 +2,7 @@
 title: Node Interface Down
 description:
 date: 2017-01-04
+weight: 2
 ---
 Brings one or more network interfaces down on a target node for a configurable duration, then restores them. Can be used to simulate network partitions, NIC failures, or loss of connectivity at the node level.
 

--- a/content/en/docs/scenarios/network-chaos-ng-scenarios/node-network-chaos/_index.md
+++ b/content/en/docs/scenarios/network-chaos-ng-scenarios/node-network-chaos/_index.md
@@ -2,6 +2,7 @@
 title: Node Network Chaos
 description: "Injects network degradation (latency, packet loss, bandwidth) into a target node's network interfaces using Linux tc rules."
 date: 2017-01-04
+weight: 2
 ---
 Injects network degradation (latency, packet loss, bandwidth restriction) into a target node's network interfaces using Linux `tc` (traffic control) rules. Unlike node-network-filter which blocks specific ports via iptables, this module shapes traffic at the interface level. Includes safety checks for existing `tc` rules on the node.
 

--- a/content/en/docs/scenarios/network-chaos-ng-scenarios/node-network-filter/_index.md
+++ b/content/en/docs/scenarios/network-chaos-ng-scenarios/node-network-filter/_index.md
@@ -2,6 +2,7 @@
 title: Node Network Filter
 description:
 date: 2017-01-04
+weight: 2
 ---
 <krkn-hub-scenario id="node-network-filter">
 Creates iptables rules on one or more nodes to block incoming and outgoing traffic on a port in the node network interface. Can be used to block network based services connected to the node or to block inter-node communication.

--- a/content/en/docs/scenarios/network-chaos-ng-scenarios/pod-network-chaos/_index.md
+++ b/content/en/docs/scenarios/network-chaos-ng-scenarios/pod-network-chaos/_index.md
@@ -2,6 +2,7 @@
 title: Pod Network Chaos
 description: "Injects network degradation (latency, packet loss, bandwidth) into a target pod's network interfaces using Linux tc rules."
 date: 2017-01-04
+weight: 2
 ---
 Injects network degradation (latency, packet loss, bandwidth restriction) into a target pod's network interfaces using Linux `tc` (traffic control) rules. Unlike pod-network-filter which blocks specific ports via iptables, this module shapes traffic at the interface level.
 

--- a/content/en/docs/scenarios/network-chaos-ng-scenarios/pod-network-filter/_index.md
+++ b/content/en/docs/scenarios/network-chaos-ng-scenarios/pod-network-filter/_index.md
@@ -2,6 +2,7 @@
 title: Pod Network Filter
 description:
 date: 2017-01-04
+weight: 2
 ---
 <krkn-hub-scenario id="pod-network-filter">
 Creates iptables rules on one or more pods to block incoming and outgoing traffic on a port in the pod network interface. Can be used to block network based services connected to the pod or to block inter-pod communication.


### PR DESCRIPTION
Five network-chaos-ng scenario pages (node-interface-down, node-network-chaos, node-network-filter, pod-network-chaos, pod-network-filter) were missing the `weight` frontmatter field required by Hugo for deterministic sidebar ordering.

Without this field Hugo falls back to date-based sorting, which can cause these pages to appear in an unpredictable order relative to other scenario sections. All five pages now carry `weight: 2`, consistent with the existing pattern used across equivalent sub-pages in the hog-scenarios section.

This same issue was identified and flagged by the automated reviewer on PR #412.

Fixes #413

## Documentation Update

**Related Feature:** `docs/fix-network-chaos-ng-missing-weight`

**Changes:** Added `weight: 2` to the frontmatter of five network-chaos-ng scenario pages (`node-interface-down`, `node-network-chaos`, `node-network-filter`, `pod-network-chaos`, `pod-network-filter`). No content was modified — this is a frontmatter-only fix to restore correct Hugo sidebar ordering.
