### PR TITLE
fix: replace broken basic-run link in Metrics Validation journey

### DIFF
--- a/content/en/docs/getting-started/user-journeys/metrics-validation.md
+++ b/content/en/docs/getting-started/user-journeys/metrics-validation.md
@@ -12,7 +12,7 @@ This journey is well suited to CI/CD pipelines where you cannot watch the cluste
 
 ## What you need
 
-- Everything from [Basic Run](../basic-run/)
+- Everything from the [Getting Started guide](../../) (install krknctl, create a test workload, and run a first scenario)
 - A Prometheus instance accessible from where Krkn runs (auto-detected on OpenShift; set via scenario flags on Kubernetes) — need to set one up? See [installing Prometheus on a kind cluster](../../developers-guide/testing-changes.md#prometheus)
 - krknctl installed
 


### PR DESCRIPTION
## Summary

Fixes a broken internal link left after #335 was closed.

`content/en/docs/getting-started/user-journeys/metrics-validation.md` had:

```md
- Everything from [Basic Run](../basic-run/)
```

`../basic-run/` resolves to `/docs/getting-started/user-journeys/basic-run/` — a page that does not exist. The Basic Run content lives in the Getting Started `_index.md` (the maintainers intentionally keep it combined there, per the #335 close comment).

**Fix:** Point the prerequisite link directly to the Getting Started guide:

```md
- Everything from the [Getting Started guide](../../) (install krknctl, create a test workload, and run a first scenario)
```

`../../` from `user-journeys/metrics-validation.md` resolves correctly to `/docs/getting-started/`.

Made with [Cursor](https://cursor.com)