### PR TITLE
docs(krkn-ai): add runner restriction notice to container Run Mode section

### DIFF
--- a/content/en/docs/krkn_ai/container.md
+++ b/content/en/docs/krkn_ai/container.md
@@ -58,6 +58,10 @@ podman run --rm \
 
 Executes Krkn-AI tests based on a configuration file.
 
+{{% alert title="Note" %}}
+The container image only supports the `krknhub` runner type. The `krknctl` runner is not supported due to limitations around mounting the Podman socket inside a container.
+{{% /alert %}}
+
 **Usage:**
 
 ```bash
@@ -85,8 +89,6 @@ podman run --rm \
 
 
 ## Podman Considerations
-
-Container version only supports krknhub runner type at the moment due to limitations around mounting podman socket.
 
 ### Run without `--privileged` flag
 


### PR DESCRIPTION
The Run Mode section had no mention that the container image only supports the `krknhub` runner type. Users following the instructions directly had no indication of this constraint until their run failed.

Added a Hugo alert block above the Run Mode usage example to make the restriction visible before the user runs the command. The note was previously only present as a plain-text line in the separate Podman Considerations section.

Fixes #416

## Documentation Update

**Related Feature:** `docs/krkn-ai-container-runner-notice`

**Changes:** Added a `{{% alert %}}` block to the Run Mode section of `content/en/docs/krkn_ai/container.md` noting that only the `krknhub` runner type is supported in container mode.
