### PR TITLE
(docs) remove leftover documentation boilerplate from krkn.md"

### DIFF
--- a/content/en/docs/installation/krkn.md
+++ b/content/en/docs/installation/krkn.md
@@ -51,7 +51,6 @@ $ source chaos/bin/activate
 $ pip install -r requirements.txt
 ```
 {{% alert title="Note" %}} Make sure python3-devel and latest pip versions are installed on the system. The dependencies install has been tested with pip >= 21.1.3 versions.{{% /alert %}}
-Where can your user find your project code? How can they install it (binaries, installable package, build from source)? Are there multiple options/versions they can install and how should they choose the right one for them?
 
 ### Getting Started with Krkn
 If you are wanting to try to edit your configuration files and scenarios see [getting started](../getting-started/getting-started-krkn.md) doc 


### PR DESCRIPTION
## Documentation Update

**Related Feature:**
N/A
**Issue Number**
#420 
**Changes:**

* Removed leftover placeholder/template text from `content/en/docs/installation/krkn.md`.
* The removed text appeared to be documentation-author guidance that was unintentionally visible on the published website.
* This improves documentation clarity and professionalism for end users.
