### PR TITLE
docs: fix incorrect docker verification command in krknctl docs

### DIFF
--- a/content/en/docs/installation/krknctl.md
+++ b/content/en/docs/installation/krknctl.md
@@ -111,7 +111,7 @@ If both Podman and Docker are installed be sure that the docker compatibility is
 ### Docker:
 #### Linux:
 Check that the user has been added to the `docker` group and can correctly connect to the Docker unix socket  
-running the command `podman ps` if an error is returned  run the command `sudo usermod -aG docker $USER`
+running the command `docker ps` if an error is returned  run the command `sudo usermod -aG docker $USER`
 
 
 ### What's next?


### PR DESCRIPTION
## Documentation Update
**Related Feature:** 
fix-docker-command
#425 
**Changes:** 

Fixed an incorrect Docker installation verification command in:
website/content/en/docs/installation/krknctl.md
Replaced the incorrect command:
podman ps
with the correct command:
docker ps
Why this is relevant:
The installation documentation is the first thing new users follow when setting up krkn. Having podman ps as the verification step in the Docker installation guide causes confusion because:

Incorrect tooling — podman and docker are different container runtimes. A user following the Docker setup would not have Podman installed.
Setup failure — New users would think their Docker installation failed when the command returns an error, even if Docker is correctly installed.
Trust in docs — Incorrect commands in installation guides reduce confidence in the documentation overall.

This is a single-line, non-breaking fix limited to one file with zero impact on any code or functionality.
