### PR TITLE
docs: fix markdown syntax highlighting for yaml templates

### DIFF
--- a/content/en/docs/getting-started/getting-started-krkn.md
+++ b/content/en/docs/getting-started/getting-started-krkn.md
@@ -84,7 +84,7 @@ node_scenarios:
 ### Templates
 #### Pod Scenario Yaml Template
 For example, for adding a pod level scenario for a new application, refer to the sample scenario below to know what fields are necessary and what to add in each location:
-```bash
+```yaml
 # yaml-language-server: $schema=../plugin.schema.json
 - id: kill-pods
   config:
@@ -96,7 +96,7 @@ For example, for adding a pod level scenario for a new application, refer to the
 
 #### Node Scenario Yaml Template
 
-```bash
+```yaml
 node_scenarios:
   - actions:  # Node chaos scenarios to be injected.
     - <chaos scenario>
@@ -110,7 +110,7 @@ node_scenarios:
 
 
 #### Time Chaos Scenario Template
-```bash
+```yaml
 time_scenarios:
   - action: 'skew_time' or 'skew_date'
     object_type: 'pod' or 'node'


### PR DESCRIPTION
## Documentation Update
**Related Feature:** 
N/A
fix-yaml-highlighting

Please include the branch name where you have made changes or added new features/scenario that we need on the website (e.g., `krkn/new_scenario`) in the title of this PR.

**Changes:** 

Fixed incorrect Markdown code block syntax highlighting in:
website/content/en/docs/getting-started/getting-started-krkn.md
Changed 3 code block language tags from ```bash to ```yaml at:

Line 87 — Pod Scenario template
Line 99 — Node Scenario template
Line 113 — Time Chaos Scenario template

Why this is relevant:

Wrong highlighting — YAML tagged as bash applies incorrect color coding, making keys and values harder to read.
New user experience — Getting Started guide is the first thing new users follow, correct highlighting makes configuration easier to understand and copy.