### PR TITLE
(docs)krkn/fix-copy-paste-cli — Fix copy-paste error and typo in chaos-recommender docs

### DIFF
--- a/content/en/docs/chaos-recommender.md
+++ b/content/en/docs/chaos-recommender.md
@@ -35,7 +35,7 @@ To run the recommender with a config file specify the config file path with the 
 You can customize the default values by editing the `recommender_config.yaml` file. The configuration file contains the following options:
 
   - `application`: Specify the application name.
-  - `namespaces`: Specify the namespaces names (separated by coma or space). If you want to profile
+  - `namespaces`: Specify the namespaces names (separated by comma or space). If you want to profile
   - `labels`: Specify the labels (not used).
   - `kubeconfig`: Specify the location of the kubeconfig file (not used).
   - `prometheus_endpoint`: Specify the prometheus endpoint (must).
@@ -93,7 +93,7 @@ You can also provide the input values through command-line arguments launching t
   -N NETWORK [NETWORK ...], --NETWORK NETWORK [NETWORK ...]
                         Network related chaos tests (space separated list)
   -G GENERIC [GENERIC ...], --GENERIC GENERIC [GENERIC ...]
-                        Memory related chaos tests (space separated list)
+                        Generic related chaos tests (space separated list)
   --threshold THRESHOLD
                         Threshold
   --cpu_threshold CPU_THRESHOLD


### PR DESCRIPTION
## Documentation Update
**Related Feature:** 
fix-copy-paste-cli

**Changes:** 

Fixed a copy-paste error and a spelling mistake in:
website/content/en/docs/chaos-recommender.md
Exact changes made:

Line 96: Changed -G GENERIC flag description from Memory related chaos tests to Generic related chaos tests (copy-paste error from -M MEM flag above)
Line 38: Changed separated by coma to separated by comma (spelling mistake)

Why this is relevant:

Misleading flag description — The -G GENERIC flag was incorrectly documented as Memory related chaos tests, which is the description of the -M MEM flag. Users relying on this to understand CLI flags would be completely misinformed about what the flag actually does.
Spelling mistake — coma is a medical term (unconscious state), not the punctuation mark. comma is the correct word, and this kind of typo reduces trust in documentation quality.
First impression — The chaos-recommender docs are used by new users setting up the tool for the first time. Accurate documentation is critical at this stage.