### PR TITLE
fix(docs): correct typo conncection to connection in krkn-visualize.md

### DIFF
--- a/content/en/docs/krkn-visualize.md
+++ b/content/en/docs/krkn-visualize.md
@@ -54,7 +54,7 @@ cd visualize/krkn-visualize
 
 ## Dashboards by Category
 
-There are 23 dashboards organized into three categories. Use the **Chaos** dashboards to analyze a specific run by UUID (needs Elasticsearch connection); use the **General** and **K8s** dashboards to monitor overall cluster health before, during, and after a scenario (via prometheus conncection)
+There are 23 dashboards organized into three categories. Use the **Chaos** dashboards to analyze a specific run by UUID (needs Elasticsearch connection); use the **General** and **K8s** dashboards to monitor overall cluster health before, during, and after a scenario (via prometheus connection).
 
 ---
 


### PR DESCRIPTION
Fixes #438 

## Documentation Update
**Related Feature:** 
NA

Please include the branch name where you have made changes or added new features/scenario that we need on the website (e.g., `krkn/new_scenario`) in the title of this PR.
**Branch name:** fix/typo-visualize-md

**Changes:** 
Fixed a spelling typo in 'content/en/docs/krkn-visualize.md '.

The word "conncection" had an extra 'c' — corrected to "connection".

Tested locally with `npx hugo server` and the page renders fine.

Thanks!
