### PR TITLE
docs(krkn-hub): correct stale defaults for node-interface-down params

### DIFF
--- a/content/en/docs/scenarios/network-chaos-ng-scenarios/node-interface-down/_tab-krkn-hub.md
+++ b/content/en/docs/scenarios/network-chaos-ng-scenarios/node-interface-down/_tab-krkn-hub.md
@@ -35,13 +35,13 @@ See list of variables that apply to all scenarios [here](/docs/scenarios/all-sce
 |-------------------------------| -----------------------------------------------------------------     | ------------------------------------ |
 | TOTAL_CHAOS_DURATION          | Duration in seconds to keep the interface(s) down                    | 60                                   |
 | RECOVERY_TIME                 | Seconds to wait after bringing the interface(s) back up              | 0                                    |
-| NODE_SELECTOR                 | Label selector to choose target nodes. If not specified, a schedulable node will be chosen at random | "node-role.kubernetes.io/worker=" |
+| NODE_SELECTOR                 | Label selector to choose target nodes. If not specified, a schedulable node will be chosen at random | "" |
 | NODE_NAME                     | The node name to target (used when label selector is not set)        |                                      |
 | INSTANCE_COUNT                | Restricts the number of nodes selected by the label selector         | 1                                    |
 | EXECUTION                     | Execution mode for multiple nodes: `serial` or `parallel`            | parallel                               |
 | INTERFACES                    | Comma-separated list of interface names to bring down (e.g. `eth0` or `eth0,bond0`). Leave empty to auto-detect the default interface | "" |
 | NAMESPACE                     | Namespace where the chaos workload pod will be deployed              | default                              |
-| TAINTS                        | List of taints for which tolerations need to be created. Example: `["node-role.kubernetes.io/master:NoSchedule"]` | [] |
+| TAINTS                        | List of taints for which tolerations need to be created. Example: `["node-role.kubernetes.io/master:NoSchedule"]` | "" |
 | SERVICE_ACCOUNT               | Optional service account for the chaos workload pod                  | "" |
 
 


### PR DESCRIPTION
## Documentation Update

**Related Feature:** node-interface-down scenario [krkn-hub/node-interface-down](https://github.com/krkn-chaos/krkn-hub/tree/main/node-interface-down
)

**Changes:**

Two parameter defaults in the krkn-hub tab were mismatched against the actual `env.sh` values:

| Parameter | Documented default | Actual default (env.sh) |
|---|---|---|
| `NODE_SELECTOR` | `"node-role.kubernetes.io/worker="` | `""` (empty) |
| `TAINTS` | `[]` | `""` (empty string) |


Updated both rows to reflect what the scenario actually uses when no value is provided.


**Verification:** cross-referenced against `node-interface-down/env.sh` in krkn-hub:
- export LABEL_SELECTOR=${NODE_SELECTOR:=""}
- export TAINTS=${TAINTS:=""}
