### PR TITLE
docs(krkn-hub): add missinlg Type and Default columns to service-hijacking param table

### DIFF
--- a/content/en/docs/scenarios/service-hijacking-scenario/_tab-krkn-hub.md
+++ b/content/en/docs/scenarios/service-hijacking-scenario/_tab-krkn-hub.md
@@ -59,9 +59,9 @@ export <parameter_name>=<value>
 
 See list of variables that apply to all scenarios [here](/docs/scenarios/all-scenario-env.md) that can be used/set in addition to these scenario specific variables
 
-| Parameter             | Description                                                                                                                                                                                                                               |
-|-----------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-|  SCENARIO_BASE64 | Base64 encoded service-hijacking scenario file. Note that the __-w0__ option in the command substitution `SCENARIO_BASE64="$(base64 -w0 <scenario_file>)"` is __mandatory__ in order to remove line breaks from the base64 command output |
+| Parameter        | Description                                                                                                                                                                                                                               | Type   | Default |
+|------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------|---------|
+| SCENARIO_BASE64  | Base64 encoded service-hijacking scenario file. Note that the __-w0__ option in the command substitution `SCENARIO_BASE64="$(base64 -w0 <scenario_file>)"` is __mandatory__ in order to remove line breaks from the base64 command output | string | ""      |
 
 
 A sample scenario file can be found [here](service-hijacking-scenarios-krkn.md#sample-scenario), you'll need to customize it based on your wanted response codes for API calls

--- a/content/en/docs/scenarios/service-hijacking-scenario/_tab-krkn-hub.md
+++ b/content/en/docs/scenarios/service-hijacking-scenario/_tab-krkn-hub.md
@@ -59,9 +59,9 @@ export <parameter_name>=<value>
 
 See list of variables that apply to all scenarios [here](/docs/scenarios/all-scenario-env.md) that can be used/set in addition to these scenario specific variables
 
-| Parameter        | Description                                                                                                                                                                                                                               | Type   | Default |
-|------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------|---------|
-| SCENARIO_BASE64  | Base64 encoded service-hijacking scenario file. Note that the __-w0__ option in the command substitution `SCENARIO_BASE64="$(base64 -w0 <scenario_file>)"` is __mandatory__ in order to remove line breaks from the base64 command output | string | ""      |
+| Parameter        | Description                                                                                                                                                                                                                                        | Type   | Default    |
+|------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------|------------|
+| SCENARIO_BASE64  | **Required.** Base64 encoded service-hijacking scenario file. Note that the __-w0__ option in the command substitution `SCENARIO_BASE64="$(base64 -w0 <scenario_file>)"` is __mandatory__ in order to remove line breaks from the base64 command output | string | (required) |
 
 
 A sample scenario file can be found [here](service-hijacking-scenarios-krkn.md#sample-scenario), you'll need to customize it based on your wanted response codes for API calls


### PR DESCRIPTION
## Documentation Update

**Related Feature:** service-hijacking scenario ([krkn-hub/service-hijacking](https://github.com/krkn-chaos/krkn-hub/tree/main/service-hijacking))

**Changes:**

The `SCENARIO_BASE64` parameter table in the krkn-hub tab was missing the `Type` and `Default` columns, leaving it inconsistent with all other scenario parameter tables on the site.

Added both columns:
- Type: `string`
- Default: `""` (the variable must be explicitly provided by the user)

**Verification:** cross-referenced against `service-hijacking/env.sh` in krkn-hub:
```bash
export SCENARIO_BASE64=${SCENARIO_BASE64:=1}
