### PR TITLE
docs: correct kubeconfig volume mount path in 18 hub tab files

### DIFF
--- a/content/en/docs/installation/krkn-hub.md
+++ b/content/en/docs/installation/krkn-hub.md
@@ -30,7 +30,7 @@ You can take advantage of the [get_docker_params.sh](https://github.com/krkn-cha
 
 For example: `docker run $(./get_docker_params.sh) --net=host -v <path-to-kube-config>:/home/krkn/.kube/config:Z -d quay.io/redhat-chaos/krkn-hub:power-outages`
 
-{{% alert title="Tip" %}}Because the container runs with a non-root user, ensure the kube config is globally readable before mounting it in the container. You can achieve this with the following commands: `kubectl config view --flatten > ~/kubeconfig && chmod 444 ~/kubeconfig && docker run $(./get_docker_params.sh) --name=<container_name> --net=host -v ~kubeconfig:/home/krkn/.kube/config:Z -d containers.krkn-chaos.dev/krkn-chaos/krkn-hub:<scenario>` {{% /alert %}}
+{{% alert title="Tip" %}}Because the container runs with a non-root user, ensure the kube config is globally readable before mounting it in the container. You can achieve this with the following commands: `kubectl config view --flatten > ~/kubeconfig && chmod 444 ~/kubeconfig && docker run $(./get_docker_params.sh) --name=<container_name> --net=host -v ~/kubeconfig:/home/krkn/.kube/config:Z -d containers.krkn-chaos.dev/krkn-chaos/krkn-hub:<scenario>` {{% /alert %}}
 
 
 ### What's next?

--- a/content/en/docs/scenarios/container-scenario/_tab-krkn-hub.md
+++ b/content/en/docs/scenarios/container-scenario/_tab-krkn-hub.md
@@ -38,7 +38,7 @@ $ docker inspect <container-name or container-id> \
   --format "{{.State.ExitCode}}" # Outputs exit code which can considered as pass/fail for the scenario
 ```
 {{% alert title="Tip" %}} Because the container runs with a non-root user, ensure the kube config is globally readable before mounting it in the container. You can achieve this with the following commands:
-```kubectl config view --flatten > ~/kubeconfig && chmod 444 ~/kubeconfig && docker run $(./get_docker_params.sh) --name=<container_name> --net=host --pull=always -v ~kubeconfig:/home/krkn/.kube/config:Z -d containers.krkn-chaos.dev/krkn-chaos/krkn-hub:<scenario>``` {{% /alert %}}
+```kubectl config view --flatten > ~/kubeconfig && chmod 444 ~/kubeconfig && docker run $(./get_docker_params.sh) --name=<container_name> --net=host --pull=always -v ~/kubeconfig:/home/krkn/.kube/config:Z -d containers.krkn-chaos.dev/krkn-chaos/krkn-hub:<scenario>``` {{% /alert %}}
 #### Supported parameters
 
 The following environment variables can be set on the host running the container to tweak the scenario/faults being injected:

--- a/content/en/docs/scenarios/hog-scenarios/cpu-hog-scenario/_tab-krkn-hub.md
+++ b/content/en/docs/scenarios/hog-scenarios/cpu-hog-scenario/_tab-krkn-hub.md
@@ -41,7 +41,7 @@ $ docker inspect <container-name or container-id> \
 ```
 
 {{% alert title="Tip" %}} Because the container runs with a non-root user, ensure the kube config is globally readable before mounting it in the container. You can achieve this with the following commands:
-```kubectl config view --flatten > ~/kubeconfig && chmod 444 ~/kubeconfig && docker run $(./get_docker_params.sh) --name=<container_name> --net=host --pull=always -v ~kubeconfig:/home/krkn/.kube/config:Z -d containers.krkn-chaos.dev/krkn-chaos/krkn-hub:<scenario>``` {{% /alert %}}
+```kubectl config view --flatten > ~/kubeconfig && chmod 444 ~/kubeconfig && docker run $(./get_docker_params.sh) --name=<container_name> --net=host --pull=always -v ~/kubeconfig:/home/krkn/.kube/config:Z -d containers.krkn-chaos.dev/krkn-chaos/krkn-hub:<scenario>``` {{% /alert %}}
 #### Supported parameters
 
 The following environment variables can be set on the host running the container to tweak the scenario/faults being injected:

--- a/content/en/docs/scenarios/hog-scenarios/io-hog-scenario/_tab-krkn-hub.md
+++ b/content/en/docs/scenarios/hog-scenarios/io-hog-scenario/_tab-krkn-hub.md
@@ -40,7 +40,7 @@ $ docker inspect <container-name or container-id> \
 ```
 
 {{% alert title="Tip" %}} Because the container runs with a non-root user, ensure the kube config is globally readable before mounting it in the container. You can achieve this with the following commands:
-```kubectl config view --flatten > ~/kubeconfig && chmod 444 ~/kubeconfig && docker run $(./get_docker_params.sh) --name=<container_name> --net=host --pull=always -v ~kubeconfig:/home/krkn/.kube/config:Z -d containers.krkn-chaos.dev/krkn-chaos/krkn-hub:<scenario>``` {{% /alert %}}
+```kubectl config view --flatten > ~/kubeconfig && chmod 444 ~/kubeconfig && docker run $(./get_docker_params.sh) --name=<container_name> --net=host --pull=always -v ~/kubeconfig:/home/krkn/.kube/config:Z -d containers.krkn-chaos.dev/krkn-chaos/krkn-hub:<scenario>``` {{% /alert %}}
 #### Supported parameters
 
 The following environment variables can be set on the host running the container to tweak the scenario/faults being injected:

--- a/content/en/docs/scenarios/hog-scenarios/memory-hog-scenario/_tab-krkn-hub.md
+++ b/content/en/docs/scenarios/hog-scenarios/memory-hog-scenario/_tab-krkn-hub.md
@@ -40,7 +40,7 @@ $ docker inspect <container-name or container-id> \
 ```
 
 {{% alert title="Tip" %}} Because the container runs with a non-root user, ensure the kube config is globally readable before mounting it in the container. You can achieve this with the following commands:
-```kubectl config view --flatten > ~/kubeconfig && chmod 444 ~/kubeconfig && docker run $(./get_docker_params.sh) --name=<container_name> --net=host --pull=always -v ~kubeconfig:/home/krkn/.kube/config:Z -d containers.krkn-chaos.dev/krkn-chaos/krkn-hub:<scenario>``` {{% /alert %}}
+```kubectl config view --flatten > ~/kubeconfig && chmod 444 ~/kubeconfig && docker run $(./get_docker_params.sh) --name=<container_name> --net=host --pull=always -v ~/kubeconfig:/home/krkn/.kube/config:Z -d containers.krkn-chaos.dev/krkn-chaos/krkn-hub:<scenario>``` {{% /alert %}}
 #### Supported parameters
 
 The following environment variables can be set on the host running the container to tweak the scenario/faults being injected:

--- a/content/en/docs/scenarios/kubevirt-vm-outage-scenario/_tab-krkn-hub.md
+++ b/content/en/docs/scenarios/kubevirt-vm-outage-scenario/_tab-krkn-hub.md
@@ -38,7 +38,7 @@ $ docker inspect <container-name or container-id> \
   --format "{{.State.ExitCode}}" # Outputs exit code which can considered as pass/fail for the scenario
 ```
 {{% alert title="Tip" %}} Because the container runs with a non-root user, ensure the kube config is globally readable before mounting it in the container. You can achieve this with the following commands:
-```kubectl config view --flatten > ~/kubeconfig && chmod 444 ~/kubeconfig && docker run $(./get_docker_params.sh) --name=<container_name> --net=host --pull=always -v ~kubeconfig:/home/krkn/.kube/config:Z -d containers.krkn-chaos.dev/krkn-chaos/krkn-hub:<scenario>``` {{% /alert %}}
+```kubectl config view --flatten > ~/kubeconfig && chmod 444 ~/kubeconfig && docker run $(./get_docker_params.sh) --name=<container_name> --net=host --pull=always -v ~/kubeconfig:/home/krkn/.kube/config:Z -d containers.krkn-chaos.dev/krkn-chaos/krkn-hub:<scenario>``` {{% /alert %}}
 
 
 #### Supported parameters

--- a/content/en/docs/scenarios/network-chaos-ng-scenarios/node-interface-down/_tab-krkn-hub.md
+++ b/content/en/docs/scenarios/network-chaos-ng-scenarios/node-interface-down/_tab-krkn-hub.md
@@ -17,7 +17,7 @@ $ docker inspect <container-name or container-id> --format "{{.State.ExitCode}}"
 
 **TIP**: Because the container runs with a non-root user, ensure the kube config is globally readable before mounting it in the container. You can achieve this with the following commands:
 ```bash
-kubectl config view --flatten > ~/kubeconfig && chmod 444 ~/kubeconfig && docker run $(./get_docker_params.sh) --name=<container_name> --net=host --pull=always -v ~kubeconfig:/home/krkn/.kube/config:Z -d quay.io/krkn-chaos/krkn-hub:<scenario>
+kubectl config view --flatten > ~/kubeconfig && chmod 444 ~/kubeconfig && docker run $(./get_docker_params.sh) --name=<container_name> --net=host --pull=always -v ~/kubeconfig:/home/krkn/.kube/config:Z -d quay.io/krkn-chaos/krkn-hub:<scenario>
 ```
 
 

--- a/content/en/docs/scenarios/network-chaos-ng-scenarios/node-network-filter/_tab-krkn-hub.md
+++ b/content/en/docs/scenarios/network-chaos-ng-scenarios/node-network-filter/_tab-krkn-hub.md
@@ -17,7 +17,7 @@ $ docker inspect <container-name or container-id> --format "{{.State.ExitCode}}"
 
 **TIP**: Because the container runs with a non-root user, ensure the kube config is globally readable before mounting it in the container. You can achieve this with the following commands:
 ```bash
-kubectl config view --flatten > ~/kubeconfig && chmod 444 ~/kubeconfig && docker run $(./get_docker_params.sh) --name=<container_name> --net=host --pull=always -v ~kubeconfig:/home/krkn/.kube/config:Z -d quay.io/krkn-chaos/krkn-hub:<scenario>
+kubectl config view --flatten > ~/kubeconfig && chmod 444 ~/kubeconfig && docker run $(./get_docker_params.sh) --name=<container_name> --net=host --pull=always -v ~/kubeconfig:/home/krkn/.kube/config:Z -d quay.io/krkn-chaos/krkn-hub:<scenario>
 ```
 
 

--- a/content/en/docs/scenarios/network-chaos-ng-scenarios/pod-network-filter/_tab-krkn-hub.md
+++ b/content/en/docs/scenarios/network-chaos-ng-scenarios/pod-network-filter/_tab-krkn-hub.md
@@ -18,7 +18,7 @@ $ docker inspect <container-name or container-id> --format "{{.State.ExitCode}}"
 
 **TIP**: Because the container runs with a non-root user, ensure the kube config is globally readable before mounting it in the container. You can achieve this with the following commands:
 ```bash
-kubectl config view --flatten > ~/kubeconfig && chmod 444 ~/kubeconfig && docker run $(./get_docker_params.sh) --name=<container_name> --net=host --pull=always -v ~kubeconfig:/home/krkn/.kube/config:Z -d quay.io/krkn-chaos/krkn-hub:<scenario>
+kubectl config view --flatten > ~/kubeconfig && chmod 444 ~/kubeconfig && docker run $(./get_docker_params.sh) --name=<container_name> --net=host --pull=always -v ~/kubeconfig:/home/krkn/.kube/config:Z -d quay.io/krkn-chaos/krkn-hub:<scenario>
 ```
 
 

--- a/content/en/docs/scenarios/network-chaos-scenario/_tab-krkn-hub.md
+++ b/content/en/docs/scenarios/network-chaos-scenario/_tab-krkn-hub.md
@@ -34,7 +34,7 @@ $ docker inspect <container-name or container-id> \
 ```
 
 {{% alert title="Tip" %}} Because the container runs with a non-root user, ensure the kube config is globally readable before mounting it in the container. You can achieve this with the following commands:
-```kubectl config view --flatten > ~/kubeconfig && chmod 444 ~/kubeconfig && docker run $(./get_docker_params.sh) --name=<container_name> --net=host --pull=always -v ~kubeconfig:/home/krkn/.kube/config:Z -d containers.krkn-chaos.dev/krkn-chaos/krkn-hub:<scenario>``` {{% /alert %}}
+```kubectl config view --flatten > ~/kubeconfig && chmod 444 ~/kubeconfig && docker run $(./get_docker_params.sh) --name=<container_name> --net=host --pull=always -v ~/kubeconfig:/home/krkn/.kube/config:Z -d containers.krkn-chaos.dev/krkn-chaos/krkn-hub:<scenario>``` {{% /alert %}}
 #### Supported parameters
 
 The following environment variables can be set on the host running the container to tweak the scenario/faults being injected:

--- a/content/en/docs/scenarios/pod-network-scenario/_tab-krkn-hub.md
+++ b/content/en/docs/scenarios/pod-network-scenario/_tab-krkn-hub.md
@@ -42,7 +42,7 @@ $ docker inspect <container-name or container-id> \
 ```
 
 {{% alert title="Tip" %}} Because the container runs with a non-root user, ensure the kube config is globally readable before mounting it in the container. You can achieve this with the following commands:
-```kubectl config view --flatten > ~/kubeconfig && chmod 444 ~/kubeconfig && docker run $(./get_docker_params.sh) --name=<container_name> --net=host --pull=always -v ~kubeconfig:/home/krkn/.kube/config:Z -d containers.krkn-chaos.dev/krkn-chaos/krkn-hub:<scenario>``` {{% /alert %}}
+```kubectl config view --flatten > ~/kubeconfig && chmod 444 ~/kubeconfig && docker run $(./get_docker_params.sh) --name=<container_name> --net=host --pull=always -v ~/kubeconfig:/home/krkn/.kube/config:Z -d containers.krkn-chaos.dev/krkn-chaos/krkn-hub:<scenario>``` {{% /alert %}}
 #### Supported parameters
 
 The following environment variables can be set on the host running the container to tweak the scenario/faults being injected:

--- a/content/en/docs/scenarios/power-outage-scenarios/_tab-krkn-hub.md
+++ b/content/en/docs/scenarios/power-outage-scenarios/_tab-krkn-hub.md
@@ -46,7 +46,7 @@ $ docker inspect <container-name or container-id> \
   --format "{{.State.ExitCode}}" # Outputs exit code which can considered as pass/fail for the scenario
 ```
 {{% alert title="Tip" %}} Because the container runs with a non-root user, ensure the kube config is globally readable before mounting it in the container. You can achieve this with the following commands:
-```kubectl config view --flatten > ~/kubeconfig && chmod 444 ~/kubeconfig && docker run $(./get_docker_params.sh) --name=<container_name> --net=host --pull=always -v ~kubeconfig:/home/krkn/.kube/config:Z -d containers.krkn-chaos.dev/krkn-chaos/krkn-hub:<scenario>``` {{% /alert %}}
+```kubectl config view --flatten > ~/kubeconfig && chmod 444 ~/kubeconfig && docker run $(./get_docker_params.sh) --name=<container_name> --net=host --pull=always -v ~/kubeconfig:/home/krkn/.kube/config:Z -d containers.krkn-chaos.dev/krkn-chaos/krkn-hub:<scenario>``` {{% /alert %}}
 #### Supported parameters
 
 The following environment variables can be set on the host running the container to tweak the scenario/faults being injected:

--- a/content/en/docs/scenarios/pvc-scenario/_tab-krkn-hub.md
+++ b/content/en/docs/scenarios/pvc-scenario/_tab-krkn-hub.md
@@ -42,7 +42,7 @@ $ docker inspect <container-name or container-id> \
 ```
 
 {{% alert title="Tip" %}} Because the container runs with a non-root user, ensure the kube config is globally readable before mounting it in the container. You can achieve this with the following commands:
-```kubectl config view --flatten > ~/kubeconfig && chmod 444 ~/kubeconfig && docker run $(./get_docker_params.sh) --name=<container_name> --net=host --pull=always -v ~kubeconfig:/home/krkn/.kube/config:Z -d containers.krkn-chaos.dev/krkn-chaos/krkn-hub:<scenario>``` {{% /alert %}}
+```kubectl config view --flatten > ~/kubeconfig && chmod 444 ~/kubeconfig && docker run $(./get_docker_params.sh) --name=<container_name> --net=host --pull=always -v ~/kubeconfig:/home/krkn/.kube/config:Z -d containers.krkn-chaos.dev/krkn-chaos/krkn-hub:<scenario>``` {{% /alert %}}
 #### Supported parameters
 
 The following environment variables can be set on the host running the container to tweak the scenario/faults being injected:

--- a/content/en/docs/scenarios/service-disruption-scenarios/_tab-krkn-hub.md
+++ b/content/en/docs/scenarios/service-disruption-scenarios/_tab-krkn-hub.md
@@ -41,7 +41,7 @@ $ docker inspect <container-name or container-id> \
 ```
 
 {{% alert title="Tip" %}} Because the container runs with a non-root user, ensure the kube config is globally readable before mounting it in the container. You can achieve this with the following commands:
-```kubectl config view --flatten > ~/kubeconfig && chmod 444 ~/kubeconfig && docker run $(./get_docker_params.sh) --name=<container_name> --net=host --pull=always -v ~kubeconfig:/home/krkn/.kube/config:Z -d containers.krkn-chaos.dev/krkn-chaos/krkn-hub:<scenario>``` {{% /alert %}}
+```kubectl config view --flatten > ~/kubeconfig && chmod 444 ~/kubeconfig && docker run $(./get_docker_params.sh) --name=<container_name> --net=host --pull=always -v ~/kubeconfig:/home/krkn/.kube/config:Z -d containers.krkn-chaos.dev/krkn-chaos/krkn-hub:<scenario>``` {{% /alert %}}
 #### Supported parameters
 
 The following environment variables can be set on the host running the container to tweak the scenario/faults being injected:

--- a/content/en/docs/scenarios/service-hijacking-scenario/_tab-krkn-hub.md
+++ b/content/en/docs/scenarios/service-hijacking-scenario/_tab-krkn-hub.md
@@ -44,7 +44,7 @@ $ docker inspect <container-name or container-id> \
 
 {{% alert title="Tip" %}} ecause the container runs with a non-root user, ensure the kube config is globally readable before mounting it in the container. You can achieve this with the following commands:
 ```bash
-kubectl config view --flatten > ~/kubeconfig && chmod 444 ~/kubeconfig && docker run $(./get_docker_params.sh) --name=<container_name> --net=host --pull=always -v ~kubeconfig:/home/krkn/.kube/config:Z -d containers.krkn-chaos.dev/krkn-chaos/krkn-hub:<scenario>
+kubectl config view --flatten > ~/kubeconfig && chmod 444 ~/kubeconfig && docker run $(./get_docker_params.sh) --name=<container_name> --net=host --pull=always -v ~/kubeconfig:/home/krkn/.kube/config:Z -d containers.krkn-chaos.dev/krkn-chaos/krkn-hub:<scenario>
 ```
 
 {{% /alert %}}

--- a/content/en/docs/scenarios/syn-flood-scenario/_tab-krkn-hub.md
+++ b/content/en/docs/scenarios/syn-flood-scenario/_tab-krkn-hub.md
@@ -58,7 +58,7 @@ docker run $(./get_docker_params.sh) \
   --name=<container_name> \
   --net=host \
   --pull=always \
-  -v ~kubeconfig:/home/krkn/.kube/config:Z \
+  -v ~/kubeconfig:/home/krkn/.kube/config:Z \
   -d containers.krkn-chaos.dev/krkn-chaos/krkn-hub:<scenario>
 ```
 #### Supported parameters

--- a/content/en/docs/scenarios/time-scenarios/_tab-krkn-hub.md
+++ b/content/en/docs/scenarios/time-scenarios/_tab-krkn-hub.md
@@ -43,7 +43,7 @@ $ docker inspect <container-name or container-id> \
 
 {{% alert title="Tip" %}} Because the container runs with a non-root user, ensure the kube config is globally readable before mounting it in the container. You can achieve this with the following commands:
 ```bash
-kubectl config view --flatten > ~/kubeconfig && chmod 444 ~/kubeconfig && docker run $(./get_docker_params.sh) --name=<container_name> --net=host --pull=always -v ~kubeconfig:/home/krkn/.kube/config:Z -d containers.krkn-chaos.dev/krkn-chaos/krkn-hub:<scenario>
+kubectl config view --flatten > ~/kubeconfig && chmod 444 ~/kubeconfig && docker run $(./get_docker_params.sh) --name=<container_name> --net=host --pull=always -v ~/kubeconfig:/home/krkn/.kube/config:Z -d containers.krkn-chaos.dev/krkn-chaos/krkn-hub:<scenario>
 ```
 {{% /alert %}}
 #### Supported parameters

--- a/content/en/docs/scenarios/zone-outage-scenarios/_tab-krkn-hub.md
+++ b/content/en/docs/scenarios/zone-outage-scenarios/_tab-krkn-hub.md
@@ -41,7 +41,7 @@ $ docker inspect <container-name or container-id> \
   --format "{{.State.ExitCode}}" # Outputs exit code which can considered as pass/fail for the scenario
 ```
 {{% alert title="Tip" %}} Because the container runs with a non-root user, ensure the kube config is globally readable before mounting it in the container. You can achieve this with the following commands:
-```kubectl config view --flatten > ~/kubeconfig && chmod 444 ~/kubeconfig && docker run $(./get_docker_params.sh) --name=<container_name> --net=host --pull=always -v ~kubeconfig:/home/krkn/.kube/config:Z -d containers.krkn-chaos.dev/krkn-chaos/krkn-hub:<scenario>``` {{% /alert %}}
+```kubectl config view --flatten > ~/kubeconfig && chmod 444 ~/kubeconfig && docker run $(./get_docker_params.sh) --name=<container_name> --net=host --pull=always -v ~/kubeconfig:/home/krkn/.kube/config:Z -d containers.krkn-chaos.dev/krkn-chaos/krkn-hub:<scenario>``` {{% /alert %}}
 #### Supported parameters
 
 The following environment variables can be set on the host running the container to tweak the scenario/faults being injected:


### PR DESCRIPTION
## Documentation Update

**Related Feature:**
fix/456-kubeconfig-slash

**Changes:**
Corrects `-v ~kubeconfig:` to `-v ~/kubeconfig:` in the docker run tip block across 18 scenario hub tab files and the installation page.

For full context on why this breaks the volume mount, please refer to the issue: Closes #456