### PR TITLE
docs: replace stale Google CLA section with DCO sign-off instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,17 +3,18 @@
 We'd love to accept your patches and contributions to this project. There are
 just a few small guidelines you need to follow.
 
-## Contributor License Agreement
+## Developer Certificate of Origin (DCO)
 
-Contributions to this project must be accompanied by a Contributor License
-Agreement. You (or your employer) retain the copyright to your contribution;
-this simply gives us permission to use and redistribute your contributions as
-part of the project. Head over to <https://cla.developers.google.com/> to see
-your current agreements on file or to sign a new one.
+This project uses DCO sign-off instead of a CLA. All commits must be signed off
+by adding `-s` to your commit command:
 
-You generally only need to submit a CLA once, so if you've already submitted one
-(even if it was for a different project), you probably don't need to do it
-again.
+```bash
+git commit -s -m "your commit message"
+```
+
+This adds a `Signed-off-by` line to your commit certifying that you wrote the
+change and have the right to submit it under the project license. CI will block
+your PR if any commit is missing the sign-off.
 
 ## Code reviews
 


### PR DESCRIPTION
## Documentation Update

**Related Feature:**
fix/457-contributing-dco

**Changes:**
Replaces the Google CLA section in CONTRIBUTING.md with accurate DCO sign-off instructions. The CLA section was pointing contributors to cla.developers.google.com which is not what this project enforces.

For full context please refer to the issue: Closes #457