### PR TITLE
Broken Markdown Code Block Formatting

### DIFF
--- a/content/en/docs/krknctl/usage.md
+++ b/content/en/docs/krknctl/usage.md
@@ -12,7 +12,9 @@ Commands are grouped by action and may include one or more subcommands to furthe
 - #### `available`:
     Builds a list of all the available scenarios in krkn-hub
 
-    ```% krknctl list available ```
+    ```bash
+    % krknctl list available
+    ```
 
     | Name | Size | Digest | Last Modified | 
     | -------- | --- | ------- | --------- |


### PR DESCRIPTION
## Documentation Update
**Related Feature:** 

block-Formatting

**Changes:** 

content/en/docs/krknctl/usage.md, Line 15 Current incorrect content:    ```% krknctl list available ``` Correct replacement:


```bash 
% krknctl list available  
```
The current formatting opens and closes the code block on the exact same line, violating standard Markdown syntax, and lacks a language tag. The replacement applies standard, consistent formatting without changing the underlying command.