### PR TITLE
docs(kubevirt-vm-outage): fix timeout key and add disable_auto_restart param

### DIFF
--- a/content/en/docs/scenarios/kubevirt-vm-outage-scenario/_tab-krkn.md
+++ b/content/en/docs/scenarios/kubevirt-vm-outage-scenario/_tab-krkn.md
@@ -26,6 +26,7 @@ scenarios:
       vm_name: <my-application-vm>
       namespace: <vm-workloads>
       timeout: 60
+      disable_auto_restart: false
       kill_count: 3
 ```
 
@@ -36,6 +37,7 @@ scenarios:
 | vm_name | The name of the VMI to delete | Yes | N/A | "database-vm", "web-server-vm" |
 | namespace | The namespace where the VMI is located | No | "default" | "openshift-cnv", "vm-workloads" |
 | timeout | How long to wait (in seconds) for VMI to become running before attempting recovery | No | 60 | 30, 120, 300 |
+| disable_auto_restart | When set to true, patches spec.running=False on the VM so it does not auto-restart after deletion. | No | false | true, false |
 | kill_count | How many VMI's to kill serially | No | 1 | 3 |
 
 ## Execution Flow
@@ -63,7 +65,8 @@ scenarios:
     parameters:
       vm_name: my-vm
       namespace: kubevirt
-      duration: 60
+      timeout: 60
+      disable_auto_restart: false
       kill_count: 3
 ```
 
@@ -76,7 +79,8 @@ scenarios:
     parameters:
       vm_name: app-vm
       namespace: application
-      duration: 120
+      timeout: 120
+      disable_auto_restart: false
       kill_count: 1
   
   - name: "kubevirt outage test - database VM"
@@ -84,7 +88,8 @@ scenarios:
     parameters:
       vm_name: db-vm
       namespace: database
-      duration: 180
+      timeout: 180
+      disable_auto_restart: false
       kill_count: 2
 ```
 


### PR DESCRIPTION
Fixes #461

## What changed

The `kubevirt_vm_outage` scenario docs had two issues:

1. **Wrong parameter key**: Sample YAML configs used `duration` but the plugin reads `timeout` — users copying the examples silently got the 60s default regardless of their value.

2. **Missing parameter**: `disable_auto_restart` exists in the plugin but was undocumented.

## Fix

- Replaced `duration` → `timeout` in the 3 Sample Configuration YAML blocks
- Added `disable_auto_restart: false` to all 4 YAML examples (including the Usage block for consistency)
- Added `disable_auto_restart` row to the Detailed Parameters table