### PR TITLE
docs: clarify pod scenarios using krknctl - docs/pod-scenarios

### DIFF
--- a/content/en/docs/scenarios/pod-scenario/_tab-krknctl.md
+++ b/content/en/docs/scenarios/pod-scenario/_tab-krknctl.md
@@ -1,5 +1,5 @@
 ```bash
-krknctl run pod-scenarios [--<parameter> <value>]
+krknctl run pod-scenarios [--<parameter>:<value>]
 ```
 
 Use this command to run a pod disruption scenario. Pass the optional flags below to target specific pods and control how the run behaves. Global `krknctl` flags are listed [here](../all-scenario-env-krknctl.md).

--- a/content/en/docs/scenarios/pod-scenario/_tab-krknctl.md
+++ b/content/en/docs/scenarios/pod-scenario/_tab-krknctl.md
@@ -2,27 +2,27 @@
 krknctl run pod-scenarios [--<parameter> <value>]
 ```
 
-Can also set any global variable listed [here](../all-scenario-env-krknctl.md)
+Use this command to run a pod disruption scenario. Pass the optional flags below to target specific pods and control how the run behaves. Global `krknctl` flags are listed [here](../all-scenario-env-krknctl.md).
 
-
-Scenario specific parameters:
-| Parameter      | Description    | Type      | Required |  Default |
-| ----------------------- | ----------------------    | ----------------  | :------: | ------------------------------------ |
-`--namespace` | Targeted namespace in the cluster ( supports regex ) | string | No | openshift-* |
-`--pod-label` | Label of the pod(s) to target ex. "app=test" | string | No |
-`--exclude-label` | Pods matching this label will be excluded from the chaos even if they match other criteria | string | No | "" |
-`--name-pattern` | Regex pattern to match the pods in NAMESPACE when POD_LABEL is not specified | string | No | .* |
-`--disruption-count` | Number of pods to disrupt | number | No | 1 |
-`--kill-timeout` | Timeout to wait for the target pod(s) to be removed in seconds | number | No | 180 |
-`--expected-recovery-time` | Fails if the pod disrupted do not recover within the timeout set | number | No | 120 |
-`--node-label-selector` | Label of the node(s) to target | string | No | "" |
-`--node-names` | Name of the node(s) to target. Example: ["worker-node-1","worker-node-2","master-node-1"] | string | No | [] |
+| Parameter | Description | Type | Required | Default |
+|-----------|-------------|------|----------|---------|
+| `--namespace` | Namespace to target. Supports regex. | string | No | `openshift-*` |
+| `--pod-label` | Label selector for the pods to target, for example `app=test`. | string | No | - |
+| `--exclude-label` | Pods matching this label are excluded from the run, even if they match other criteria. | string | No | `""` |
+| `--name-pattern` | Regex pattern to match pods in the namespace when `--pod-label` is not set. | string | No | `.*` |
+| `--disruption-count` | Number of pods to disrupt. | number | No | `1` |
+| `--kill-timeout` | Seconds to wait for the target pod(s) to be removed. | number | No | `180` |
+| `--expected-recovery-time` | Seconds to wait for disrupted pods to recover before the scenario fails. | number | No | `120` |
+| `--node-label-selector` | Label selector for the nodes that host the target pods. | string | No | `""` |
+| `--node-names` | Explicit node names to target. Example: `["worker-node-1","worker-node-2"]`. | string | No | `[]` |
 
 #### Behavior Notes
 
-- **Recovery monitoring:** After disrupting pods, krkn monitors for recovery up to `--expected-recovery-time` seconds. If any pods remain unrecovered after the timeout, the scenario reports failure.
+- Pods are selected from the namespace and pod filters first, then filtered by node selectors.
+- The scenario fails if the disrupted pods do not recover within `--expected-recovery-time` seconds.
 
-To see all available scenario options
+To see the full CLI help:
+
 ```bash
 krknctl run pod-scenarios --help
 ```

--- a/content/en/docs/scenarios/pod-scenario/pod-scenarios-krknctl.md
+++ b/content/en/docs/scenarios/pod-scenario/pod-scenarios-krknctl.md
@@ -1,0 +1,14 @@
+---
+title: Pod Scenarios using krknctl
+description: Scenario-specific `krknctl` usage for pod disruption runs
+weight: 10
+---
+
+## Overview
+
+This page summarizes the `krknctl` form of the Pod Scenarios run command.
+
+For the full pod scenario overview, see the [Pod Scenarios](/docs/scenarios/pod-scenario/) page.
+
+{{< readfile file="_tab-krknctl.md" >}}
+


### PR DESCRIPTION
## Documentation Update
**Related Feature:** Pod Scenarios using krknctl

Please include the branch name where you have made changes or added new features/scenario that we need on the website (e.g., `krkn/new_scenario`) in the title of this PR.

**Changes:** 
- Clarified the `krknctl run pod-scenarios` command
- Documented the pod-scenario flags shown in the krknctl tab
- Kept the wording aligned with the existing Pod Scenarios docs structure

Fixes issue #84 
