### PR TITLE
fix(security): harden webhook signature validation

### DIFF
--- a/netlify/functions/webhook-rebuild.js
+++ b/netlify/functions/webhook-rebuild.js
@@ -24,7 +24,8 @@ const initializeServices = async () => {
 // Verify webhook signature for security
 function verifyWebhookSignature(payload, signature, secret) {
     if (!secret) return true;
-    if (!signature) return false;
+    if (typeof payload !== 'string' && !Buffer.isBuffer(payload)) return false;
+    if (typeof signature !== 'string') return false;
     
     const expectedSignature = crypto
         .createHmac('sha256', secret)
@@ -85,6 +86,15 @@ exports.handler = async (event, context) => {
         const signature = event.headers['x-hub-signature-256'] || event.headers['x-webhook-signature'];
         
         if (webhookSecret && event.httpMethod === 'POST') {
+            if (typeof event.body !== 'string') {
+                console.error('Invalid webhook signature');
+                return {
+                    statusCode: 401,
+                    headers,
+                    body: JSON.stringify({ error: 'Invalid webhook signature' })
+                };
+            }
+
             const isValid = verifyWebhookSignature(event.body, signature, webhookSecret);
             if (!isValid) {
                 console.error('Invalid webhook signature');

--- a/netlify/functions/webhook-rebuild.js
+++ b/netlify/functions/webhook-rebuild.js
@@ -23,7 +23,8 @@ const initializeServices = async () => {
 
 // Verify webhook signature for security
 function verifyWebhookSignature(payload, signature, secret) {
-    if (!secret || !signature) return true; // Allow unsigned webhooks if no secret configured
+    if (!secret) return true;
+    if (!signature) return false;
     
     const expectedSignature = crypto
         .createHmac('sha256', secret)
@@ -33,6 +34,10 @@ function verifyWebhookSignature(payload, signature, secret) {
     const providedSignature = signature.startsWith('sha256=') 
         ? signature.slice(7) 
         : signature;
+
+    if (!/^[a-fA-F0-9]{64}$/.test(providedSignature)) {
+        return false;
+    }
     
     return crypto.timingSafeEqual(
         Buffer.from(expectedSignature, 'hex'),

--- a/netlify/functions/webhook-rebuild.test.js
+++ b/netlify/functions/webhook-rebuild.test.js
@@ -1,11 +1,29 @@
-const test = require('node:test');
+const { test, afterEach } = require('node:test');
 const assert = require('node:assert/strict');
 const crypto = require('crypto');
 
-function loadHandler() {
-    const modulePath = require.resolve('./webhook-rebuild.js');
-    const servicePath = require.resolve('../../api/services/DocumentationIndex');
+const modulePath = require.resolve('./webhook-rebuild.js');
+const servicePath = require.resolve('../../api/services/DocumentationIndex');
+const originalWebhookSecret = process.env.WEBHOOK_SECRET;
+const originalServiceModule = require.cache[servicePath];
 
+afterEach(() => {
+    if (originalWebhookSecret === undefined) {
+        delete process.env.WEBHOOK_SECRET;
+    } else {
+        process.env.WEBHOOK_SECRET = originalWebhookSecret;
+    }
+
+    delete require.cache[modulePath];
+
+    if (originalServiceModule) {
+        require.cache[servicePath] = originalServiceModule;
+    } else {
+        delete require.cache[servicePath];
+    }
+});
+
+function loadHandler() {
     delete require.cache[modulePath];
     delete require.cache[servicePath];
 
@@ -79,4 +97,19 @@ test('accepts correctly signed webhook requests when WEBHOOK_SECRET is configure
 
     assert.equal(response.statusCode, 200);
     assert.equal(JSON.parse(response.body).message, 'Documentation index rebuilt successfully via webhook');
+});
+
+test('rejects signed webhook requests with no body when WEBHOOK_SECRET is configured', async () => {
+    process.env.WEBHOOK_SECRET = 'secret-value';
+
+    const handler = loadHandler();
+    const response = await handler({
+        httpMethod: 'POST',
+        headers: {
+            'x-hub-signature-256': 'sha256=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+        }
+    });
+
+    assert.equal(response.statusCode, 401);
+    assert.deepEqual(JSON.parse(response.body), { error: 'Invalid webhook signature' });
 });

--- a/netlify/functions/webhook-rebuild.test.js
+++ b/netlify/functions/webhook-rebuild.test.js
@@ -1,0 +1,82 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const crypto = require('crypto');
+
+function loadHandler() {
+    const modulePath = require.resolve('./webhook-rebuild.js');
+    const servicePath = require.resolve('../../api/services/DocumentationIndex');
+
+    delete require.cache[modulePath];
+    delete require.cache[servicePath];
+
+    require.cache[servicePath] = {
+        id: servicePath,
+        filename: servicePath,
+        loaded: true,
+        exports: class DocumentationIndex {
+            async initialize() {}
+            async rebuildIndex() {
+                return {
+                    success: true,
+                    documentCount: 1,
+                    version: 'test',
+                    timestamp: '2026-05-17T00:00:00.000Z'
+                };
+            }
+        }
+    };
+
+    return require('./webhook-rebuild.js').handler;
+}
+
+test('rejects unsigned webhook requests when WEBHOOK_SECRET is configured', async () => {
+    process.env.WEBHOOK_SECRET = 'secret-value';
+
+    const handler = loadHandler();
+    const response = await handler({
+        httpMethod: 'POST',
+        headers: {},
+        body: JSON.stringify({ test: true })
+    });
+
+    assert.equal(response.statusCode, 401);
+    assert.deepEqual(JSON.parse(response.body), { error: 'Invalid webhook signature' });
+});
+
+test('rejects malformed webhook signatures when WEBHOOK_SECRET is configured', async () => {
+    process.env.WEBHOOK_SECRET = 'secret-value';
+
+    const handler = loadHandler();
+    const response = await handler({
+        httpMethod: 'POST',
+        headers: {
+            'x-hub-signature-256': 'sha256=not-hex'
+        },
+        body: JSON.stringify({ test: true })
+    });
+
+    assert.equal(response.statusCode, 401);
+    assert.deepEqual(JSON.parse(response.body), { error: 'Invalid webhook signature' });
+});
+
+test('accepts correctly signed webhook requests when WEBHOOK_SECRET is configured', async () => {
+    process.env.WEBHOOK_SECRET = 'secret-value';
+
+    const body = JSON.stringify({ test: true });
+    const signature = `sha256=${crypto
+        .createHmac('sha256', process.env.WEBHOOK_SECRET)
+        .update(body)
+        .digest('hex')}`;
+
+    const handler = loadHandler();
+    const response = await handler({
+        httpMethod: 'POST',
+        headers: {
+            'x-hub-signature-256': signature
+        },
+        body
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.equal(JSON.parse(response.body).message, 'Documentation index rebuilt successfully via webhook');
+});


### PR DESCRIPTION
## Summary

Hardens webhook signature validation for `/.netlify/functions/webhook-rebuild`.

This change fixes a fail-open path where unsigned webhook requests were accepted when `WEBHOOK_SECRET` was configured, and also rejects malformed signature values instead of letting them fall through to an internal error.

## Changes

- Require a signature when `WEBHOOK_SECRET` is set
- Reject missing signatures with `401`
- Reject malformed non-hex signatures with `401`
- Preserve successful handling for correctly signed requests
- Add focused regression tests for:
  - missing signature
  - malformed signature
  - valid signature

## Why

The webhook endpoint is publicly reachable through the site redirects, so signature validation must fail closed. Before this fix, a request with no signature header could still trigger the webhook path.

## Testing

- `node --test netlify/functions/webhook-rebuild.test.js`
- `node --check netlify/functions/webhook-rebuild.js`
- `node --check netlify/functions/webhook-rebuild.test.js`
