### PR TITLE
docs(network-chaos-ng): add missing weight field to scenario frontmatters

### DIFF
--- a/content/en/docs/scenarios/network-chaos-ng-scenarios/node-interface-down/_index.md
+++ b/content/en/docs/scenarios/network-chaos-ng-scenarios/node-interface-down/_index.md
@@ -2,6 +2,7 @@
 title: Node Interface Down
 description:
 date: 2017-01-04
+weight: 2
 ---
 Brings one or more network interfaces down on a target node for a configurable duration, then restores them. Can be used to simulate network partitions, NIC failures, or loss of connectivity at the node level.
 

--- a/content/en/docs/scenarios/network-chaos-ng-scenarios/node-network-chaos/_index.md
+++ b/content/en/docs/scenarios/network-chaos-ng-scenarios/node-network-chaos/_index.md
@@ -2,6 +2,7 @@
 title: Node Network Chaos
 description: "Injects network degradation (latency, packet loss, bandwidth) into a target node's network interfaces using Linux tc rules."
 date: 2017-01-04
+weight: 2
 ---
 Injects network degradation (latency, packet loss, bandwidth restriction) into a target node's network interfaces using Linux `tc` (traffic control) rules. Unlike node-network-filter which blocks specific ports via iptables, this module shapes traffic at the interface level. Includes safety checks for existing `tc` rules on the node.
 

--- a/content/en/docs/scenarios/network-chaos-ng-scenarios/node-network-filter/_index.md
+++ b/content/en/docs/scenarios/network-chaos-ng-scenarios/node-network-filter/_index.md
@@ -2,6 +2,7 @@
 title: Node Network Filter
 description:
 date: 2017-01-04
+weight: 2
 ---
 <krkn-hub-scenario id="node-network-filter">
 Creates iptables rules on one or more nodes to block incoming and outgoing traffic on a port in the node network interface. Can be used to block network based services connected to the node or to block inter-node communication.

--- a/content/en/docs/scenarios/network-chaos-ng-scenarios/pod-network-chaos/_index.md
+++ b/content/en/docs/scenarios/network-chaos-ng-scenarios/pod-network-chaos/_index.md
@@ -2,6 +2,7 @@
 title: Pod Network Chaos
 description: "Injects network degradation (latency, packet loss, bandwidth) into a target pod's network interfaces using Linux tc rules."
 date: 2017-01-04
+weight: 2
 ---
 Injects network degradation (latency, packet loss, bandwidth restriction) into a target pod's network interfaces using Linux `tc` (traffic control) rules. Unlike pod-network-filter which blocks specific ports via iptables, this module shapes traffic at the interface level.
 

--- a/content/en/docs/scenarios/network-chaos-ng-scenarios/pod-network-filter/_index.md
+++ b/content/en/docs/scenarios/network-chaos-ng-scenarios/pod-network-filter/_index.md
@@ -2,6 +2,7 @@
 title: Pod Network Filter
 description:
 date: 2017-01-04
+weight: 2
 ---
 <krkn-hub-scenario id="pod-network-filter">
 Creates iptables rules on one or more pods to block incoming and outgoing traffic on a port in the pod network interface. Can be used to block network based services connected to the pod or to block inter-pod communication.

--- a/content/en/docs/scenarios/network-chaos-ng-scenarios/vmi-network-chaos/_index.md
+++ b/content/en/docs/scenarios/network-chaos-ng-scenarios/vmi-network-chaos/_index.md
@@ -2,6 +2,7 @@
 title: VMI Network Chaos
 description:
 date: 2017-01-04
+weight: 2
 ---
 <krkn-hub-scenario id="vmi-network-chaos">
 Injects network degradation into a KubeVirt Virtual Machine Instance (VMI) by shaping traffic on the VM's tap interface inside the virt-launcher network namespace. Supports configurable bandwidth limiting, latency injection, and packet loss. Unlike node or pod network chaos, this scenario targets the tap device that connects QEMU to the bridge, so only the specific VMI is affected without disrupting OVN's BFD heartbeats or other workloads on the same node.

--- a/content/en/docs/scenarios/network-chaos-ng-scenarios/vmi-network-filter/_index.md
+++ b/content/en/docs/scenarios/network-chaos-ng-scenarios/vmi-network-filter/_index.md
@@ -2,6 +2,7 @@
 title: VMI Network Filter
 description:
 date: 2017-01-04
+weight: 2
 ---
 <krkn-hub-scenario id="vmi-network-filter">
 Injects iptables-based network filtering into a KubeVirt Virtual Machine Instance (VMI) by applying INPUT and OUTPUT rules inside the virt-launcher network namespace via nsenter. Supports port and protocol-specific filtering so you can selectively block DNS, SSH, HTTP, or any other traffic without cutting all connectivity. The tap interface (tap0) is targeted directly so only the specific VMI is isolated, leaving OVN's BFD heartbeats and other node workloads unaffected.


### PR DESCRIPTION
Adds `weight: 2` to 7 scenario `_index.md` files under `network-chaos-ng-scenarios/` to match the convention used by other sub-scenario pages (e.g., `hog-scenarios/`).

**Files updated:**
- `node-interface-down/_index.md`
- `node-network-chaos/_index.md`
- `node-network-filter/_index.md`
- `pod-network-chaos/_index.md`
- `pod-network-filter/_index.md`
- `vmi-network-chaos/_index.md`
- `vmi-network-filter/_index.md`

The 5 files from #413 plus 2 additional VMI sibling pages that had the same gap.

Fixes #413