### PR TITLE
fixed the PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,11 @@
 ## Documentation Update
-**Related Feature:** 
+Fixes #<!-- issue number -->
 
-Please include the branch name where you have made changes or added new features/scenario that we need on the website (e.g., `krkn/new_scenario`) in the title of this PR.
+<!--
+  Please include the branch name where you have made changes or added new
+  features/scenario that we need on the website (e.g., `krkn/new_scenario`)
+  in the title of this PR.
+-->
 
-**Changes:** 
-
-Describe the documentation updates made for the feature.
+**Changes:**
+<!-- Describe the documentation updates made for the feature. -->


### PR DESCRIPTION
Fixed the PR template to prevent maintainers manually closing the issue and contributors from manually deleting the line. Now, they can write directly what changes they have made and raise PR. I think, it reduces a bit of friction while raising PR.

Fixes #455