### PR TITLE
fix(docs): correct false Snyk container scanning claim in security.md (#397)

### DIFF
--- a/content/en/docs/security.md
+++ b/content/en/docs/security.md
@@ -113,7 +113,7 @@ Known Weakness. krkn-lib static code analysis should be added to the roadmap.
 
 #### Container image scanning
 
-Our base image on top of which all the tags are build is scanned on the building phase by [Snyk](https://snyk.io) CLI in the CI pipeline.
+Known Weakness. Container image scanning should be added to the roadmap. The `docker-image.yml` CI workflow builds and pushes images but does not currently include a Snyk CLI scan or equivalent vulnerability scanner step.
 
 #### Input validation protocol
 Python's flexible typing has made user input validation a challenge for the Krkn core. To solve this, we've established a new validation protocol between the Krknctl CLI and our container images. By making Krknctl the main entry point for running Krkn, we can now rely on it to ensure all user input is robustly validated.


### PR DESCRIPTION
## Summary

Fixes an inaccurate security claim in the project's self-assessment documentation.

Closes #397

## Problem

`content/en/docs/security.md` line 116 stated:

> Our base image on top of which all the tags are build is scanned on the building phase by Snyk CLI in the CI pipeline.

Checked `docker-image.yml` in `krkn-chaos/krkn` — no Snyk step exists anywhere in that workflow. Images are built and pushed with no vulnerability scanner running.

The security self-assessment is what contributors and adopters read to understand the project's actual security posture. An inaccurate claim here is misleading, especially for organizations evaluating krkn for production use.

## Fix

Replace the false claim with a **Known Weakness** entry — the same pattern already used on lines 109 and 112 of the same file for static analysis gaps that haven't been implemented yet:

**Before:**
```
Our base image on top of which all the tags are build is scanned on the
building phase by Snyk CLI in the CI pipeline.
```

**After:**
```
Known Weakness. Container image scanning should be added to the roadmap.
The `docker-image.yml` CI workflow builds and pushes images but does not
currently include a Snyk CLI scan or equivalent vulnerability scanner step.
```

This is consistent with how the project documents other planned-but-not-yet-implemented security controls.

Made with [Cursor](https://cursor.com)