### PR TITLE
docs: fix http to https in git clone examples in contribution guides

### DIFF
--- a/content/en/docs/cerberus/contribute.md
+++ b/content/en/docs/cerberus/contribute.md
@@ -18,7 +18,7 @@ How to:
 
 In order to submit a change or a PR, please fork the project and follow instructions:
 ```bash
-$ git clone http://github.com/<me>/cerberus
+$ git clone https://github.com/<me>/cerberus
 $ cd cerberus
 $ git checkout -b <branch_name>
 $ <make change>

--- a/content/en/docs/contribution-guidelines/git-pointers.md
+++ b/content/en/docs/contribution-guidelines/git-pointers.md
@@ -20,7 +20,7 @@ How to:
 
 In order to submit a change or a PR, please fork the project and follow instructions:
 ```bash
-$ git clone http://github.com/<me>/krkn-hub
+$ git clone https://github.com/<me>/krkn-hub
 $ cd krkn-hub
 $ git checkout -b <branch_name>
 $ <make change>


### PR DESCRIPTION
## Documentation Update

**Related Feature:** contribution guides

**Changes:**

Fixed the git clone protocol from `http://` to `https://` in two contribution guide pages. Both pages tell new contributors to clone using the insecure protocol. Notably, `git-pointers.md` already uses `https://` correctly for the upstream remote step a few lines below, making the same file inconsistent with itself.

Please refer to #481 for full details.

Closes #481