### PR TITLE
docs: add customapp_pod scenario documentation

### DIFF
--- a/content/en/docs/scenarios/_index.md
+++ b/content/en/docs/scenarios/_index.md
@@ -143,6 +143,15 @@ Many pod scenarios now support the `exclude_label` parameter to protect critical
 </div>
 
 <div class="scenario-card">
+<h3><a href="custom-app-pod/">Custom App Pod</a></h3>
+<span class="scenario-badge">pod_disruption_scenarios</span>
+<p class="scenario-description">Test application resilience by terminating specific application pods using pattern matching</p>
+<div class="cloud-badges">
+<span class="cloud-badge cloud-badge--agnostic">Cloud Agnostic</span>
+</div>
+</div>
+
+<div class="scenario-card">
 <h3><a href="container-scenario/">Container Failures</a></h3>
 <span class="scenario-badge">container_scenarios</span>
 <p class="scenario-description">Injects container failures based on the provided kill signal</p>

--- a/content/en/docs/scenarios/custom-app-pod/_index.md
+++ b/content/en/docs/scenarios/custom-app-pod/_index.md
@@ -1,0 +1,111 @@
+---
+title: Custom App Pod Scenario
+description: Test application resilience by terminating specific application pods using pattern matching
+date: 2024-05-19
+weight: 45
+---
+
+## Overview
+
+The custom app pod scenario tests how your application responds when specific pods are terminated. Unlike generic pod kill scenarios, this scenario lets you target pods by name pattern, making it useful for testing behavior when specific components fail.
+
+## Use Cases
+
+- Test deployment rollout when specific pod instances are killed
+- Verify application logic that depends on pod naming conventions
+- Test multi-replica applications with specialized pod roles
+- Validate monitoring and alerting for specific pod failures
+
+## Scenario Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `namespace_pattern` | regex | Yes | - | Regex pattern to match target namespace |
+| `name_pattern` | regex | Yes | - | Regex pattern to match pod names |
+| `krkn_pod_recovery_time` | integer | No | 120 | Expected pod recovery time in seconds |
+| `timeout` | integer | No | 180 | Timeout for pod termination operation in seconds |
+| `kill` | integer | No | 1 | Number of pods to terminate matching the criteria |
+| `node_label_selector` | string | No | - | Optional: Target pods only on nodes with matching labels |
+| `node_names` | list | No | - | List of specific node names to target pods on |
+
+## Examples
+
+### Target coredns pods in kube-system
+
+This example terminates coredns pods to test DNS resilience:
+
+```yaml
+- id: kill-coredns
+  config:
+    namespace_pattern: "^kube-system$"
+    name_pattern: "coredns.*"
+    krkn_pod_recovery_time: 120
+    timeout: 180
+    kill: 1
+```
+
+### Target custom application pods
+
+Target application-specific pods:
+
+```yaml
+- id: kill-app-pods
+  config:
+    namespace_pattern: "^my-app$"
+    name_pattern: "my-app-worker-.*"
+    krkn_pod_recovery_time: 60
+    kill: 2
+```
+
+### Target pods on specific nodes
+
+Combine with node label selector:
+
+```yaml
+- id: kill-app-worker-nodes
+  config:
+    namespace_pattern: "my-app"
+    name_pattern: "worker.*"
+    node_label_selector: "node-role.kubernetes.io/worker="
+    krkn_pod_recovery_time: 90
+```
+
+## Pattern Matching
+
+Both `namespace_pattern` and `name_pattern` use regex syntax:
+
+- `.` - matches any character
+- `.*` - matches any characters (zero or more)
+- `^` - matches start of string
+- `$` - matches end of string
+- `|` - matches either pattern
+
+Examples:
+- `^kube-system$` - exactly matches "kube-system"
+- `coredns.*` - matches "coredns" followed by anything
+- `worker-[0-9]` - matches "worker-" followed by a digit
+
+## Recovery Expectations
+
+The `krkn_pod_recovery_time` parameter tells krkn how long to wait for pods to recover. Set this based on your deployment configuration:
+
+- Pods with `imagePullPolicy: Always` need more time
+- Deployments with multiple replicas recover faster
+- Stateful services may have longer recovery times
+
+## Related Scenarios
+
+- [Pod Scenario](/docs/scenarios/pod-scenario/) - Kill pods without pattern matching
+- [Node Scenarios](/docs/scenarios/node-scenarios/) - Disrupt entire nodes
+
+{{< tabpane text=true >}}
+  {{< tab header="**Krkn**" lang="krkn" >}}
+{{< readfile file="_tab-krkn.md" >}}
+  {{< /tab >}}
+  {{< tab header="**Krkn-hub**" lang="krkn-hub" >}}
+{{< readfile file="_tab-krkn-hub.md" >}}
+  {{< /tab >}}
+  {{< tab header="**Krknctl**" lang="krknctl" >}}
+{{< readfile file="_tab-krknctl.md" >}}
+  {{< /tab >}}
+{{< /tabpane >}}

--- a/content/en/docs/scenarios/custom-app-pod/_tab-krkn-hub.md
+++ b/content/en/docs/scenarios/custom-app-pod/_tab-krkn-hub.md
@@ -1,0 +1,63 @@
+## krkn-hub
+
+The custom app pod scenario runs via the pod-scenarios krkn-hub container.
+
+If enabling [Cerberus](/docs/cerberus/) to monitor the cluster and pass/fail the scenario post chaos, refer [docs](/docs/cerberus/). Make sure to start it before injecting the chaos and set `CERBERUS_ENABLED` environment variable for the chaos injection container to autoconnect.
+
+```bash
+$ podman run \
+  --name=<container_name> \
+  --net=host \
+  --pull=always \
+  --env-host=true \
+  -v <path-to-kube-config>:/home/krkn/.kube/config:Z \
+  -d containers.krkn-chaos.dev/krkn-chaos/krkn-hub:pod-scenarios
+$ podman logs -f <container_name or container_id> # Streams Kraken logs
+$ podman inspect <container-name or container-id> \
+  --format "{{.State.ExitCode}}" # Outputs exit code which can considered as pass/fail for the scenario
+```
+
+{{% alert title="Note" %}} --env-host: This option is not available with the remote Podman client, including Mac and Windows (excluding WSL2) machines.
+Without the --env-host option you'll have to set each environment variable on the podman command line like  `-e <VARIABLE>=<value>`
+{{% /alert %}}
+
+```bash
+$ docker run $(./get_docker_params.sh) \
+  --name=<container_name> \
+  --net=host \
+  --pull=always \
+  -v <path-to-kube-config>:/home/krkn/.kube/config:Z \
+  -d containers.krkn-chaos.dev/krkn-chaos/krkn-hub:pod-scenarios
+$ docker logs -f <container_name or container_id> # Streams Kraken logs
+$ docker inspect <container-name or container-id> \
+  --format "{{.State.ExitCode}}" # Outputs exit code which can considered as pass/fail for the scenario
+```
+
+{{% alert title="Tip" %}} Because the container runs with a non-root user, ensure the kube config is globally readable before mounting it in the container. You can achieve this with the following commands:
+```kubectl config view --flatten > ~/kubeconfig && chmod 444 ~/kubeconfig && docker run $(./get_docker_params.sh) --name=<container_name> --net=host --pull=always -v ~/kubeconfig:/home/krkn/.kube/config:Z -d containers.krkn-chaos.dev/krkn-chaos/krkn-hub:pod-scenarios``` {{% /alert %}}
+
+#### Supported parameters
+
+The following environment variables can be set on the host running the container to tweak the scenario/faults being injected:
+
+Example if --env-host is used:
+```bash
+export <parameter_name>=<value>
+```
+OR on the command line like example:
+
+```bash
+-e <VARIABLE>=<value>
+```
+
+See list of variables that apply to all scenarios [here](/docs/scenarios/all-scenario-env.md) that can be used/set in addition to these scenario specific variables
+
+Parameter               | Description                                                           | Type   | Default
+----------------------- | --------------------------------------------------------------------- | ------ | -----------------------------------
+NAMESPACE               | Targeted namespace in the cluster ( supports regex )                 | string | openshift-.*
+NAME_PATTERN            | Regex pattern to match pod names                                      | string | .*
+DISRUPTION_COUNT        | Number of pods to terminate                                           | number | 1
+KILL_TIMEOUT            | Timeout to wait for the target pod(s) to be removed in seconds       | number | 180
+EXPECTED_RECOVERY_TIME  | Fails if the pods do not recover within the timeout set              | number | 120
+NODE_LABEL_SELECTOR     | Label of the node(s) to target                                        | string | ""
+NODE_NAMES              | Name of the node(s) to target. Example: ["worker-node-1","master-node-1"] | string | []

--- a/content/en/docs/scenarios/custom-app-pod/_tab-krkn.md
+++ b/content/en/docs/scenarios/custom-app-pod/_tab-krkn.md
@@ -1,0 +1,44 @@
+## krkn
+
+The custom app pod scenario is available in krkn through the plugin-based scenario system.
+
+### Scenario File
+
+Example scenario file: [customapp_pod.yaml](https://github.com/krkn-chaos/krkn/blob/main/scenarios/openshift/customapp_pod.yaml)
+
+### Basic Usage
+
+```yaml
+- id: kill-custom-pods
+  config:
+    namespace_pattern: "my-namespace"
+    name_pattern: "my-app.*"
+    krkn_pod_recovery_time: 120
+    timeout: 180
+    kill: 1
+```
+
+### With Node Targeting
+
+Target pods on specific nodes:
+
+```yaml
+- id: kill-pods-on-workers
+  config:
+    namespace_pattern: "production"
+    name_pattern: "api-.*"
+    node_label_selector: "node-role.kubernetes.io/worker="
+    krkn_pod_recovery_time: 90
+    kill: 2
+```
+
+### Configuration in config.yaml
+
+Add to your main krkn config:
+
+```yaml
+scenarios:
+  - name: custom-app-scenario
+    file: scenarios/openshift/customapp_pod.yaml
+    enabled: true
+```

--- a/content/en/docs/scenarios/custom-app-pod/_tab-krknctl.md
+++ b/content/en/docs/scenarios/custom-app-pod/_tab-krknctl.md
@@ -1,0 +1,45 @@
+## krknctl
+
+Run the custom app pod scenario with krknctl:
+
+```bash
+krknctl scenario run custom-app-pod \
+  --namespace-pattern "^kube-system$" \
+  --name-pattern "coredns.*" \
+  --krkn-pod-recovery-time 120 \
+  --timeout 180 \
+  --kill 1
+```
+
+### Parameters
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--namespace-pattern` | string | Yes | Regex pattern for target namespace |
+| `--name-pattern` | string | Yes | Regex pattern for pod names |
+| `--krkn-pod-recovery-time` | integer | No | Expected recovery time (default: 120s) |
+| `--timeout` | integer | No | Operation timeout (default: 180s) |
+| `--kill` | integer | No | Number of pods to kill (default: 1) |
+| `--node-label-selector` | string | No | Target pods on specific nodes |
+| `--node-names` | string | No | Comma-separated list of specific node names to target |
+
+### Examples
+
+Kill one coredns pod:
+
+```bash
+krknctl scenario run custom-app-pod \
+  --namespace-pattern "^kube-system$" \
+  --name-pattern "coredns.*" \
+  --kill 1
+```
+
+Kill two app worker pods with longer recovery time:
+
+```bash
+krknctl scenario run custom-app-pod \
+  --namespace-pattern "production" \
+  --name-pattern "worker-.*" \
+  --krkn-pod-recovery-time 150 \
+  --kill 2
+```

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1208,6 +1208,7 @@ $ krknctl run pod-scenarios --kubeconfig ~/.kube/config
           </div>
           <ul class="scenario-category__list">
             <li><a href="/docs/scenarios/pod-scenario/">Pod Failures</a></li>
+            <li><a href="/docs/scenarios/custom-app-pod/">Custom App Pod</a></li>
             <li><a href="/docs/scenarios/container-scenario/">Container Kill</a></li>
             <li><a href="/docs/scenarios/kubevirt-vm-outage-scenario/">KubeVirt VM Outage</a></li>
           </ul>


### PR DESCRIPTION
## Documentation Update

**Related Feature:** krkn/scenarios/openshift/customapp_pod

**Changes:**

Added comprehensive documentation for the customapp_pod scenario to enable users to test application resilience by terminating pods matched by name and namespace patterns.

**Documentation includes:**
- Parameter descriptions and types (namespace_pattern, name_pattern, krkn_pod_recovery_time, timeout, kill, node_label_selector, node_names)
- Usage examples across all three platforms (krkn, krknctl, krkn-hub)
- Pattern matching guidance with regex examples and best practices
- Real-world use cases (DNS resilience testing, multi-replica applications, node-specific targeting)
- Recovery time expectations based on deployment configuration

**Why this matters:**
The customapp_pod scenario was fully implemented and actively used in the test suite (#485) but had zero documentation. Users had to read the source code to discover how to use it. This PR resolves that gap and improves user experience.

Fixes #485