### PR TITLE
docs: add pod_path_provisioner scenario documentation

### DIFF
--- a/content/en/docs/scenarios/_index.md
+++ b/content/en/docs/scenarios/_index.md
@@ -165,6 +165,15 @@ Many pod scenarios now support the `exclude_label` parameter to protect critical
 </div>
 
 <div class="scenario-card">
+<h3><a href="pod-path-provisioner/">Pod Path Provisioner</a></h3>
+<span class="scenario-badge">pod_disruption_scenarios</span>
+<p class="scenario-description">Test kind cluster storage resilience by terminating the local-path-provisioner pod</p>
+<div class="cloud-badges">
+<span class="cloud-badge cloud-badge--agnostic">Cloud Agnostic</span>
+</div>
+</div>
+
+<div class="scenario-card">
 <h3><a href="container-scenario/">Container Failures</a></h3>
 <span class="scenario-badge">container_scenarios</span>
 <p class="scenario-description">Injects container failures based on the provided kill signal</p>

--- a/content/en/docs/scenarios/pod-path-provisioner/_index.md
+++ b/content/en/docs/scenarios/pod-path-provisioner/_index.md
@@ -1,0 +1,77 @@
+---
+title: Pod Path Provisioner Scenario
+description: Test kind cluster storage resilience by terminating the local-path-provisioner pod
+date: 2026-05-19
+weight: 47
+---
+
+## Overview
+
+The pod path provisioner scenario kills the `local-path-provisioner` pod in kind clusters to test storage provisioner recovery. This is relevant for kind-based CI environments and local development setups that use PVC-backed storage.
+
+## Use Cases
+
+- Validate local-path-provisioner restarts correctly after failure
+- Test PVC recovery when the storage provisioner is unavailable
+- Check that storage-dependent workloads handle provisioner downtime
+
+## Scenario Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `namespace_pattern` | regex | Yes | - | Regex pattern to match the target namespace |
+| `label_selector` | string | Yes | - | Label selector to match target pods |
+| `krkn_pod_recovery_time` | integer | No | 120 | Expected pod recovery time in seconds |
+| `timeout` | integer | No | 180 | Timeout for pod termination in seconds |
+| `kill` | integer | No | 1 | Number of pods to terminate |
+| `node_label_selector` | string | No | - | Target pods only on nodes with matching labels |
+| `node_names` | list | No | - | List of specific node names to target pods on |
+
+## Examples
+
+### Kill the local-path-provisioner pod
+
+```yaml
+- id: kill-path-provisioner
+  config:
+    namespace_pattern: "local-path-storage"
+    label_selector: "app=local-path-provisioner"
+    krkn_pod_recovery_time: 20
+    kill: 1
+```
+
+### Target pods on a specific node
+
+```yaml
+- id: kill-path-provisioner-on-node
+  config:
+    namespace_pattern: "local-path-storage"
+    label_selector: "app=local-path-provisioner"
+    node_label_selector: "kubernetes.io/hostname=kind-control-plane"
+    krkn_pod_recovery_time: 20
+    kill: 1
+```
+
+## Recovery Expectations
+
+The `krkn_pod_recovery_time` parameter controls how long krkn waits for the pod to recover. Set this based on your kind cluster resources:
+
+- A lightly loaded kind cluster recovers in about 20 seconds
+- Increase this value if the cluster is under load or resource-constrained
+
+## Related Scenarios
+
+- [Pod Scenario](/docs/scenarios/pod-scenario/) - Generic pod kill by label for any namespace
+- [Custom App Pod](/docs/scenarios/custom-app-pod/) - Kill pods by name pattern
+
+{{< tabpane text=true >}}
+  {{< tab header="**Krkn**" lang="krkn" >}}
+{{< readfile file="_tab-krkn.md" >}}
+  {{< /tab >}}
+  {{< tab header="**Krkn-hub**" lang="krkn-hub" >}}
+{{< readfile file="_tab-krkn-hub.md" >}}
+  {{< /tab >}}
+  {{< tab header="**Krknctl**" lang="krknctl" >}}
+{{< readfile file="_tab-krknctl.md" >}}
+  {{< /tab >}}
+{{< /tabpane >}}

--- a/content/en/docs/scenarios/pod-path-provisioner/_tab-krkn-hub.md
+++ b/content/en/docs/scenarios/pod-path-provisioner/_tab-krkn-hub.md
@@ -1,0 +1,63 @@
+## krkn-hub
+
+The pod path provisioner scenario runs via the pod-scenarios krkn-hub container.
+
+If enabling [Cerberus](/docs/cerberus/) to monitor the cluster and pass/fail the scenario post chaos, refer [docs](/docs/cerberus/). Make sure to start it before injecting the chaos and set `CERBERUS_ENABLED` environment variable for the chaos injection container to autoconnect.
+
+```bash
+$ podman run \
+  --name=<container_name> \
+  --net=host \
+  --pull=always \
+  --env-host=true \
+  -v <path-to-kube-config>:/home/krkn/.kube/config:Z \
+  -d containers.krkn-chaos.dev/krkn-chaos/krkn-hub:pod-scenarios
+$ podman logs -f <container_name or container_id> # Streams Kraken logs
+$ podman inspect <container-name or container-id> \
+  --format "{{.State.ExitCode}}" # Outputs exit code which can considered as pass/fail for the scenario
+```
+
+{{% alert title="Note" %}} --env-host: This option is not available with the remote Podman client, including Mac and Windows (excluding WSL2) machines.
+Without the --env-host option you'll have to set each environment variable on the podman command line like  `-e <VARIABLE>=<value>`
+{{% /alert %}}
+
+```bash
+$ docker run $(./get_docker_params.sh) \
+  --name=<container_name> \
+  --net=host \
+  --pull=always \
+  -v <path-to-kube-config>:/home/krkn/.kube/config:Z \
+  -d containers.krkn-chaos.dev/krkn-chaos/krkn-hub:pod-scenarios
+$ docker logs -f <container_name or container_id> # Streams Kraken logs
+$ docker inspect <container-name or container-id> \
+  --format "{{.State.ExitCode}}" # Outputs exit code which can considered as pass/fail for the scenario
+```
+
+{{% alert title="Tip" %}} Because the container runs with a non-root user, ensure the kube config is globally readable before mounting it in the container. You can achieve this with the following commands:
+```kubectl config view --flatten > ~/kubeconfig && chmod 444 ~/kubeconfig && docker run $(./get_docker_params.sh) --name=<container_name> --net=host --pull=always -v ~/kubeconfig:/home/krkn/.kube/config:Z -d containers.krkn-chaos.dev/krkn-chaos/krkn-hub:pod-scenarios``` {{% /alert %}}
+
+#### Supported parameters
+
+The following environment variables can be set on the host running the container to tweak the scenario/faults being injected:
+
+Example if --env-host is used:
+```bash
+export <parameter_name>=<value>
+```
+OR on the command line like example:
+
+```bash
+-e <VARIABLE>=<value>
+```
+
+See list of variables that apply to all scenarios [here](/docs/scenarios/all-scenario-env.md) that can be used/set in addition to these scenario specific variables
+
+Parameter               | Description                                                           | Type   | Default
+----------------------- | --------------------------------------------------------------------- | ------ | -----------------------------------
+NAMESPACE               | Targeted namespace in the cluster ( supports regex )                 | string | openshift-.*
+POD_LABEL               | Label selector to match target pods                                   | string | ""
+DISRUPTION_COUNT        | Number of pods to terminate                                           | number | 1
+KILL_TIMEOUT            | Timeout to wait for the target pod(s) to be removed in seconds       | number | 180
+EXPECTED_RECOVERY_TIME  | Fails if the pods do not recover within the timeout set              | number | 120
+NODE_LABEL_SELECTOR     | Label of the node(s) to target                                        | string | ""
+NODE_NAMES              | Name of the node(s) to target. Example: ["worker-node-1","master-node-1"] | string | []

--- a/content/en/docs/scenarios/pod-path-provisioner/_tab-krkn.md
+++ b/content/en/docs/scenarios/pod-path-provisioner/_tab-krkn.md
@@ -1,0 +1,29 @@
+## krkn
+
+The pod path provisioner scenario is available in krkn through the plugin-based scenario system.
+
+### Scenario File
+
+Example scenario file: [pod_path_provisioner.yml](https://github.com/krkn-chaos/krkn/blob/main/scenarios/kind/pod_path_provisioner.yml)
+
+### Basic Usage
+
+```yaml
+- id: kill-path-provisioner
+  config:
+    namespace_pattern: "local-path-storage"
+    label_selector: "app=local-path-provisioner"
+    krkn_pod_recovery_time: 20
+    kill: 1
+```
+
+### Configuration in config.yaml
+
+Add to your main krkn config:
+
+```yaml
+kraken:
+  chaos_scenarios:
+    - pod_disruption_scenarios:
+        - scenarios/kind/pod_path_provisioner.yml
+```

--- a/content/en/docs/scenarios/pod-path-provisioner/_tab-krknctl.md
+++ b/content/en/docs/scenarios/pod-path-provisioner/_tab-krknctl.md
@@ -1,0 +1,44 @@
+## krknctl
+
+Run the pod path provisioner scenario with krknctl:
+
+```bash
+krknctl run pod-scenarios \
+  --namespace "local-path-storage" \
+  --pod-label "app=local-path-provisioner" \
+  --expected-recovery-time 20 \
+  --disruption-count 1
+```
+
+### Parameters
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--namespace` | string | Yes | Targeted namespace (supports regex) |
+| `--pod-label` | string | Yes | Label selector to match target pods |
+| `--expected-recovery-time` | integer | No | Expected recovery time in seconds (default: 120) |
+| `--disruption-count` | integer | No | Number of pods to kill (default: 1) |
+| `--kill-timeout` | integer | No | Timeout for pod removal in seconds (default: 180) |
+| `--node-label-selector` | string | No | Target pods on nodes with this label |
+| `--node-names` | string | No | Comma-separated list of specific node names to target |
+
+### Examples
+
+Kill the local-path-provisioner pod:
+
+```bash
+krknctl run pod-scenarios \
+  --namespace "local-path-storage" \
+  --pod-label "app=local-path-provisioner" \
+  --disruption-count 1
+```
+
+Kill provisioner pod with longer recovery window:
+
+```bash
+krknctl run pod-scenarios \
+  --namespace "local-path-storage" \
+  --pod-label "app=local-path-provisioner" \
+  --expected-recovery-time 60 \
+  --disruption-count 1
+```

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1175,6 +1175,7 @@ $ krknctl run pod-scenarios --kubeconfig ~/.kube/config
           </div>
           <ul class="scenario-category__list">
             <li><a href="/docs/scenarios/pod-scenario/">Pod Failures</a></li>
+            <li><a href="/docs/scenarios/pod-path-provisioner/">Pod Path Provisioner</a></li>
             <li><a href="/docs/scenarios/container-scenario/">Container Kill</a></li>
             <li><a href="/docs/scenarios/kubevirt-vm-outage-scenario/">KubeVirt VM Outage</a></li>
           </ul>


### PR DESCRIPTION
Fixes #487

Adds documentation for the `pod_path_provisioner` scenario, which kills the `local-path-provisioner` pod in kind clusters to test storage provisioner resilience. The scenario exists in the krkn repo but had no documentation on the website.

## Documentation Update
**Related Feature:** `main` branch, [`scenarios/kind/pod_path_provisioner.yml`](https://github.com/krkn-chaos/krkn/blob/main/scenarios/kind/pod_path_provisioner.yml)

**Changes:**
- Add `content/en/docs/scenarios/pod-path-provisioner/` with scenario overview, use cases, and parameter reference table
- Add krkn YAML configuration examples with label selector usage
- Add krkn-hub Docker container environment variables and supported parameters
- Add krknctl CLI usage with example commands and flag reference
- Add scenario card on the scenarios landing page
- Add link under Pod and Container scenarios on the homepage


