### PR TITLE
docs: Fix broken links and duplicate text in node-scenarios page (#462)

### DIFF
--- a/content/en/docs/scenarios/node-scenarios/_index.md
+++ b/content/en/docs/scenarios/node-scenarios/_index.md
@@ -25,17 +25,17 @@ The following node chaos scenarios are supported:
 11. **node_disk_detach_attach_scenario**: Scenario to detach and reattach disks (only for baremetals).
 
 ## Clouds
-Supported cloud supported:
-- [AWS](node-scenarios-krkn.md#aws)
-- [Azure](node-scenarios-krkn.md#azure)
-- [OpenStack](node-scenarios-krkn.md#openstack)
-- [BareMetal](node-scenarios-krkn.md#baremetal)
-- [GCP](node-scenarios-krkn.md#gcp)
-- [VMware](node-scenarios-krkn.md#vmware)
-- [Alibaba](node-scenarios-krkn.md#alibaba)
-- [Docker](node-scenarios-krkn.md#docker)
-- [IBMCloud](node-scenarios-krkn.md#ibmcloud)
-- [IBMCloud Power](node-scenarios-krkn.md#ibmcloud-power)
+Supported cloud providers:
+- [AWS](#aws)
+- [Azure](#azure)
+- [OpenStack](#openstack)
+- [BareMetal](#baremetal)
+- [GCP](#gcp)
+- [VMware](#vmware)
+- [Alibaba](#alibaba)
+- [Docker](#docker)
+- [IBMCloud](#ibmcloud)
+- [IBMCloud Power](#ibmcloud-power)
 
 {{% alert title="Note" %}}If the node does not recover from the node_crash_scenario injection, reboot the node to get it back to Ready state. {{% /alert %}}
 


### PR DESCRIPTION
Fixes #462

## Documentation Update
**Related Feature:** 
NA

Please include the branch name where you have made changes or added new features/scenario that we need on the website (e.g., `krkn/new_scenario`) in the title of this PR.
**Branch:** `fix/node-scenarios-docs`

**Changes:** 
Fixed two issues on the node-scenarios documentation page:

1. The cloud provider links (AWS, Azure, GCP, etc.) in the Clouds section were broken — they pointed to `node-scenarios-krkn.md#<cloud>` causing 404s. Updated them to use proper anchor references (`#<cloud>`) so they jump to the correct section on the same page.

2. Fixed typo "Supported cloud supported:" → "Supported cloud providers:"


**Demo:**
https://github.com/user-attachments/assets/88b7238c-de5d-41c1-ac5e-931cd1847618
