### PR TITLE
update installation links to krkn-chaos org

### DIFF
--- a/content/en/docs/cerberus/installation.md
+++ b/content/en/docs/cerberus/installation.md
@@ -16,9 +16,9 @@ Following ways are supported to run Cerberus:
 
 
 ## Git
-Pick the latest stable release to install [here](https://github.com/redhat-chaos/cerberus/releases/).
+Pick the latest stable release to install [here](https://github.com/krkn-chaos/cerberus/releases/).
 ```bash
-$ git clone https://github.com/redhat-chaos/cerberus.git --branch <release>
+$ git clone https://github.com/krkn-chaos/cerberus.git --branch <release>
 ```
 
 ### Install the dependencies
@@ -28,14 +28,14 @@ $ pip3 install -r requirements.txt
 ```
 
 ### Configure and Run
-Setup the [config](https://github.com/redhat-chaos/cerberus/tree/master/config) according to your requirements. Information on the available options can be found at [usage](usage.md).
+Setup the [config](https://github.com/krkn-chaos/cerberus/tree/main/config) according to your requirements. Information on the available options can be found at [usage](usage.md).
 
 #### Run
 ```bash
 $ python3 start_cerberus.py --config <config_file_location>
 ```
 
-**NOTE**: When config file location is not passed, default [config](https://github.com/redhat-chaos/cerberus/tree/master/config) is used.
+**NOTE**: When config file location is not passed, default [config](https://github.com/krkn-chaos/cerberus/tree/main/config) is used.
 
 
 ## Python Package
@@ -48,40 +48,40 @@ $ pip3 install cerberus-client
 ```
 
 ### Configure and Run
-Setup the [config](https://github.com/redhat-chaos/cerberus/tree/master/config) according to your requirements. Information on the available options can be found at [usage](usage.md).
+Setup the [config](https://github.com/krkn-chaos/cerberus/tree/main/config) according to your requirements. Information on the available options can be found at [usage](usage.md).
 
 #### Run
 ```bash
 $ cerberus_client -c <config_file_location>`
 ```
-{{% alert title="Note" %}}When config_file_location is not passed, default [config](https://github.com/redhat-chaos/cerberus/tree/master/config) is used.{{% /alert %}}
+{{% alert title="Note" %}}When config_file_location is not passed, default [config](https://github.com/krkn-chaos/cerberus/tree/main/config) is used.{{% /alert %}}
 {{% alert title="Note" %}}It's recommended to run Cerberus either using the containerized  or github version to be able to use the latest enhancements and fixes.{{% /alert %}}
 
 ## Containerized version
 
 Assuming docker ( 17.05 or greater with multi-build support ) is installed on the host, run:
 ```bash
-$ docker pull quay.io/redhat-chaos/cerberus
-# Setup the [config](https://github.com/redhat-chaos/cerberus/tree/master/config) according to your requirements. Information on the available options can be found at [usage](usage.md).
+$ docker pull quay.io/krkn-chaos/cerberus
+# Setup the [config](https://github.com/krkn-chaos/cerberus/tree/main/config) according to your requirements. Information on the available options can be found at [usage](usage.md).
 $ docker run \
   --name=cerberus \
   --net=host \
   -v <path_to_kubeconfig>:/root/.kube/config \
   -v <path_to_cerberus_config>:/root/cerberus/config/config.yaml \
-  -d quay.io/redhat-chaos/cerberus:latest
+  -d quay.io/krkn-chaos/cerberus:latest
 $ docker logs -f cerberus
 ```
 
 Similarly, podman can be used to achieve the same:
 ```bash
-$ podman pull quay.io/redhat-chaos/cerberus
-# Setup the [config](https://github.com/redhat-chaos/cerberus/tree/master/config) according to your requirements. Information on the available options can be found at [usage](usage.md).
+$ podman pull quay.io/krkn-chaos/cerberus
+# Setup the [config](https://github.com/krkn-chaos/cerberus/tree/main/config) according to your requirements. Information on the available options can be found at [usage](usage.md).
 $ podman run \
   --name=cerberus \
   --net=host \
   -v <path_to_kubeconfig>:/root/.kube/config:Z \
   -v <path_to_cerberus_config>:/root/cerberus/config/config.yaml:Z \
-  -d quay.io/redhat-chaos/cerberus:latest
+  -d quay.io/krkn-chaos/cerberus:latest
 $ podman logs -f cerberus
 ```
 
@@ -89,8 +89,8 @@ The go/no-go signal ( True or False ) gets published at http://`<hostname>`:8080
 
 {{% alert title="Note" %}}The report is generated at /root/cerberus/cerberus.report inside the container, it can mounted to a directory on the host in case we want to capture it.{{% /alert %}}
 
-If you want to build your own Cerberus image, see [here](https://github.com/redhat-chaos/cerberus/tree/master/containers/build_own_image-README.md).
+If you want to build your own Cerberus image, see [here](https://github.com/krkn-chaos/cerberus/tree/main/containers/build_own_image-README.md).
 To run Cerberus on Power (ppc64le) architecture, build and run a containerized version by following the instructions given [here](https://github.com/cloud-bulldozer/cerberus/tree/master/containers/build_own_image-README.md).
 
 ## Run containerized Cerberus as a Kubernetes/OpenShift deployment
-Refer to the [instructions](https://github.com/redhat-chaos/cerberus/blob/master/containers/README.md#cerberus-as-a-kubernetesopenshift-application) for information on how to run cerberus as a Kubernetes or OpenShift application.
+Refer to the [instructions](https://github.com/krkn-chaos/cerberus/blob/main/containers/README.md#cerberus-as-a-kubernetesopenshift-application) for information on how to run cerberus as a Kubernetes or OpenShift application.


### PR DESCRIPTION
Fixes #492

The cerberus installation guide had 12 references still pointing to the old `redhat-chaos` org, both for GitHub links and container images. Anyone following the docs would clone from a fork and pull an image that may not have the latest fixes.

## Changes

- Replaced 8 GitHub links from `github.com/redhat-chaos/cerberus` to `github.com/krkn-chaos/cerberus`
- Replaced 4 container image references from `quay.io/redhat-chaos/cerberus` to `quay.io/krkn-chaos/cerberus`
- Updated `master` branch references to `main` in all affected URLs

For more details please refer to the issue #492.