### PR TITLE
update stale redhat-chaos org links across core documentation

### DIFF
--- a/content/en/docs/chaos-testing-guide/_index.md
+++ b/content/en/docs/chaos-testing-guide/_index.md
@@ -80,13 +80,13 @@ We want to look at this in terms of CPU, Memory, Disk, Throughput, Network etc.
 
 
 ### Tooling
-Now that we looked at the best practices, In this section, we will go through how [Kraken](https://github.com/redhat-chaos/krkn) - a chaos testing framework can help test the resilience of Kubernetes and make sure the applications and services are following the best practices.
+Now that we looked at the best practices, In this section, we will go through how [Kraken](https://github.com/krkn-chaos/krkn) - a chaos testing framework can help test the resilience of Kubernetes and make sure the applications and services are following the best practices.
 
 #### Cluster recovery checks, metrics evaluation and pass/fail criteria
 - Most of the scenarios have built in checks to verify if the targeted component recovered from the failure after the specified duration of time but there might be cases where other components might have an impact because of a certain failure and it’s extremely important to make sure that the system/application is healthy as a whole post chaos. This is exactly where [Cerberus](/docs/cerberus) comes to the rescue.
 If the monitoring tool, cerberus is enabled it will consume the signal and continue running chaos or not based on that signal.
 
-- Apart from checking the recovery and cluster health status, it’s equally important to evaluate the performance metrics like latency, resource usage spikes, throughput, etcd health like disk fsync, leader elections etc. To help with this, Kraken has a way to evaluate promql expressions from the incluster prometheus and set the exit status to 0 or 1 based on the severity set for each of the query. Details on how to use this feature can be found [here](https://github.com/redhat-chaos/krkn#alerts).
+- Apart from checking the recovery and cluster health status, it’s equally important to evaluate the performance metrics like latency, resource usage spikes, throughput, etcd health like disk fsync, leader elections etc. To help with this, Kraken has a way to evaluate promql expressions from the incluster prometheus and set the exit status to 0 or 1 based on the severity set for each of the query. Details on how to use this feature can be found [here](https://github.com/krkn-chaos/krkn#alerts).
 
 - The overall pass or fail of kraken is based on the recovery of the specific component (within a certain amount of time), the cerberus health signal which tracks the health of the entire cluster and metrics evaluation from incluster prometheus.
 
@@ -249,7 +249,7 @@ oc apply -f https://github.com/startxfr/tekton-catalog/raw/stable/task/kraken-sc
 ```
 
 Then you must change content of `kraken-aws-creds` secret, `kraken-kubeconfig` and `kraken-config-example` configMap
-to reflect your cluster configuration. Refer to the [kraken configuration](https://github.com/redhat-chaos/krkn/blob/main/config/config.yaml)
+to reflect your cluster configuration. Refer to the [kraken configuration](https://github.com/krkn-chaos/krkn/blob/main/config/config.yaml)
 and [configuration examples](https://github.com/startxfr/tekton-catalog/blob/stable/task/kraken-scenario/0.1/samples/) 
 for details on how to configure theses resources.
 

--- a/content/en/docs/installation/krkn-hub.md
+++ b/content/en/docs/installation/krkn-hub.md
@@ -28,7 +28,7 @@ Docker is also supported but all variables you want to set (separate from the de
 
 You can take advantage of the [get_docker_params.sh](https://github.com/krkn-chaos/krkn-hub/blob/main/get_docker_params.sh) script to create your parameters string This will take all environment variables and put them in the form "-e =" to make a long string that can get passed to the command
 
-For example: `docker run $(./get_docker_params.sh) --net=host -v <path-to-kube-config>:/home/krkn/.kube/config:Z -d quay.io/redhat-chaos/krkn-hub:power-outages`
+For example: `docker run $(./get_docker_params.sh) --net=host -v <path-to-kube-config>:/home/krkn/.kube/config:Z -d quay.io/krkn-chaos/krkn-hub:power-outages`
 
 {{% alert title="Tip" %}}Because the container runs with a non-root user, ensure the kube config is globally readable before mounting it in the container. You can achieve this with the following commands: `kubectl config view --flatten > ~/kubeconfig && chmod 444 ~/kubeconfig && docker run $(./get_docker_params.sh) --name=<container_name> --net=host -v ~/kubeconfig:/home/krkn/.kube/config:Z -d containers.krkn-chaos.dev/krkn-chaos/krkn-hub:<scenario>` {{% /alert %}}
 

--- a/content/en/docs/krkn/SLOs_validation.md
+++ b/content/en/docs/krkn/SLOs_validation.md
@@ -17,7 +17,7 @@ performance_monitoring:
 ```
 
 ### Validation and alerting based on the queries defined by the user during chaos
-Takes PromQL queries as input and modifies the return code of the run to determine pass/fail. It's especially useful in case of automated runs in CI where user won't be able to monitor the system. This feature can be enabled in the [config](https://github.com/redhat-chaos/krkn/blob/main/config/config.yaml) by setting the following:
+Takes PromQL queries as input and modifies the return code of the run to determine pass/fail. It's especially useful in case of automated runs in CI where user won't be able to monitor the system. This feature can be enabled in the [config](https://github.com/krkn-chaos/krkn/blob/main/config/config.yaml) by setting the following:
 
 ```yaml
 performance_monitoring:
@@ -28,7 +28,7 @@ performance_monitoring:
 ```
 
 #### Alert profile
-A couple of [alert profiles](https://github.com/redhat-chaos/krkn/tree/main/config) [alerts](https://github.com/redhat-chaos/krkn/blob/main/config/alerts.yaml) are shipped by default and can be tweaked to add more queries to alert on. User can provide a URL or path to the file in the [config](https://github.com/redhat-chaos/krkn/blob/main/config/config.yaml). The following are a few alerts examples:
+A couple of [alert profiles](https://github.com/krkn-chaos/krkn/tree/main/config) [alerts](https://github.com/krkn-chaos/krkn/blob/main/config/alerts.yaml) are shipped by default and can be tweaked to add more queries to alert on. User can provide a URL or path to the file in the [config](https://github.com/krkn-chaos/krkn/blob/main/config/config.yaml). The following are a few alerts examples:
 
 ```yaml
 - expr: avg_over_time(histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket[2m]))[5m:]) > 0.01
@@ -54,7 +54,7 @@ critical: Prints a fatal message with the alarm description to stdout and exits 
 ```
 
 #### Metrics Profile
-A couple of [metric profiles](https://github.com/redhat-chaos/krkn/tree/main/config), [metrics.yaml](https://github.com/redhat-chaos/krkn/blob/main/config/metrics.yaml), and [metrics-aggregated.yaml](https://github.com/redhat-chaos/krkn/blob/main/config/metrics-aggregated.yaml) are shipped by default and can be tweaked to add more metrics to capture during the run. The following are the API server metrics for example:
+A couple of [metric profiles](https://github.com/krkn-chaos/krkn/tree/main/config), [metrics.yaml](https://github.com/krkn-chaos/krkn/blob/main/config/metrics.yaml), and [metrics-aggregated.yaml](https://github.com/krkn-chaos/krkn/blob/main/config/metrics-aggregated.yaml) are shipped by default and can be tweaked to add more metrics to capture during the run. The following are the API server metrics for example:
 
 ```yaml
 metrics:

--- a/content/en/docs/krkn/config.md
+++ b/content/en/docs/krkn/config.md
@@ -5,9 +5,9 @@ weight: 1
 ---
 
 # Config
-Set the scenarios to inject and the tunings like duration to wait between each scenario in the config file located at [config/config.yaml](https://github.com/redhat-chaos/krkn/blob/main/config/config.yaml).
+Set the scenarios to inject and the tunings like duration to wait between each scenario in the config file located at [config/config.yaml](https://github.com/krkn-chaos/krkn/blob/main/config/config.yaml).
 
-**NOTE**: [config](https://github.com/redhat-chaos/krkn/blob/main/config/config_performance.yaml) can be used if leveraging the [automated way](https://github.com/redhat-chaos/krkn#setting-up-infrastructure-dependencies) to install the infrastructure pieces.
+**NOTE**: [config](https://github.com/krkn-chaos/krkn/blob/main/config/config_performance.yaml) can be used if leveraging the [automated way](https://github.com/krkn-chaos/krkn#setting-up-infrastructure-dependencies) to install the infrastructure pieces.
 
 Config components:
 * [Kraken](#kraken)

--- a/content/en/docs/managedcluster_scenarios.md
+++ b/content/en/docs/managedcluster_scenarios.md
@@ -13,7 +13,7 @@ The following ManagedCluster chaos scenarios are supported:
 5. **stop_klusterlet_scenario**: Scenario to stop the klusterlet of the ManagedCluster instance.
 6. **stop_start_klusterlet_scenario**: Scenario to stop and start the klusterlet of the ManagedCluster instance.
 
-ManagedCluster scenarios can be injected by placing the ManagedCluster scenarios config files under `managedcluster_scenarios` option in the Kraken config. Refer to [managedcluster_scenarios_example](https://github.com/redhat-chaos/krkn/blob/main/scenarios/kube/managedcluster_scenarios_example.yml) config file.
+ManagedCluster scenarios can be injected by placing the ManagedCluster scenarios config files under `managedcluster_scenarios` option in the Kraken config. Refer to [managedcluster_scenarios_example](https://github.com/krkn-chaos/krkn/blob/main/scenarios/kube/managedcluster_scenarios_example.yml) config file.
 
 ```bash
 managedcluster_scenarios:

--- a/content/en/docs/rollback-scenarios/_index.md
+++ b/content/en/docs/rollback-scenarios/_index.md
@@ -123,7 +123,7 @@ Example Output:
 
 There are two configuration options for rollback scenarios in the `kraken` section of the configuration file: `auto_rollback` and `rollback_versions_directory`.
 
-By default, these options are set as follows and can be overridden in [config/config.yaml](https://github.com/redhat-chaos/krkn/blob/main/config/config.yaml) file.
+By default, these options are set as follows and can be overridden in [config/config.yaml](https://github.com/krkn-chaos/krkn/blob/main/config/config.yaml) file.
 
 ```yaml
 kraken:

--- a/content/en/docs/scenarios/managed-cluster-scenario/managed-cluster-scenario.md
+++ b/content/en/docs/scenarios/managed-cluster-scenario/managed-cluster-scenario.md
@@ -18,7 +18,7 @@ The following ManagedCluster chaos scenarios are supported:
 5. **stop_klusterlet_scenario**: Scenario to stop the klusterlet of the ManagedCluster instance.
 6. **stop_start_klusterlet_scenario**: Scenario to stop and start the klusterlet of the ManagedCluster instance.
 
-ManagedCluster scenarios can be injected by placing the ManagedCluster scenarios config files under `managedcluster_scenarios` option in the Kraken config. Refer to [managedcluster_scenarios_example](https://github.com/redhat-chaos/krkn/blob/main/scenarios/kube/managedcluster_scenarios_example.yml) config file.
+ManagedCluster scenarios can be injected by placing the ManagedCluster scenarios config files under `managedcluster_scenarios` option in the Kraken config. Refer to [managedcluster_scenarios_example](https://github.com/krkn-chaos/krkn/blob/main/scenarios/kube/managedcluster_scenarios_example.yml) config file.
 
 ```yaml
 managedcluster_scenarios:

--- a/content/en/docs/scenarios/syn-flood-scenario/_tab-krkn-hub.md
+++ b/content/en/docs/scenarios/syn-flood-scenario/_tab-krkn-hub.md
@@ -3,7 +3,7 @@ This scenario simulates a user-defined surge of TCP SYN requests directed at one
 For more details, please refer to the following [documentation](https://github.com/krkn-chaos/krkn-hub/blob/main/docs/syn-flood.md).
 
 #### Run
-If enabling [Cerberus](https://github.com/krkn-chaos/krkn#kraken-scenario-passfail-criteria-and-report) to monitor the cluster and pass/fail the scenario post chaos, refer [docs](https://github.com/redhat-chaos/krkn-hub/tree/main/docs/cerberus.md). Make sure to start it before injecting the chaos and set `CERBERUS_ENABLED` environment variable for the chaos injection container to autoconnect.
+If enabling [Cerberus](https://github.com/krkn-chaos/krkn#kraken-scenario-passfail-criteria-and-report) to monitor the cluster and pass/fail the scenario post chaos, refer [docs](https://github.com/krkn-chaos/krkn-hub/tree/main/docs/cerberus.md). Make sure to start it before injecting the chaos and set `CERBERUS_ENABLED` environment variable for the chaos injection container to autoconnect.
 
 ```bash
 $ podman run --name=<container_name> \

--- a/content/en/docs/scenarios/zone-outage-scenarios/_tab-krkn.md
+++ b/content/en/docs/scenarios/zone-outage-scenarios/_tab-krkn.md
@@ -1,4 +1,4 @@
-Zone outage can be injected by placing the zone_outage config file under zone_outages option in the [kraken config](https://github.com/redhat-chaos/krkn/blob/main/config/config.yaml). Refer to [zone_outage_scenario](https://github.com/krkn-chaos/krkn/blob/main/scenarios/openshift/zone_outage.yaml) config file for the parameters that need to be defined.
+Zone outage can be injected by placing the zone_outage config file under zone_outages option in the [kraken config](https://github.com/krkn-chaos/krkn/blob/main/config/config.yaml). Refer to [zone_outage_scenario](https://github.com/krkn-chaos/krkn/blob/main/scenarios/openshift/zone_outage.yaml) config file for the parameters that need to be defined.
 
 Example scenario files from [scenarios-hub](https://github.com/krkn-chaos/scenarios-hub):
 - [zone_outage.yaml](https://github.com/krkn-chaos/scenarios-hub/blob/main/openshift/zone_outage.yaml) (AWS)


### PR DESCRIPTION
Fixes #494

Several pages in the docs still linked to the old `redhat-chaos` org. This updates 16 stale references across 9 files to point to `krkn-chaos` instead.

For more details please refer to issue #494.