### PR TITLE
Remove redundant code from layout

### DIFF
--- a/layouts/_partials/hooks/body-end.html
+++ b/layouts/_partials/hooks/body-end.html
@@ -340,9 +340,6 @@
           card.style.minHeight = rowHeightPx + 'px';
           card.style.removeProperty('aspectRatio');
         });
-        // #region agent log
-        fetch('http://127.0.0.1:7905/ingest/58111621-164e-4fc0-80aa-1a565995fece',{method:'POST',headers:{'Content-Type':'application/json','X-Debug-Session-Id':'008ba3'},body:JSON.stringify({sessionId:'008ba3',location:'body-end.html:measureAndSetRowHeights',message:'row measure',data:{rowIndex:rowIndex,titles:titles,scrollHeights:scrollHeights,maxContentH:maxContentH,rowHeightPx:rowHeightPx,rowWidth:rowWidth},timestamp:Date.now(),hypothesisId:'H1-H5'})}).catch(function(){});
-        // #endregion
       });
       requestAnimationFrame(function() {
         var buffer = 8;


### PR DESCRIPTION
## Summary

Removed leftover debug code from the website layout.

## What Changed

- Removed a `fetch` call to `http://127.0.0.1:7905`
- Removed related debug-only code
- Did not change the actual page layout logic

## Why

This debug code was not needed on the real website. It could make user's browsers try to call a local server that does not exist.