### PR TITLE
Add touch-screen dragging support for touch-screen devices

### DIFF
--- a/static/css/chatbot.css
+++ b/static/css/chatbot.css
@@ -184,6 +184,7 @@
     border-radius: var(--krkn-chat-radius-lg) var(--krkn-chat-radius-lg) 0 0;
     cursor: move;
     user-select: none;
+    touch-action: none;
     transition: background-color 0.2s;
 }
 

--- a/static/js/chatbot.js
+++ b/static/js/chatbot.js
@@ -424,13 +424,14 @@ class KrknChatbot {
         let isDragging = false;
         let dragStart = { x: 0, y: 0 };
         let windowStart = { x: 0, y: 0 };
+        let activeTouchId = null;
 
-        chatHeader.addEventListener('mousedown', (e) => {
-            if (e.target.closest('.krkn-chat-close')) return;
+        const handleStart = (clientX, clientY, e) => {
+            if (e.target.closest('.krkn-chat-close')) return false;
             
             isDragging = true;
-            dragStart.x = e.clientX;
-            dragStart.y = e.clientY;
+            dragStart.x = clientX;
+            dragStart.y = clientY;
             
             const rect = chatWindow.getBoundingClientRect();
             windowStart.x = rect.left;
@@ -438,14 +439,14 @@ class KrknChatbot {
             
             chatWindow.style.transition = 'none';
             document.body.style.userSelect = 'none';
-            e.preventDefault();
-        });
+            return true;
+        };
 
-        document.addEventListener('mousemove', (e) => {
+        const handleMove = (clientX, clientY, e) => {
             if (!isDragging) return;
             
-            const deltaX = e.clientX - dragStart.x;
-            const deltaY = e.clientY - dragStart.y;
+            const deltaX = clientX - dragStart.x;
+            const deltaY = clientY - dragStart.y;
             
             let newX = windowStart.x + deltaX;
             let newY = windowStart.y + deltaY;
@@ -461,16 +462,72 @@ class KrknChatbot {
             chatWindow.style.top = newY + 'px';
             chatWindow.style.right = 'auto';
             chatWindow.style.bottom = 'auto';
-        });
+            
+            if (e) e.preventDefault();
+        };
 
-        document.addEventListener('mouseup', () => {
+        const handleEnd = () => {
             if (isDragging) {
                 isDragging = false;
-                
+                activeTouchId = null;
                 chatWindow.style.transition = '';
                 document.body.style.userSelect = '';
+                removeDynamicListeners();
+            }
+        };
+
+        // Dynamic event listeners for move/end
+        const onMouseMove = (e) => handleMove(e.clientX, e.clientY, e);
+        const onMouseUp = () => handleEnd();
+
+        const onTouchMove = (e) => {
+            if (!isDragging || activeTouchId === null) return;
+            for (let i = 0; i < e.changedTouches.length; i++) {
+                if (e.changedTouches[i].identifier === activeTouchId) {
+                    handleMove(e.changedTouches[i].clientX, e.changedTouches[i].clientY, e);
+                    break;
+                }
+            }
+        };
+
+        const onTouchEnd = (e) => {
+            if (activeTouchId === null) return;
+            for (let i = 0; i < e.changedTouches.length; i++) {
+                if (e.changedTouches[i].identifier === activeTouchId) {
+                    handleEnd();
+                    break;
+                }
+            }
+        };
+
+        const removeDynamicListeners = () => {
+            document.removeEventListener('mousemove', onMouseMove);
+            document.removeEventListener('mouseup', onMouseUp);
+            document.removeEventListener('touchmove', onTouchMove, { passive: false });
+            document.removeEventListener('touchend', onTouchEnd);
+            document.removeEventListener('touchcancel', onTouchEnd);
+        };
+
+        // Attach start listeners to header
+        chatHeader.addEventListener('mousedown', (e) => {
+            if (handleStart(e.clientX, e.clientY, e)) {
+                e.preventDefault();
+                document.addEventListener('mousemove', onMouseMove);
+                document.addEventListener('mouseup', onMouseUp);
             }
         });
+
+        chatHeader.addEventListener('touchstart', (e) => {
+            if (e.touches.length > 1 && isDragging) return;
+            const touch = e.changedTouches[0];
+            if (handleStart(touch.clientX, touch.clientY, e)) {
+                activeTouchId = touch.identifier;
+                e.preventDefault();
+                document.addEventListener('touchmove', onTouchMove, { passive: false });
+                document.addEventListener('touchend', onTouchEnd);
+                document.addEventListener('touchcancel', onTouchEnd);
+            }
+        }, { passive: false });
     }
 
     toggleChat() {


### PR DESCRIPTION
## Documentation Update
**Related Feature:** 

This PR addresses a significant accessibility problem. The floating chatbot assistant widget was movable on desktop devices with mouse interactions. However, it was completely still and non-interactive on mobile, tablet, and touch-screen laptop screens.

**Changes:** 
- **Modular Drag Handlers**: Refactored the core dragging math inside `static/js/chatbot.js` into reusable helper functions (`handleStart`, `handleMove`, and `handleEnd`) to support unified mouse and touch input.
- **Touch Event Listeners**: Registered standard mobile touch events (`touchstart`, `touchmove`, `touchend`, and `touchcancel`) on the chatbot header.
- **Interruption Prevention**: Added `e.preventDefault()` inside the `touchstart` listener to block default browser touch actions (such as standard scrolling or cursor focus) when dragging is initiated.
- **CSS Touch Action Bypass**: Added `touch-action: none;` to the `.krkn-chat-header` class in `static/css/chatbot.css`. This prevents modern mobile browsers from panning/scrolling the underlying page and prematurely canceling the swipe gestures.
