### PR TITLE
docs: fixed the contribution guide link on dev-guide page

### DIFF
--- a/content/en/docs/developers-guide/_index.md
+++ b/content/en/docs/developers-guide/_index.md
@@ -34,5 +34,5 @@ We’re happy to assist. Now, __release the Krkn!__
 
 ## Follow Contribution Guide
 
-Once all you're happy with your changes, follow the [contribution](#docs/git-pointers.md) guide on how to create your own branch and squash your commits
+Once all you're happy with your changes, follow the [contribution guide](../contribution-guidelines/git-pointers/) guide on how to create your own branch and squash your commits
  

--- a/content/en/docs/developers-guide/_index.md
+++ b/content/en/docs/developers-guide/_index.md
@@ -34,5 +34,5 @@ We’re happy to assist. Now, __release the Krkn!__
 
 ## Follow Contribution Guide
 
-Once all you're happy with your changes, follow the [contribution guide](../contribution-guidelines/git-pointers/) guide on how to create your own branch and squash your commits
+Once all you're happy with your changes, follow the [contribution guide](../contribution-guidelines/git-pointers.md) on how to create your own branch and squash your commits
  


### PR DESCRIPTION
## Documentation Update

Fixes a broken internal link in the Developers Guide index page that was using an invalid `#docs/git-pointers.md` hash-style path instead of a proper relative path.

**Changes:** 

- **File:** `content/en/docs/developers-guide/_index.md`
- **Line 37:** Changed `[contribution](#docs/git-pointers.md)` to `[contribution guide](../contribution-guidelines/git-pointers.md)`
