### PR TITLE
fix(netlify): restrict CORS origin on chat function to production domain

### DIFF
--- a/netlify/functions/chat.js
+++ b/netlify/functions/chat.js
@@ -66,16 +66,32 @@ const initializeServices = async () => {
 };
 
 exports.handler = async (event, context) => {
-    const allowedOrigin = process.env.ALLOWED_ORIGIN || 'https://krkn-chaos.dev';
+    // Build allow-list from env (supports comma-separated origins)
+    const allowedOrigins = (process.env.ALLOWED_ORIGINS || process.env.ALLOWED_ORIGIN || 'https://krkn-chaos.dev')
+        .split(',')
+        .map(s => s.trim())
+        .filter(Boolean);
+
+    // Read the incoming Origin header (case-insensitive lookup)
+    const requestOrigin = event.headers?.origin || event.headers?.Origin || '';
+
+    // Check if the request origin is in the allow-list
+    const isAllowedOrigin = allowedOrigins.includes(requestOrigin);
+
+    // Build CORS headers — echo back the matched origin and add Vary: Origin
     const headers = {
-        'Access-Control-Allow-Origin': allowedOrigin,
+        'Access-Control-Allow-Origin': isAllowedOrigin ? requestOrigin : allowedOrigins[0],
         'Access-Control-Allow-Headers': 'Content-Type',
         'Access-Control-Allow-Methods': 'POST, OPTIONS',
-        'Content-Type': 'application/json'
+        'Content-Type': 'application/json',
+        'Vary': 'Origin'
     };
 
     // Handle preflight OPTIONS request
     if (event.httpMethod === 'OPTIONS') {
+        if (!isAllowedOrigin) {
+            return { statusCode: 403, headers, body: JSON.stringify({ error: 'Origin not allowed' }) };
+        }
         return {
             statusCode: 200,
             headers,
@@ -89,6 +105,16 @@ exports.handler = async (event, context) => {
             statusCode: 405,
             headers,
             body: JSON.stringify({ error: 'Method not allowed' })
+        };
+    }
+
+    // Server-side origin enforcement — reject requests without a valid origin
+    // before processing the message or consuming daily quota
+    if (!requestOrigin || !isAllowedOrigin) {
+        return {
+            statusCode: 403,
+            headers,
+            body: JSON.stringify({ error: 'Forbidden — origin not allowed' })
         };
     }
 

--- a/netlify/functions/chat.js
+++ b/netlify/functions/chat.js
@@ -26,23 +26,23 @@ const DAILY_LIMIT = parseInt(process.env.DAILY_CHAT_LIMIT) || 100;
 
 function checkDailyLimit() {
     const today = new Date().toISOString().split('T')[0];
-    
+
     // Reset if new day
     if (dailyUsage.date !== today) {
         dailyUsage = { date: today, count: 0 };
     }
-    
+
     return dailyUsage.count < DAILY_LIMIT;
 }
 
 function incrementUsage() {
     const today = new Date().toISOString().split('T')[0];
-    
+
     // Reset if new day
     if (dailyUsage.date !== today) {
         dailyUsage = { date: today, count: 0 };
     }
-    
+
     dailyUsage.count++;
     return dailyUsage.count;
 }
@@ -52,7 +52,7 @@ const initializeServices = async () => {
         documentationIndex = new DocumentationIndex();
         await documentationIndex.initialize();
     }
-    
+
     if (!chatService) {
         chatService = new ChatService({
             documentationIndex,
@@ -66,9 +66,9 @@ const initializeServices = async () => {
 };
 
 exports.handler = async (event, context) => {
-    // Handle CORS
+    const allowedOrigin = process.env.ALLOWED_ORIGIN || 'https://krkn-chaos.dev';
     const headers = {
-        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Origin': allowedOrigin,
         'Access-Control-Allow-Headers': 'Content-Type',
         'Access-Control-Allow-Methods': 'POST, OPTIONS',
         'Content-Type': 'application/json'
@@ -148,7 +148,7 @@ exports.handler = async (event, context) => {
 
     } catch (error) {
         console.error('Chat function error:', error);
-        
+
         return {
             statusCode: 500,
             headers,


### PR DESCRIPTION
## Security Fix
**Related Feature:** 
change-cors-origin

**Changes:**

The chat serverless function (`netlify/functions/chat.js`) used `Access-Control-Allow-Origin: '*'`, which allows **any third-party website** to make requests to the Krkn chatbot API.

### Problem
A wildcard CORS origin means a malicious or unrelated site can embed requests to `/.netlify/functions/chat`, consuming the daily request quota (100 requests/day) and making the chatbot unavailable for legitimate users on `krkn-chaos.dev`.

### Fix
- Replaced `'*'` with `process.env.ALLOWED_ORIGIN || 'https://krkn-chaos.dev'`
- Production defaults to `https://krkn-chaos.dev` with no config change required
- Dev/preview deployments can override via `ALLOWED_ORIGIN` environment variable in the Netlify dashboard

### Files Changed
- `netlify/functions/chat.js` — Restricted CORS origin from wildcard to production domain