### PR TITLE
fix(api): return 503 status when health check detects errors

### DIFF
--- a/api/server.js
+++ b/api/server.js
@@ -52,15 +52,15 @@ let dailyUsageTracker;
 async function initializeServices() {
     try {
         logger.info('Initializing services...');
-        
+
         // Initialize daily usage tracker
         dailyUsageTracker = new DailyUsageTracker();
         await dailyUsageTracker.initialize();
-        
+
         // Initialize documentation index
         documentationIndex = new DocumentationIndex();
         await documentationIndex.initialize();
-        
+
         // Initialize chat service with documentation context
         chatService = new ChatService({
             documentationIndex,
@@ -72,7 +72,7 @@ async function initializeServices() {
             projectId: config.llm.projectId,
             location: config.llm.location
         });
-        
+
         logger.info('Services initialized successfully');
     } catch (error) {
         logger.error('Failed to initialize services:', error);
@@ -85,7 +85,7 @@ app.get('/api/health', async (req, res) => {
     try {
         const currentUsage = dailyUsageTracker ? await dailyUsageTracker.getCurrentUsage() : 0;
         const remainingUsage = dailyUsageTracker ? await dailyUsageTracker.getRemainingUsage(config.rateLimiting.dailyLimit) : config.rateLimiting.dailyLimit;
-        
+
         res.json({
             status: 'healthy',
             timestamp: new Date().toISOString(),
@@ -102,8 +102,8 @@ app.get('/api/health', async (req, res) => {
         });
     } catch (error) {
         logger.error('Health check error:', error);
-        res.json({
-            status: 'healthy',
+        res.status(503).json({
+            status: 'degraded',
             timestamp: new Date().toISOString(),
             services: {
                 chatService: !!chatService,
@@ -129,7 +129,7 @@ const dailyLimitMiddleware = async (req, res, next) => {
         // Check if daily limit exceeded
         if (await dailyUsageTracker.hasExceededLimit(config.rateLimiting.dailyLimit)) {
             const currentUsage = await dailyUsageTracker.getCurrentUsage();
-            
+
             logger.warn('Daily chat limit exceeded', {
                 currentUsage,
                 limit: config.rateLimiting.dailyLimit,
@@ -184,7 +184,7 @@ app.post('/api/chat',
             }
 
             const { message, context, conversationHistory } = req.body;
-            
+
             // Log the request (without sensitive data)
             logger.info('Chat request received', {
                 messageLength: message.length,
@@ -213,7 +213,7 @@ app.post('/api/chat',
                 try {
                     const newUsageCount = await dailyUsageTracker.incrementUsage();
                     const remaining = await dailyUsageTracker.getRemainingUsage(config.rateLimiting.dailyLimit);
-                    
+
                     logger.info('Daily usage incremented', {
                         currentUsage: newUsageCount,
                         remaining: remaining,
@@ -237,9 +237,9 @@ app.post('/api/chat',
 
         } catch (error) {
             logger.error('Chat endpoint error:', error);
-            
+
             // Don't expose internal errors to clients
-            const errorMessage = process.env.NODE_ENV === 'production' 
+            const errorMessage = process.env.NODE_ENV === 'production'
                 ? 'I\'m having trouble processing your request right now. Please try again later.'
                 : error.message;
 
@@ -262,7 +262,7 @@ app.get('/api/search',
     async (req, res) => {
         try {
             const { query, limit = 10 } = req.query;
-            
+
             if (!query) {
                 return res.status(400).json({
                     error: 'Query parameter is required'
@@ -305,7 +305,7 @@ app.get('/api/topics', async (req, res) => {
         }
 
         const topics = await documentationIndex.getTopics();
-        
+
         res.json({
             topics,
             timestamp: new Date().toISOString()
@@ -329,7 +329,7 @@ app.post('/api/admin/rebuild-index', async (req, res) => {
         }
 
         const result = await documentationIndex.rebuildIndex();
-        
+
         res.json({
             message: 'Documentation index rebuilt successfully',
             ...result,
@@ -349,7 +349,7 @@ app.post('/api/admin/rebuild-index', async (req, res) => {
 app.all('/webhook/rebuild-docs', async (req, res) => {
     try {
         const startTime = Date.now();
-        
+
         if (!documentationIndex) {
             return res.status(503).json({
                 error: 'Documentation service not available'
@@ -396,7 +396,7 @@ app.use((err, req, res, next) => {
     logger.error('Unhandled error:', err);
     res.status(500).json({
         error: 'Internal server error',
-        message: process.env.NODE_ENV === 'production' 
+        message: process.env.NODE_ENV === 'production'
             ? 'Something went wrong'
             : err.message
     });
@@ -413,24 +413,24 @@ app.use((req, res) => {
 // Graceful shutdown
 process.on('SIGINT', async () => {
     logger.info('Received SIGINT, shutting down gracefully...');
-    
+
     // Close any open connections or cleanup
     if (chatService && typeof chatService.cleanup === 'function') {
         await chatService.cleanup();
     }
-    
-    
+
+
     process.exit(0);
 });
 
 process.on('SIGTERM', async () => {
     logger.info('Received SIGTERM, shutting down gracefully...');
-    
+
     if (chatService && typeof chatService.cleanup === 'function') {
         await chatService.cleanup();
     }
-    
-    
+
+
     process.exit(0);
 });
 
@@ -438,7 +438,7 @@ process.on('SIGTERM', async () => {
 async function startServer() {
     try {
         await initializeServices();
-        
+
         app.listen(PORT, () => {
             logger.info(`Krkn Chatbot API server running on port ${PORT}`);
             logger.info(`Environment: ${process.env.NODE_ENV || 'development'}`);


### PR DESCRIPTION
## Bug Fix

**Related Feature:**
`fix/health-check-status`

**Changes:**

The `/api/health` endpoint previously returned HTTP `200` with
`status: "healthy"` even when an internal error occurred in the
catch block. This means monitoring systems, load balancers, and
CI/CD pipelines would always see a healthy service — even when
something was actually failing.

**Before:**
```js
} catch (error) {
    logger.error('Health check error:', error);
    res.json({
        status: 'healthy',  // ❌ misleading — error occurred
```

**After:**
```js
} catch (error) {
    logger.error('Health check error:', error);
    res.status(503).json({
        status: 'degraded',  // ✅ accurately reflects error state
```

**Why this matters:**
- Load balancers rely on non-200 responses to detect and route
  around degraded instances
- Monitoring systems (Prometheus, Datadog, etc.) use HTTP status
  codes to trigger alerts — a 200 masks real failures silently
- This is a 2-line change with zero impact on the happy path

This is a code-only change with no impact on documentation
or site functionality.