### PR TITLE
fix(scripts): handle CRLF line endings in frontmatter parser for Wind…

### DIFF
--- a/scripts/build-search-index.js
+++ b/scripts/build-search-index.js
@@ -17,7 +17,7 @@ class BuildTimeIndexer {
         this.contentPath = contentPath;
         this.indexData = [];
         this.topics = new Map();
-        
+
         // Configure marked for parsing markdown
         marked.setOptions({
             gfm: true,
@@ -32,10 +32,10 @@ class BuildTimeIndexer {
 
     async processDirectory(dirPath) {
         const entries = await fs.readdir(dirPath, { withFileTypes: true });
-        
+
         for (const entry of entries) {
             const fullPath = path.join(dirPath, entry.name);
-            
+
             if (entry.isDirectory()) {
                 await this.processDirectory(fullPath);
             } else if (entry.isFile() && entry.name.endsWith('.md')) {
@@ -48,11 +48,11 @@ class BuildTimeIndexer {
         try {
             const content = await fs.readFile(filePath, 'utf-8');
             const parsed = this.parseMarkdown(content);
-            
+
             if (parsed && parsed.title) {
                 const url = this.generateUrl(filePath);
                 const topic = this.extractTopic(filePath);
-                
+
                 const document = {
                     id: filePath,
                     title: parsed.title,
@@ -64,9 +64,9 @@ class BuildTimeIndexer {
                     lastModified: (await fs.stat(filePath)).mtime,
                     wordCount: this.countWords(parsed.content)
                 };
-                
+
                 this.indexData.push(document);
-                
+
                 // Add to topics map
                 if (topic) {
                     if (!this.topics.has(topic)) {
@@ -82,14 +82,12 @@ class BuildTimeIndexer {
 
     parseMarkdown(content) {
         try {
-            // Extract frontmatter
-            const frontmatterMatch = content.match(/^---\n([\s\S]*?)\n---/);
-            let frontmatter = {};
+            const frontmatterMatch = content.match(/^---\r?\n([\s\S]*?)\r?\n---/); let frontmatter = {};
             let markdownContent = content;
-            
+
             if (frontmatterMatch) {
                 markdownContent = content.substring(frontmatterMatch[0].length);
-                const yamlLines = frontmatterMatch[1].split('\n');
+                const yamlLines = frontmatterMatch[1].split(/\r?\n/);
                 for (const line of yamlLines) {
                     const colonIndex = line.indexOf(':');
                     if (colonIndex > 0) {
@@ -99,32 +97,32 @@ class BuildTimeIndexer {
                     }
                 }
             }
-            
+
             // Convert markdown to HTML then extract text
             const html = marked(markdownContent);
             const $ = cheerio.load(html);
             const textContent = $.text().replace(/\s+/g, ' ').trim();
-            
+
             // Extract title
             let title = frontmatter.title;
             if (!title) {
                 const firstHeading = $('h1, h2').first().text().trim();
                 title = firstHeading || 'Untitled';
             }
-            
+
             // Extract description  
             let description = frontmatter.description;
             if (!description) {
                 const firstParagraph = $('p').first().text().trim();
                 description = firstParagraph.substring(0, 200) + (firstParagraph.length > 200 ? '...' : '');
             }
-            
+
             // Extract tags
             let tags = [];
             if (frontmatter.tags) {
                 tags = frontmatter.tags.split(',').map(tag => tag.trim());
             }
-            
+
             return {
                 title,
                 description,
@@ -155,12 +153,12 @@ class BuildTimeIndexer {
 
 async function buildSearchIndex() {
     console.log('Building search index...');
-    
+
     try {
         const contentPath = path.join(__dirname, '../content/en');
         const indexer = new BuildTimeIndexer(contentPath);
         await indexer.buildIndex();
-        
+
         const indexData = {
             documents: indexer.indexData,
             topics: Array.from(indexer.topics.entries()).map(([name, docs]) => ({
@@ -169,12 +167,12 @@ async function buildSearchIndex() {
             })),
             buildTime: new Date().toISOString()
         };
-        
+
         const outputPath = path.join(__dirname, '../static/search-index.json');
         await fs.writeFile(outputPath, JSON.stringify(indexData, null, 2));
-        
+
         console.log(`✅ Indexed ${indexData.documents.length} documents`);
-        
+
     } catch (error) {
         console.error('Failed to build search index:', error);
         process.exit(1);

--- a/scripts/build-search-index.js
+++ b/scripts/build-search-index.js
@@ -82,7 +82,8 @@ class BuildTimeIndexer {
 
     parseMarkdown(content) {
         try {
-            const frontmatterMatch = content.match(/^---\r?\n([\s\S]*?)\r?\n---/); let frontmatter = {};
+            const frontmatterMatch = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+            let frontmatter = {};
             let markdownContent = content;
 
             if (frontmatterMatch) {


### PR DESCRIPTION
## Bug Fix

**Related Feature:**
`fix/crlf-frontmatter-parser`

**Changes:**

The frontmatter parser in `scripts/build-search-index.js` used
`\n` (Unix line endings) in both the regex and string split,
causing it to silently fail on Windows machines that use `\r\n`
(CRLF) line endings.

**Root Cause:**
Windows contributors cloning this repo get files with CRLF line
endings by default. The frontmatter regex `/^---\n([\s\S]*?)\n---/`
does not account for `\r` — so on Windows, the regex never matches,
`frontmatter` stays as `{}`, and every document gets indexed with
no title, no description, and incorrect content — silently breaking
the entire search index.

**Before:**
```js
// ❌ Fails on Windows CRLF line endings
const frontmatterMatch = content.match(/^---\n([\s\S]*?)\n---/);
// ❌ Splits incorrectly — \r left in key/value strings
const yamlLines = frontmatterMatch[1].split('\n');
```

**After:**
```js
// ✅ Handles both LF (Unix/macOS) and CRLF (Windows)
const frontmatterMatch = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
// ✅ Correctly splits on both line ending types
const yamlLines = frontmatterMatch[1].split(/\r?\n/);
```

**Why this matters:**
- Windows contributors running `npm run build` or
  `npm run build:search-index` locally would get a completely
  broken search index with all documents showing as `Untitled`
- The chatbot's documentation search quality degrades silently —
  no error is thrown, making this extremely hard to debug
- `\r?\n` is the standard cross-platform fix — zero impact on
  Unix/macOS builds

This is a 2-line change with no impact on production Netlify
builds (which run on Linux) but fixes local development for
all Windows contributors.