### PR TITLE
feat(ci): add upstream repository dispatch trigger for doc-sync bot (#320)

### DIFF
--- a/.github/workflows/upstream-doc-trigger.yml
+++ b/.github/workflows/upstream-doc-trigger.yml
@@ -1,0 +1,36 @@
+name: Upstream Doc Sync Trigger
+
+# Listen for a custom webhook event from upstream repos (like krkn-hub or krknctl)
+on:
+  repository_dispatch:
+    types: [upstream_pr_merged]
+
+jobs:
+  prepare-doc-sync:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
+    steps:
+      - name: Checkout Website Repo
+        uses: actions/checkout@v4
+
+      - name: Identify Upstream Source
+        env:
+          UPSTREAM_REPO: ${{ github.event.client_payload.repository }}
+        run: |
+          echo "Triggered by a merge in: $UPSTREAM_REPO"
+          echo "Preparing environment for Doc Sync..."
+
+      # (This is where your future LFX Mentorship LLM Python script will run)
+      - name: Run Doc Sync Bot (Stub)
+        run: |
+          echo "LLM Agent parses changes here and generates markdown files."
+
+      # Triggering the neighboring workflow directly using your CI expertise!
+      - name: Trigger Native Search Index Rebuild
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "Triggering rebuild-docs-index.yml..."
+          gh workflow run rebuild-docs-index.yml


### PR DESCRIPTION
As part of my LFX Mentorship application for the Automated Doc Sync Bot (Issue #320), I noticed that before we even run an LLM to generate documentation, the system first needs a reliable way to know *when* upstream code actually changes.

Instead of jumping straight to the LLM generation script, this PR lays the CI/CD groundwork. It adds a `repository_dispatch` workflow that listens for upstream merges from repos like `krkn`, `krkn-hub`, and `krknctl` to trigger the future bot. 

Furthermore, instead of relying on external Netlify webhooks, I integrated this natively with our existing architecture. It automatically triggers the neighboring `.github/workflows/rebuild-docs-index.yml` action using the `gh` CLI. 

Since I recently fixed the search index build script to report skipped files in PR #439, this setup guarantees that whenever the future AI bot generates new markdown, the site's search index will automatically and cleanly rebuild using our native CI.