### PR TITLE
feat(.github): add structured issue templates for bug reports and feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,43 @@
+name: 🐛 Bug Report
+description: Report a bug on the Krkn documentation website
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug! Please fill out the details below.
+  - type: input
+    id: url
+    attributes:
+      label: Page URL
+      description: The URL of the page where you found the bug
+      placeholder: https://krkn-chaos.dev/docs/...
+    validations:
+      required: false
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the bug
+      description: A clear description of what the bug is
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What you expected to happen
+    validations:
+      required: false
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - Documentation content
+        - Website UI/layout
+        - Chatbot
+        - Search
+        - Build/deployment
+        - Other
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -5,4 +5,4 @@ contact_links:
     about: Ask questions in the #krkn Kubernetes Slack channel
   - name: 📖 Contributing Guide
     url: https://github.com/krkn-chaos/website/blob/main/CONTRIBUTING.md
-    about: Read the contributing guide before opening a PR
+    about: Read the contributing guide before opening an issue or PR

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: 💬 Slack Channel
+    url: https://kubernetes.slack.com/archives/C05SFMHRWK1
+    about: Ask questions in the #krkn Kubernetes Slack channel
+  - name: 📖 Contributing Guide
+    url: https://github.com/krkn-chaos/website/blob/main/CONTRIBUTING.md
+    about: Read the contributing guide before opening a PR

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,5 +4,5 @@ contact_links:
     url: https://kubernetes.slack.com/archives/C05SFMHRWK1
     about: Ask questions in the #krkn Kubernetes Slack channel
   - name: 📖 Contributing Guide
-    url: https://github.com/krkn-chaos/website/blob/main/CONTRIBUTING.md
+    url: https://github.com/krkn-chaos/website/blob/HEAD/CONTRIBUTING.md
     about: Read the contributing guide before opening an issue or PR

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,32 @@
+name: ✨ Feature Request
+description: Suggest a new feature or improvement for the Krkn website
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the feature
+      description: A clear description of what you'd like to see
+    validations:
+      required: true
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      description: Why would this feature be useful?
+    validations:
+      required: false
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - Documentation content
+        - Website UI/layout
+        - Chatbot
+        - Search
+        - Developer experience
+        - CI/CD
+        - Other
+    validations:
+      required: true


### PR DESCRIPTION
## Documentation Update

**Related Feature:**
`feat/github-issue-templates`

**Changes:**

Added structured GitHub issue templates to the repository.
Previously the repo had zero issue templates — contributors
opening issues had no guidance on what information to provide,
increasing maintainer triage overhead.

Three files added under `.github/ISSUE_TEMPLATE/`:

1. **`bug_report.yml`** — Structured bug report template with:
   - Page URL field (optional) — helps reproduce doc-specific bugs
   - Bug description (required)
   - Expected behavior field
   - Area dropdown (Documentation, UI, Chatbot, Search, Build, Other)

2. **`feature_request.yml`** — Feature request template with:
   - Feature description (required)
   - Motivation field — why is this useful?
   - Area dropdown (Documentation, UI, Chatbot, Search, DX, CI/CD, Other)

3. **`config.yml`** — Issue template config with contact links:
   - Direct link to `#krkn` Kubernetes Slack channel for questions
   - Direct link to `CONTRIBUTING.md` for contributor guidance

**Why this matters:**
- Dropdowns ensure issues are consistently categorized
- Auto-applied labels (`bug`, `enhancement`) reduce manual triage
- Slack + CONTRIBUTING.md links surface the right resources
  before contributors open unnecessary issues
- Standard practice for CNCF Sandbox projects

This is an additive-only change — zero impact on existing
issues, PRs, code, or site functionality.