### PR TITLE
feat(chatbot): close chat window on Escape key press for keyboard accessibility

### DIFF
--- a/static/js/chatbot.js
+++ b/static/js/chatbot.js
@@ -413,6 +413,13 @@ class KrknChatbot {
 
         // Replace quick buttons with page-specific suggestions
         this.updateQuickButtons();
+
+        // Close chatbot window when user presses Escape key (accessibility)
+        document.addEventListener('keydown', (e) => {
+            if (e.key === 'Escape' && this.isOpen) {
+                this.toggleChat();
+            }
+        });
     }
 
     setupBasicDragging() {


### PR DESCRIPTION
## Documentation Update

**Related Feature:**
`feat/chatbot-escape-key`

**Changes:**

Added keyboard accessibility support to the chatbot widget —
pressing `Escape` now closes the chat window when it is open.

**Problem:**
The chatbot window had no keyboard dismiss mechanism. Users
who open the chatbot and want to close it without reaching
for the mouse had no way to do so — a standard UX expectation
for any modal or overlay element was missing.

**Fix:**
Added a `keydown` event listener inside `createChatbot()` in
`static/js/chatbot.js` that calls `toggleChat()` when:
- The pressed key is `Escape`
- The chatbot window is currently open (`this.isOpen === true`)

**Before:**
```js
// No keyboard handling — Escape key did nothing
```

**After:**
```js
// Close chatbot window when user presses Escape key (accessibility)
document.addEventListener('keydown', (e) => {
    if (e.key === 'Escape' && this.isOpen) {
        this.toggleChat();
    }
});
```

**Why this matters:**
- `Escape` to dismiss is a universally expected keyboard pattern
  for modals, drawers, and overlay elements
- Required by WCAG 2.1 Success Criterion 2.1.2 (No Keyboard Trap)
  — users must be able to move focus away from any component
  using only the keyboard
- 8-line change with zero impact on existing chat functionality
- Only fires when chatbot is open — no interference with other
  page keyboard interactions

This is an additive-only change with no impact on documentation,
existing chat behavior, or site functionality.