### PR TITLE
docs(krkn-ai): add missing flags to run command documentation

### DIFF
--- a/content/en/docs/krkn_ai/run.md
+++ b/content/en/docs/krkn_ai/run.md
@@ -15,12 +15,16 @@ Usage: krkn_ai run [OPTIONS]
   Run Krkn-AI tests
 
 Options:
+  -k, --kubeconfig TEXT                 Path to cluster kubeconfig file. Overrides value in config file.
   -c, --config TEXT                     Path to Krkn-AI config file.
   -o, --output TEXT                     Directory to save results.
   -f, --format [json|yaml]              Format of the output file.  [default: yaml]
   -r, --runner-type [krknctl|krknhub]   Type of chaos engine to use.
   -p, --param TEXT                      Additional parameters for config file in key=value format.
+  -s, --seed INTEGER                    Random seed for reproducible runs. Overrides seed in config file.
   -v, --verbose                         Increase verbosity of output.  [default: 0]
+  -m, --monitoring                      Launch live monitoring dashboard in the background.
+  --port INTEGER                        Port to run Streamlit server on when monitoring is enabled.  [default: 8501]
   --help                                Show this message and exit.
 ```
 


### PR DESCRIPTION
The CLI usage block in `run.md` was missing four flags that exist in `krkn_ai/cli/cmd.py`.

Fixes #518

## Documentation Update

**Related Feature:** krkn-ai `run` command (`krkn_ai/cli/cmd.py`)

**Changes:** Added four missing flags to the CLI options block in `content/en/docs/krkn_ai/run.md`:

- `-k, --kubeconfig`: overrides kubeconfig path from config file
- `-s, --seed`: sets random seed for reproducible runs
- `-m, --monitoring`: launches live Streamlit dashboard during the run
- `--port`: port for the monitoring dashboard (default 8501)