### PR TITLE
docs: fix contribution guide link

### DIFF
--- a/content/en/docs/developers-guide/_index.md
+++ b/content/en/docs/developers-guide/_index.md
@@ -34,5 +34,4 @@ We’re happy to assist. Now, __release the Krkn!__
 
 ## Follow Contribution Guide
 
-Once all you're happy with your changes, follow the [contribution guide](../contribution-guidelines/git-pointers.md) on how to create your own branch and squash your commits
- 
+Once all you're happy with your changes, follow the [contribution guide](../contribution-guidelines/git-pointers/) on how to create your own branch and squash your commits


### PR DESCRIPTION
﻿Summary
- Updates the Developers Guide contribution guide link to the published Hugo route.
- Avoids the `.md` URL, which resolves to a 404 on the live site.
- Keeps the change limited to `content/en/docs/developers-guide/_index.md`.

Validation
- PASS: `curl.exe -I -L https://krkn-chaos.dev/docs/contribution-guidelines/git-pointers.md` -> `404 Not Found`; `curl.exe -I -L https://krkn-chaos.dev/docs/contribution-guidelines/git-pointers/` -> `200 OK`.
- PASS: `npm exec --yes --package hugo-extended@0.146.0 -- npm run check:links` with portable Go 1.26.1 on PATH; Hugo build completed, and the repository link-check script currently prints `IMPLEMENTATION PENDING`.
- PASS: `git diff --check`.

Notes
- Fixes #498.
- Documentation link only; no compatibility impact expected.
- No follow-up work expected.
