### PR TITLE
Fix Mermaid theme selection based on website theme

### DIFF
--- a/layouts/_partials/hooks/body-end.html
+++ b/layouts/_partials/hooks/body-end.html
@@ -405,6 +405,57 @@
 })();
 </script>
 
+<script src="https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js"></script>
+
+<script>
+(function() {
+
+  document.querySelectorAll('.mermaid').forEach(function(el) {
+    if (!el.dataset.src) {
+      el.dataset.src = el.textContent.trim();
+    }
+  });
+
+  const initialTheme = localStorage.getItem('krkn-theme') || 'dark';
+
+  mermaid.initialize({
+    startOnLoad: true,
+    theme: initialTheme === 'dark' ? 'dark' : 'default'
+  });
+  mermaid.run();
+
+  document.addEventListener('krkn-theme-changed', async function(e) {
+
+    const theme = e.detail.theme;
+
+    mermaid.initialize({
+      startOnLoad: false,
+      theme: theme === 'dark' ? 'dark' : 'default'
+    });
+
+    const diagrams = document.querySelectorAll('.mermaid');
+
+    for (let i = 0; i < diagrams.length; i++) {
+      const diagram = diagrams[i];
+      const source = diagram.dataset.src;
+
+      if (!source) continue;
+
+      try {
+        const { svg } = await mermaid.render(
+          `mermaid-theme-${Date.now()}-${i}`,
+          source
+        );
+
+        diagram.innerHTML = svg;
+      } catch (err) {
+        console.error(err);
+      }
+    }
+  });
+})();
+</script>
+
 <!-- Scroll animations -->
 <script src="{{ "js/scroll-animations.js" | relURL }}" defer></script>
 

--- a/layouts/_partials/navbar.html
+++ b/layouts/_partials/navbar.html
@@ -303,6 +303,14 @@
   function setTheme(theme) {
     document.documentElement.setAttribute('data-theme', theme);
     localStorage.setItem('krkn-theme', theme);
+
+    //Notify Mermaid 
+    document.dispatchEvent(
+       new CustomEvent('krkn-theme-changed', {
+       detail: { theme: theme }
+       })
+    );
+
     if (themeToggle) {
       themeToggle.setAttribute('aria-label',
         theme === 'dark' ? 'Switch to light theme' : 'Switch to dark theme'

--- a/layouts/partials/scripts/mermaid.html
+++ b/layouts/partials/scripts/mermaid.html
@@ -3,55 +3,10 @@
 {{ $mermaidJS := printf "https://cdn.jsdelivr.net/npm/mermaid@%s/dist/mermaid.min.js" $mermaidVersion -}}
 <script src="{{ $mermaidJS }}"></script>
 <script>
-  // Preserve the original Mermaid source before Mermaid replaces it
-  // with a generated SVG. This allows diagrams to be re-rendered later
-  // when the site theme changes.
-  document.querySelectorAll('.mermaid').forEach(function (el) {
-    if (!el.dataset.src) {
-      el.dataset.src = el.textContent.trim();
+  mermaid.initialize(
+    {
+      theme: '{{ .Site.Params.mermaid.theme | default "default" }}'
     }
-  });
-
-  function initializeMermaid() {
-    const theme = localStorage.getItem('krkn-theme') || 'dark';
-
-    mermaid.initialize({
-      startOnLoad: true,
-      theme: theme === 'dark' ? 'dark' : 'default'
-    });
-  }
-
-    initializeMermaid();
-
-  document.addEventListener('krkn-theme-changed', async function (e) {
-    const theme = e.detail.theme;
-
-    // Update Mermaid configuration for the new theme
-    mermaid.initialize({
-      startOnLoad: false,
-      theme: theme === 'dark' ? 'dark' : 'default'
-    });
-
-    const diagrams = document.querySelectorAll('.mermaid');
-
-    for (let i = 0; i < diagrams.length; i++) {
-      const diagram = diagrams[i];
-      const source = diagram.dataset.src;
-
-      if (!source) continue;
-
-      try {
-        const { svg } = await mermaid.render(
-          `mermaid-theme-${Date.now()}-${i}`,
-          source
-        );
-
-        diagram.innerHTML = svg;
-        diagram.setAttribute('data-processed', 'true');
-      } catch (err) {
-        console.error('Failed to rerender Mermaid diagram', err);
-      }
-    }
-  });
+  );
 </script>
 {{ end -}}

--- a/layouts/partials/scripts/mermaid.html
+++ b/layouts/partials/scripts/mermaid.html
@@ -3,10 +3,55 @@
 {{ $mermaidJS := printf "https://cdn.jsdelivr.net/npm/mermaid@%s/dist/mermaid.min.js" $mermaidVersion -}}
 <script src="{{ $mermaidJS }}"></script>
 <script>
-  const isDark = document.documentElement.dataset.theme === 'dark';
+  // Preserve the original Mermaid source before Mermaid replaces it
+  // with a generated SVG. This allows diagrams to be re-rendered later
+  // when the site theme changes.
+  document.querySelectorAll('.mermaid').forEach(function (el) {
+    if (!el.dataset.src) {
+      el.dataset.src = el.textContent.trim();
+    }
+  });
 
-  mermaid.initialize({
-    theme: isDark ? 'dark' : 'default'
+  function initializeMermaid() {
+    const theme = localStorage.getItem('krkn-theme') || 'dark';
+
+    mermaid.initialize({
+      startOnLoad: true,
+      theme: theme === 'dark' ? 'dark' : 'default'
+    });
+  }
+
+    initializeMermaid();
+
+  document.addEventListener('krkn-theme-changed', async function (e) {
+    const theme = e.detail.theme;
+
+    // Update Mermaid configuration for the new theme
+    mermaid.initialize({
+      startOnLoad: false,
+      theme: theme === 'dark' ? 'dark' : 'default'
+    });
+
+    const diagrams = document.querySelectorAll('.mermaid');
+
+    for (let i = 0; i < diagrams.length; i++) {
+      const diagram = diagrams[i];
+      const source = diagram.dataset.src;
+
+      if (!source) continue;
+
+      try {
+        const { svg } = await mermaid.render(
+          `mermaid-theme-${Date.now()}-${i}`,
+          source
+        );
+
+        diagram.innerHTML = svg;
+        diagram.setAttribute('data-processed', 'true');
+      } catch (err) {
+        console.error('Failed to rerender Mermaid diagram', err);
+      }
+    }
   });
 </script>
 {{ end -}}

--- a/layouts/partials/scripts/mermaid.html
+++ b/layouts/partials/scripts/mermaid.html
@@ -3,10 +3,10 @@
 {{ $mermaidJS := printf "https://cdn.jsdelivr.net/npm/mermaid@%s/dist/mermaid.min.js" $mermaidVersion -}}
 <script src="{{ $mermaidJS }}"></script>
 <script>
-  mermaid.initialize(
-    {
-      theme: '{{ .Site.Params.mermaid.theme | default "default" }}'
-    }
-  );
+  const isDark = document.documentElement.dataset.theme === 'dark';
+
+  mermaid.initialize({
+    theme: isDark ? 'dark' : 'default'
+  });
 </script>
 {{ end -}}


### PR DESCRIPTION
## Issue

Mermaid diagrams were always being initialized with the default theme. As a result, when viewing documentation pages in dark mode, diagram labels became difficult to read due to low contrast between the label text and node backgrounds.

This issue was observed on https://krkn-chaos.dev/docs/rollback-scenarios/.

## Changes Made

* Updated Mermaid theme initialization to use the site's currently selected theme instead of always rendering with a fixed theme.

* Added a theme change listener so Mermaid diagrams are updated when users switch between light and dark mode.

* Stored the original Mermaid diagram source before rendering and used it to regenerate diagrams with the correct theme, ensuring that diagram styling stays synchronized with the rest of the site without requiring a page refresh.


This ensures Mermaid diagrams render with theme-appropriate styling instead of always using the default theme.

## Screenshots

### Before

<img width="1572" height="1186" alt="image" src="https://github.com/user-attachments/assets/2e38a097-4ce0-42e7-8964-7a6d24defbbc" />

### After

<img width="1544" height="1074" alt="image" src="https://github.com/user-attachments/assets/36251fd0-cedf-4bbf-b0ad-496cac50ca7c" />

