### PR TITLE
Update rollback default directory references

### DIFF
--- a/content/en/docs/rollback-scenarios/_index.md
+++ b/content/en/docs/rollback-scenarios/_index.md
@@ -72,7 +72,7 @@ python run_kraken.py list-rollback --config config/config.yaml -r <run_uuid> -s 
 
 Example Output:
 ```bash
-/tmp/kraken-rollback/
+~/.krkn/rollback
 ├── 1755488223093251000-168dce4c-fdb4-4e8c-aa5b-7f919777801b
 │   └── network_chaos_scenarios_1755488221668750000_fphcbojh.py
 ├── 1755496143932815000-7d32bf81-2c0d-4d56-b75b-b0702b2c45f9
@@ -82,7 +82,7 @@ Example Output:
 
 ### execute-rollback
 - `execute-rollback`: Execute rollback version files and cleanup if successful
-    - By default, **all version files** located in the `rollback_versions_directory` (`/tmp/kraken-rollback/`) will be executed.
+    - By default, **all version files** located in the `rollback_versions_directory` (`~/.krkn/rrollback`) will be executed.
     - The version files will be renamed with `.executed` suffix for further inspection.
     - `-r RUN_UUID, --run_uuid=RUN_UUID` Flag: **Optional**. Specify the Run UUID to filter the execution of rollback version files.
     - `-s SCENARIO_TYPE, --scenario_type=SCENARIO_TYPE` Flag: **Optional**. Specify the Scenario Type to filter the execution of rollback version files.
@@ -106,16 +106,16 @@ Example Output:
 2025-08-22 15:54:06,137 [WARNING] scenario_type is not specified, executing all scenarios in rollback directory
 2025-08-22 15:54:06,137 [INFO] Executing rollback for run_uuid=d3f0859b-91f7-490a-afb9-878478b1574a, scenario_type=*
 2025-08-22 15:54:06,137 [INFO] Executing rollback version files for run_uuid=d3f0859b-91f7-490a-afb9-878478b1574a, scenario_type=*
-2025-08-22 15:54:06,137 [INFO] Executing rollback version file: /tmp/kraken-rollback/1755523355298089000-d3f0859b-91f7-490a-afb9-878478b1574a/application_outages_scenarios_1755523353558511000_mfsaltfl.py
+2025-08-22 15:54:06,137 [INFO] Executing rollback version file: ~/.krkn/rollback/1755523355298089000-d3f0859b-91f7-490a-afb9-878478b1574a/application_outages_scenarios_1755523353558511000_mfsaltfl.py
 2025-08-22 15:54:06,139 [INFO] Executing rollback callable...
 2025-08-22 15:54:06,139 [INFO] Rolling back network policy: krkn-deny-xafee in namespace: test-application-outage
 2025-08-22 15:54:06,148 [INFO] Network policy already deleted
 2025-08-22 15:54:06,148 [INFO] Network policy rollback completed successfully.
 2025-08-22 15:54:06,148 [INFO] Rollback completed.
-2025-08-22 15:54:06,148 [INFO] Executed /tmp/kraken-rollback/1755523355298089000-d3f0859b-91f7-490a-afb9-878478b1574a/application_outages_scenarios_1755523353558511000_mfsaltfl.py successfully.
+2025-08-22 15:54:06,148 [INFO] Executed ~/.krkn/rollback/1755523355298089000-d3f0859b-91f7-490a-afb9-878478b1574a/application_outages_scenarios_1755523353558511000_mfsaltfl.py successfully.
 2025-08-22 15:54:06,149 [INFO] Rollback execution completed successfully, cleaning up version files
 2025-08-22 15:54:06,149 [INFO] Cleaning up rollback version files for run_uuid=d3f0859b-91f7-490a-afb9-878478b1574a, scenario_type=None
-2025-08-22 15:54:06,149 [INFO] Removed /tmp/kraken-rollback/1755523355298089000-d3f0859b-91f7-490a-afb9-878478b1574a/application_outages_scenarios_1755523353558511000_mfsaltfl.py successfully.
+2025-08-22 15:54:06,149 [INFO] Removed ~/.krkn/rollback/1755523355298089000-d3f0859b-91f7-490a-afb9-878478b1574a/application_outages_scenarios_1755523353558511000_mfsaltfl.py successfully.
 2025-08-22 15:54:06,149 [INFO] Rollback execution and cleanup completed successfully
 ```
 
@@ -128,7 +128,7 @@ By default, these options are set as follows and can be overridden in [config/co
 ```yaml
 kraken:
     auto_rollback: True                                    # Enable auto rollback for scenarios.
-    rollback_versions_directory: /tmp/kraken-rollback      # Directory to store rollback version files.
+    rollback_versions_directory: ~/.krkn/rollback      # Directory to store rollback version files.
 ```
 
 ## Details of Rollback Scenario
@@ -158,14 +158,14 @@ The lifecycle of a rollback operation is scoped to **each chaos scenario**.
 ### Version Files Directory Structure
 
 The version files directory structure will be organized by
-- **Versions Directory**: The root directory for all version files, defaulting to `/tmp/kraken-rollback`.
+- **Versions Directory**: The root directory for all version files, defaulting to `~/.krkn/rollback`.
     - **Rollback Context Directory**: The Rollback Context Directory is formatted as `<timestamp (ns)>-<run_uuid>`. Since each _Run_ of a chaos scenario generates a unique **Run UUID**, which is used to identify the context of the rollback operation.
         - **Version Files**: Each version file will be named as `<chaos_scenario_name>_<timestamp (ns)>_<random_suffix>.py`.
 
 Here is an example of the directory structure:
 
 ```bash
-/tmp/kraken-rollback
+~/.krkn/rollback
 ├── 1755488223093251000-168dce4c-fdb4-4e8c-aa5b-7f919777801b
 │   └── network_chaos_scenarios_1755488221668750000_fphcbojh.py
 ├── 1755496143932815000-7d32bf81-2c0d-4d56-b75b-b0702b2c45f9


### PR DESCRIPTION
## Documentation Update
**Branch:** docs/rollback-default-directory

**Changes:** 

Updated rollback documentation to reflect the current default rollback directory used by Krkn.

### Updated references

* Changed default rollback directory references from:

  ```
  /tmp/kraken-rollback
  ```

  to:

  ```
  ~/.krkn/rollback
  ```

## Sources

The documentation changes were verified against:

### Krkn logs:

```
Using secure default rollback directory: /Users/<user>/.krkn/rollback
```

### run_kraken.py

```python
rollback_versions_dir = os.path.join(
    os.path.expanduser("~"),
    ".krkn",
    "rollback"
)
```

### tests/test_rollback.py

```python
assert rollback_versions_dir != "/tmp/kraken-rollback"
assert "/.krkn/rollback" in normalized
```

## Documentation Pages Updated

* content/en/docs/rollback-scenarios/index.md


