### PR TITLE
docs: correct testing changes link text

### DIFF
--- a/content/en/docs/contribution-guidelines/_index.md
+++ b/content/en/docs/contribution-guidelines/_index.md
@@ -59,7 +59,7 @@ Here's a quick checklist for a good PR, more details below:
 Refer to the docs below to be able to test your own images with any changes and be able to contribute them to the repository
 - [Getting Started](/docs/getting-started/getting-started-krkn.md)
 - [Contribute - Git Pointers](/docs/contribution-guidelines/git-pointers.md)
-- [Testing Your Krkn-hub Changes](/docs/developers-guide/testing-changes.md)
+- [Testing Your Krkn Changes](/docs/developers-guide/testing-changes.md)
 
 ## Questions?
 


### PR DESCRIPTION
## Documentation Update
**Related Feature:** 


**Changes:** 

Describe the documentation updates made for the feature.

- minor changes. Felt the text in https://krkn-chaos.dev/docs/contribution-guidelines/ in Helpful Documents was a bit incorrect

<img width="607" height="216" alt="image" src="https://github.com/user-attachments/assets/2450fa92-27d6-4690-8c61-3685e669779a" />

to

<img width="677" height="232" alt="image" src="https://github.com/user-attachments/assets/3cf20223-6791-433b-80f9-3d1398d7f1b6" />

As it was not krkn-hub specific
