### PR TITLE
docs: document --save-strategy for discover

### DIFF
--- a/content/en/docs/krkn_ai/discover.md
+++ b/content/en/docs/krkn_ai/discover.md
@@ -26,6 +26,9 @@ Options:
   -v, --verbose           Increase verbosity of output.
   --skip-pod-name TEXT    Pod name to skip. Supports comma separated values
                           with regex.
+  --save-strategy [skip|overwrite|merge]
+                          How to save: skip, overwrite (replace), or merge
+                          (add new).
   --help                  Show this message and exit.
 ```
 
@@ -143,3 +146,20 @@ cluster_components:
     taints: []
 ```
 
+### Save Strategy
+
+By default `discover` won't overwrite an existing output file. Control this with `--save-strategy`:
+
+| Strategy         | Behavior                                              |
+|------------------|-------------------------------------------------------|
+| `skip` (default) | Keep the existing file, do nothing.                   |
+| `overwrite`      | Replace the file with a fresh config.                 |
+| `merge`          | Keep your edits, add newly discovered components.     |
+
+```bash
+uv run krkn_ai discover -k ./tmp/kubeconfig.yaml -o ./krkn-ai.yaml --save-strategy merge
+```
+
+`merge` preserves manual edits (e.g. `disabled: true`) and adds newly discovered components.
+
+> **Note:** Comments inside `cluster_components` are not preserved after a merge.


### PR DESCRIPTION
## Documentation Update
  **Related Feature:** mrinalchaturvedi27/krkn-ai feat/save-strategy

  **Changes:**
  Added `--save-strategy` option to the `discover` command documentation:
  - Updated `--help` block with the new flag
  - Added Save Strategy section with a table explaining skip, overwrite, and merge behaviors

  Related to krkn-chaos/krkn-ai#375 — Week 2 of [#364](https://github.com/krkn-chaos/krkn-ai/issues/364)