### PR TITLE
docs: add krkn-dashboard deprecation notice

### DIFF
--- a/content/en/docs/krkn_dashboard/_index.md
+++ b/content/en/docs/krkn_dashboard/_index.md
@@ -6,6 +6,10 @@ description: >
 weight: 11
 ---
 
+{{% alert title="Deprecated" color="warning" %}}
+**krkn-dashboard is deprecated** and will be archived. If you are looking for a UI to interact with krkn, please migrate to [krkn-operator](https://github.com/krkn-chaos/krkn-operator).
+{{% /alert %}}
+
 Krkn Dashboard is the **visualization and control component** of [krkn-hub](https://github.com/krkn-chaos/krkn-hub). It provides a user-friendly web interface to run chaos experiments, watch runs in real time, and—when configured—inspect historical runs and metrics via Elasticsearch and Grafana. Instead of using the CLI or editing config files, you can trigger and monitor Krkn scenarios from your browser.
 
 ---

--- a/content/en/docs/krkn_dashboard/users-and-access.md
+++ b/content/en/docs/krkn_dashboard/users-and-access.md
@@ -5,6 +5,10 @@ description: Platform roles, groups, group roles, and cluster permissions in the
 weight: 5
 ---
 
+{{% alert title="Deprecated" color="warning" %}}
+**krkn-dashboard is deprecated** and will be archived. If you are looking for a UI to interact with krkn, please migrate to [krkn-operator](https://github.com/krkn-chaos/krkn-operator).
+{{% /alert %}}
+
 The dashboard uses platform roles, groups, group roles, and cluster policies to restrict access.
 
 ---

--- a/content/en/docs/krkn_dashboard/using-the-ui.md
+++ b/content/en/docs/krkn_dashboard/using-the-ui.md
@@ -5,6 +5,10 @@ description: How to run scenarios and use the dashboard once it is running.
 weight: 10
 ---
 
+{{% alert title="Deprecated" color="warning" %}}
+**krkn-dashboard is deprecated** and will be archived. If you are looking for a UI to interact with krkn, please migrate to [krkn-operator](https://github.com/krkn-chaos/krkn-operator).
+{{% /alert %}}
+
 ## Using the UI
 
 When starting the dashboard, if you are not signed in, you will be sent to the **login** page. Use the initial admin credentials from [installation](/docs/installation/krkn-dashboard/#first-time-setup-initial-admin-account) on first startup, or the username and password your administrator created for you. 


### PR DESCRIPTION
## Summary

- Adds a deprecation warning banner to all three krkn-dashboard documentation pages
- Directs users to migrate to [krkn-operator](https://github.com/krkn-chaos/krkn-operator)
- Uses the existing `{{% alert %}}` Hugo shortcode to match site style

## Pages updated

- `docs/krkn_dashboard/_index.md`
- `docs/krkn_dashboard/users-and-access.md`
- `docs/krkn_dashboard/using-the-ui.md`

## Test plan

- [ ] Preview site build shows warning banner on all three pages
- [ ] Link to krkn-operator resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)