### PR TITLE
docs: update krkn-ai config for nested genetic algorithm layout

### DIFF
--- a/content/en/docs/krkn_ai/config/_index.md
+++ b/content/en/docs/krkn_ai/config/_index.md
@@ -5,3 +5,35 @@ weight: 5
 ---
 
 Krkn-AI is configured using a simple declarative YAML file. This file can be automatically generated using Krkn-AI's [discover](../discover.md) feature, which creates a config file from a boilerplate template. The generated config file will have the cluster components pre-populated based on your cluster.
+
+### Config Structure
+
+The config file has two layers: **top-level settings** that apply regardless of the optimization algorithm, and **algorithm-specific sections** scoped under their own key. The `algorithm` field selects which engine to use (currently only `genetic`), and all parameters for that engine live under the corresponding section:
+
+```yaml
+kubeconfig_file_path: "./tmp/kubeconfig.yaml"
+wait_duration: 120
+
+algorithm: genetic          # algorithm selector
+
+genetic:                    # all genetic algorithm parameters live here
+  generations: 20
+  population_size: 10
+  # ...
+
+fitness_function:
+  query: 'sum(kube_pod_container_status_restarts_total)'
+  type: point
+
+scenario:
+  pod-scenarios:
+    enable: true
+
+cluster_components:
+  namespaces: [...]
+  nodes: [...]
+```
+
+> **Backward compatibility:** Config files using the old flat layout (GA fields at root level) are still supported — they are automatically migrated on load.
+
+See the subsections below for detailed documentation of each config block.

--- a/content/en/docs/krkn_ai/config/evolutionary_algorithm.md
+++ b/content/en/docs/krkn_ai/config/evolutionary_algorithm.md
@@ -20,74 +20,143 @@ Krkn-AI uses an online learning approach by leveraging an evolutionary algorithm
 - **Composition**: The process of combining existing Chaos experiments into a grouped scenario to represent a single new scenario.
 - **Population Injection**: The introduction of new individuals into the population to escape stagnation.
 
+### Algorithm Selector
+
+#### `algorithm`
+
+Selects which optimization engine to use. (Default: `genetic`)
+
+Currently the only supported value is `genetic`. The architecture is designed to support future engines — each engine gets its own config section.
+
+```yaml
+algorithm: genetic
+```
+
 ### Configurations
 
-The algorithm relies on specific configurations to guide its execution. These settings can be adjusted in the Krkn-AI config file, which you generate using the [discover](../discover.md) command.
+The algorithm relies on specific configurations to guide its execution. These settings live under the `genetic:` section of the Krkn-AI config file, which you generate using the [discover](../discover.md) command.
 
-#### `generations`
+> **Backward compatibility:** Config files using the old flat layout (GA fields at root level) are still supported — they are automatically migrated on load.
 
-Total number of generation loop to run (Default: 20)
+```yaml
+algorithm: genetic
+
+genetic:
+  generations: 20
+  population_size: 10
+  mutation_rate: 0.7
+  scenario_mutation_rate: 0.6
+  crossover_rate: 0.6
+  composition_rate: 0.0
+  selection_strategy: "roulette"
+  # tournament_size: 3
+  population_injection_rate: 0.0
+  population_injection_size: 2
+  adaptive_mutation:
+    enable: false
+  # stopping_criteria:
+  #   fitness_threshold: 200
+```
+
+#### `genetic.generations`
+
+Total number of generation loops to run. (Default: 20)
 
 - The value for this field should be **at least 1**.
 - Setting this to a higher value increases Krkn-AI testing coverage.
 - Each scenario tested in the current generation retains some properties from the previous generation.
+- Mutually exclusive with `duration` — set one or the other.
 
-#### `population_size`
+#### `genetic.duration`
 
-Minimum Population size in each generation (Default: 10)
+Maximum time (in seconds) the algorithm should run. (Default: disabled)
+
+- When set, the algorithm runs until the duration elapses instead of counting generations.
+- Mutually exclusive with `generations` — set one or the other.
+
+#### `genetic.population_size`
+
+Minimum population size in each generation. (Default: 10)
 
 - The value for this field should be **at least 2**.
 - Setting this to a higher value will increase the number of scenarios tested per generation, which is helpful for running diverse test samples.
 - A higher value is also preferred when you have a large set of objects in cluster components and multiple scenarios enabled.
 - If you have a limited set of components to be evaluated, you can set a smaller population size and fewer generations.
 
-#### `crossover_rate`
+#### `genetic.crossover_rate`
 
-How often crossover should occur for each scenario parameter (Default: 0.6 and Range: [0.0, 1.0])
+How often crossover should occur for each scenario parameter. (Default: 0.6; Range: [0.0, 1.0])
 
 - A higher crossover rate increases the likelihood that a crossover operation will create two new candidate solutions from two existing candidates.
 - Setting the crossover rate to `1.0` ensures that crossover always occurs during selection process.
 
-#### `mutation_rate`
+#### `genetic.mutation_rate`
 
-How often mutation should occur for each scenario parameter (Default: 0.7 and Range: [0.0, 1.0])
+How often mutation should occur for each scenario parameter. (Default: 0.7; Range: [0.0, 1.0])
 
 - This helps to control the diversification among the candidates. A higher value increases the likelihood that a mutation operation will be applied.
 - Setting this to `1.0` ensures persistent mutation during the selection process.
 
-#### `scenario_mutation_rate`
+#### `genetic.scenario_mutation_rate`
 
-How often a mutation should result in a change to the scenario (Default: 0.6; Range: [0.0, 1.0])
+How often a mutation should result in a change to the scenario. (Default: 0.6; Range: [0.0, 1.0])
 
 - A higher rate increases diversity between scenarios in each generation.
 - A lower rate gives priority to retaining the existing scenario across generations.
 
-#### `composition_rate`
+#### `genetic.composition_rate`
 
-How often a crossover would lead to composition (Default: 0.0 and Range: [0.0, 1.0])
+How often a crossover would lead to composition. (Default: 0.0; Range: [0.0, 1.0])
 
 - By default, this value is disabled, but you can set it to a higher rate to increase the likelihood of composition.
 
+#### `genetic.selection_strategy`
 
-#### `population_injection_rate`
+Strategy used to select parents for the next generation. (Default: `roulette`)
 
-How often a random samples gets newly added to population (Default: 0.0 and Range: [0.0, 1.0])
+- `roulette` — Fitness-proportionate selection. Higher-fitness individuals have a greater probability of being selected.
+- `tournament` — Randomly selects a subset of individuals and picks the best. Use `tournament_size` to control the subset size.
+
+#### `genetic.tournament_size`
+
+Number of individuals competing in each tournament round when `selection_strategy` is set to `tournament`. (Default: 3)
+
+#### `genetic.population_injection_rate`
+
+How often random samples get newly added to the population. (Default: 0.0; Range: [0.0, 1.0])
 
 - A higher injection rate increases the likelihood of introducing new candidates into the existing generation.
 
-#### `population_injection_size`
+#### `genetic.population_injection_size`
 
-What's the size of random samples that gets added to new population (Default: 2)
+Size of random samples that get added to the new population. (Default: 2)
 
 - A higher injection size means that more diversified samples get added during the evolutionary algorithm loop.
 - This is beneficial if you want to start with a smaller population test set and then increase the population size as you progress through the test.
 
+#### `genetic.adaptive_mutation`
+
+Dynamically adjusts the mutation rate based on fitness convergence. When enabled, the mutation rate automatically increases when the population stagnates and decreases when progress is being made.
+
+```yaml
+genetic:
+  adaptive_mutation:
+    enable: false       # Enable adaptive mutation (Default: false)
+    min: 0.05           # Minimum mutation rate (Default: 0.05)
+    max: 0.9            # Maximum mutation rate (Default: 0.9)
+    threshold: 0.1      # Fitness improvement threshold to detect stagnation (Default: 0.1)
+    generations: 5      # Number of generations to look back for stagnation (Default: 5)
+```
+
+#### `genetic.stopping_criteria`
+
+Configuration for advanced stopping conditions based on fitness, saturation, or exploration limits. See [Stopping Criteria](stopping_criteria.md) for full details.
+
+### Top-Level Settings
+
+The following fields remain at the top level of the config file (outside the `genetic:` section):
 
 #### `wait_duration`
 
 Time to wait after scenario execution. Sets Krkn's `--wait-duration` parameter. (Default: 120 seconds)
-
-#### `stopping_criteria`
-
-Configuration for advanced stopping conditions based on fitness, saturation, or exploration limits. See [Stopping Criteria](stopping_criteria.md) for full details.
 

--- a/content/en/docs/krkn_ai/config/scenarios.md
+++ b/content/en/docs/krkn_ai/config/scenarios.md
@@ -21,6 +21,8 @@ The following Krkn scenarios are currently supported by Krkn-AI.
 | [Network Scenarios](../../scenarios/network-chaos-scenario/)       	| *scenario.network-scenarios*      	|
 | [DNS Outage](../../scenarios/dns-outage/)       	| *scenario.dns-outage*      	|
 | [PVC Scenario](../../scenarios/pvc-scenario/)       	| *scenario.pvc-scenarios*      	|
+| [KubeVirt VM Outage](../../scenarios/kubevirt-vm-outage-scenario/)       	| *scenario.kubevirt-scenarios*      	|
+| [Storage Throttle](../../scenarios/storage-throttle-scenario/)       	| *scenario.storage-throttle*      	|
 
 
 By default, scenarios are not enabled. Depending on your use case, you can enable or disable these scenarios in the `krkn-ai.yaml` config file by setting the `enable` field to `true` or `false`.
@@ -58,5 +60,11 @@ scenario:
     enable: true
 
   pvc-scenarios:
+    enable: false
+
+  kubevirt-scenarios:
+    enable: false
+
+  storage-throttle:
     enable: false
 ```

--- a/content/en/docs/krkn_ai/config/stopping_criteria.md
+++ b/content/en/docs/krkn_ai/config/stopping_criteria.md
@@ -8,7 +8,7 @@ The stopping criteria framework lets users define when the genetic algorithm sho
 
 ### Configurations
 
-You can configure the following options under the `stopping_criteria` section of the Krkn-AI config file. All fields are optional and, with the exception of `saturation_threshold`, default to disabled (`null`).
+You can configure the following options under the `genetic.stopping_criteria` section of the Krkn-AI config file. All fields are optional and, with the exception of `saturation_threshold`, default to disabled (`null`).
 
 #### `fitness_threshold`
 
@@ -41,9 +41,10 @@ If the improvement in fitness is less than this threshold, it is treated as stag
 ### Example Configuration
 
 ```yaml
-stopping_criteria:
-  fitness_threshold: 200        # stop when fitness >= 200
-  generation_saturation: 5      # stop if no improvement for 5 generations
-  exploration_saturation: 3     # stop if no new scenarios for 3 generations
-  saturation_threshold: 0.0001  # minimum improvement to reset saturation counter
+genetic:
+  stopping_criteria:
+    fitness_threshold: 200        # stop when fitness >= 200
+    generation_saturation: 5      # stop if no improvement for 5 generations
+    exploration_saturation: 3     # stop if no new scenarios for 3 generations
+    saturation_threshold: 0.0001  # minimum improvement to reset saturation counter
 ```

--- a/content/en/docs/krkn_ai/discover.md
+++ b/content/en/docs/krkn_ai/discover.md
@@ -50,15 +50,19 @@ The above command generates a config file that contains the basic setup to help 
 # Path to your kubeconfig file
 kubeconfig_file_path: "./path/to/kubeconfig.yaml"
 
-# Genetic algorithm parameters
-generations: 5
-population_size: 10
-composition_rate: 0.3
-population_injection_rate: 0.1
-scenario_mutation_rate: 0.6
-
 # Duration to wait before running next scenario (seconds)
 wait_duration: 30
+
+# Algorithm selector
+algorithm: genetic
+
+# Genetic algorithm parameters
+genetic:
+  generations: 5
+  population_size: 10
+  composition_rate: 0.3
+  population_injection_rate: 0.1
+  scenario_mutation_rate: 0.6
 
 # Specify how result filenames are formatted
 output:


### PR DESCRIPTION
  ## Documentation Update
  **Related Release:** https://github.com/krkn-chaos/krkn-ai/releases/tag/v0.1.0

  **Changes:**

  Updates Krkn-AI configuration documentation to reflect the config restructuring
  introduced in krkn-ai, where genetic algorithm parameters moved from the root level
  into a nested `genetic:` section with a new `algorithm:` selector field.

  ### Updated pages

  - **config/_index.md** — Added "Config Structure" overview explaining the new
    `algorithm` field and nested layout, with a quick-reference YAML example
  - **config/evolutionary_algorithm.md** — Restructured all GA parameter docs under
    `genetic:` prefix (e.g. `genetic.generations`, `genetic.population_size`).
    Added 4 previously undocumented fields: `duration`, `selection_strategy`,
    `tournament_size`, `adaptive_mutation`
  - **config/stopping_criteria.md** — Updated text and example YAML to show
    `stopping_criteria` nested under `genetic:`
  - **config/scenarios.md** — Added two new scenarios: `kubevirt-scenarios` and
    `storage-throttle`
  - **discover.md** — Updated example config YAML from old flat layout to new
    nested format

  ### Notes

  - Old flat config files are still supported via automatic migration on load —
    this is noted in the docs for users with existing configs
  - `wait_duration` remains at the top level (not moved under `genetic:`)

