### PR TITLE
docs: add standalone mode and OpenShift Virtualization chaos docs

### DIFF
--- a/content/en/docs/scenarios/_index.md
+++ b/content/en/docs/scenarios/_index.md
@@ -3,7 +3,7 @@ type: "docs/scenarios"
 title: Scenarios
 description: Krkn scenario list
 date: 2017-01-04
-weight: 4
+weight: 6
 ---
 
 {{% alert title="Tip" %}}
@@ -129,29 +129,7 @@ Many pod scenarios now support the `exclude_label` parameter to protect critical
 }
 </style>
 
-<div class="scenario-filter" id="scenario-filter">
-<div class="scenario-filter__row">
-<span class="scenario-filter__label">Category</span>
-<div class="scenario-filter__pills" role="group" aria-label="Filter by category">
-<button class="scenario-filter__btn scenario-filter__btn--active" data-filter="all" type="button" aria-pressed="true">All</button>
-<button class="scenario-filter__btn" data-filter="pod-container" type="button" aria-pressed="false">Pod &amp; Container</button>
-<button class="scenario-filter__btn" data-filter="node-cluster" type="button" aria-pressed="false">Node &amp; Cluster</button>
-<button class="scenario-filter__btn" data-filter="network" type="button" aria-pressed="false">Network</button>
-<button class="scenario-filter__btn" data-filter="application-service" type="button" aria-pressed="false">Application &amp; Service</button>
-<button class="scenario-filter__btn" data-filter="storage-data" type="button" aria-pressed="false">Storage &amp; Data</button>
-<button class="scenario-filter__btn" data-filter="system-time" type="button" aria-pressed="false">System &amp; Time</button>
-</div>
-</div>
-<div class="scenario-filter__row scenario-filter__row--search">
-<label class="scenario-filter__label" for="scenario-filter-search">Search</label>
-<input class="scenario-filter__search" id="scenario-filter-search" type="search" placeholder="Search scenarios..." autocomplete="off" />
-<button class="scenario-filter__reset" id="scenario-filter-reset" type="button">Reset</button>
-</div>
-<div class="scenario-filter__empty" id="scenario-filter-empty" hidden>No scenarios match your filters.</div>
-</div>
-
-<section class="scenario-category" data-category="pod-container">
-<h3 class="category-header">Pod &amp; Container Disruptions</h3>
+### Pod & Container Disruptions
 
 <div class="scenario-grid">
 
@@ -183,10 +161,8 @@ Many pod scenarios now support the `exclude_label` parameter to protect critical
 </div>
 
 </div>
-</section>
 
-<section class="scenario-category" data-category="node-cluster">
-<h3 class="category-header">Node &amp; Cluster Failures</h3>
+### Node & Cluster Failures
 
 <div class="scenario-grid">
 
@@ -204,6 +180,7 @@ Many pod scenarios now support the `exclude_label` parameter to protect critical
 <span class="cloud-badge">IBM Power</span>
 <span class="cloud-badge">GCP</span>
 <span class="cloud-badge">OpenStack</span>
+<span class="cloud-badge">SSH (Standalone)</span>
 <span class="cloud-badge">VMWare</span>
 </div>
 </div>
@@ -265,10 +242,8 @@ Many pod scenarios now support the `exclude_label` parameter to protect critical
 
 
 </div>
-</section>
 
-<section class="scenario-category" data-category="network">
-<h3 class="category-header">Network Disruptions</h3>
+### Network Disruptions
 
 <div class="scenario-grid">
 
@@ -336,11 +311,9 @@ Many pod scenarios now support the `exclude_label` parameter to protect critical
 </div>
 
 </div>
-</section>
 
 
-<section class="scenario-category" data-category="application-service">
-<h3 class="category-header">Application &amp; Service Disruptions</h3>
+### Application & Service Disruptions
 
 <div class="scenario-grid">
 
@@ -380,21 +353,10 @@ Many pod scenarios now support the `exclude_label` parameter to protect critical
 </div>
 </div>
 
-<div class="scenario-card">
-<h3><a href="http-load-scenario/">HTTP Load</a></h3>
-<span class="scenario-badge">http_load_scenarios</span>
-<p class="scenario-description">Generates distributed HTTP load against target endpoints using Vegeta load testing pods deployed inside the cluster</p>
-<div class="cloud-badges">
-<span class="cloud-badge cloud-badge--agnostic">Cloud Agnostic</span>
-</div>
-</div>
-
 
 </div>
-</section>
 
-<section class="scenario-category" data-category="storage-data">
-<h3 class="category-header">Storage &amp; Data Disruptions</h3>
+### Storage & Data Disruptions
 
 <div class="scenario-grid">
 
@@ -407,20 +369,9 @@ Many pod scenarios now support the `exclude_label` parameter to protect critical
 </div>
 </div>
 
-<div class="scenario-card">
-<h3><a href="storage-throttle-scenario/">Storage I/O Throttle</a></h3>
-<span class="scenario-badge">storage_throttle_scenarios</span>
-<p class="scenario-description">Limits read/write IOPS and bandwidth on PVC-backed volumes using Linux cgroup I/O controls</p>
-<div class="cloud-badges">
-<span class="cloud-badge cloud-badge--agnostic">Cloud Agnostic</span>
-</div>
 </div>
 
-</div>
-</section>
-
-<section class="scenario-category" data-category="system-time">
-<h3 class="category-header">System &amp; Time Disruptions</h3>
+### System & Time Disruptions
 
 <div class="scenario-grid">
 
@@ -434,6 +385,55 @@ Many pod scenarios now support the `exclude_label` parameter to protect critical
 </div>
 
 </div>
-</section>
 
-<script src="/js/scenario-filter.js" defer></script>
+### Virtualization Scenarios
+
+<div class="scenario-grid">
+
+<div class="scenario-card">
+<h3><a href="vm-migration-chaos/">VM Migration Chaos</a></h3>
+<span class="scenario-badge">vm_migration_chaos_scenarios</span>
+<p class="scenario-description">Tests live migration resilience under network stress, CPU pressure, and node drain in OpenShift Virtualization</p>
+<div class="cloud-badges">
+<span class="cloud-badge cloud-badge--agnostic">Cloud Agnostic</span>
+</div>
+</div>
+
+<div class="scenario-card">
+<h3><a href="vm-storage-chaos/">VM Storage Chaos</a></h3>
+<span class="scenario-badge">vm_storage_chaos_scenarios</span>
+<p class="scenario-description">Disrupts storage services, generates IO bursts, and fills storage volumes in VM environments</p>
+<div class="cloud-badges">
+<span class="cloud-badge cloud-badge--agnostic">Cloud Agnostic</span>
+</div>
+</div>
+
+<div class="scenario-card">
+<h3><a href="vmware-migration-validation/">VMware Migration Validation</a></h3>
+<span class="scenario-badge">5-step validation pack</span>
+<p class="scenario-description">Structured 5-step chaos validation process for VMware-to-OpenShift Virtualization migrations</p>
+<div class="cloud-badges">
+<span class="cloud-badge cloud-badge--agnostic">Cloud Agnostic</span>
+</div>
+</div>
+
+</div>
+
+### Standalone Mode
+
+<div class="scenario-grid">
+
+<div class="scenario-card">
+<h3><a href="standalone-mode/">Standalone Mode</a></h3>
+<span class="scenario-badge">execution_mode: standalone</span>
+<p class="scenario-description">Run chaos experiments on bare-metal, RHEL, and VM hosts via SSH without requiring Kubernetes</p>
+<div class="cloud-badges">
+<span class="cloud-badge">SSH</span>
+<span class="cloud-badge">Bare Metal</span>
+<span class="cloud-badge">RHEL/CentOS</span>
+<span class="cloud-badge">VMware</span>
+</div>
+</div>
+
+</div>
+

--- a/content/en/docs/scenarios/node-scenarios/_index.md
+++ b/content/en/docs/scenarios/node-scenarios/_index.md
@@ -36,6 +36,7 @@ Supported cloud providers:
 - [Docker](#docker)
 - [IBMCloud](#ibmcloud)
 - [IBMCloud Power](#ibmcloud-power)
+- [SSH (Standalone)](#ssh-standalone)
 
 {{% alert title="Note" %}}If the node does not recover from the node_crash_scenario injection, reboot the node to get it back to Ready state. {{% /alert %}}
 

--- a/content/en/docs/scenarios/node-scenarios/_tab-krkn.md
+++ b/content/en/docs/scenarios/node-scenarios/_tab-krkn.md
@@ -156,6 +156,42 @@ See a sample of ibm cloud node scenarios [example config file](https://github.co
 The cloud type in the scenario yaml file needs to be `ibmpower` or `ibmcloudpower`
 
 
+## SSH (Standalone)
+
+The SSH provider enables node chaos scenarios on any Linux host reachable via SSH, without requiring a cloud provider or Kubernetes API. Use `cloud_type: ssh` and provide a `targets` list of host IPs or hostnames instead of `node_name` or `label_selector`.
+
+This is part of krkn's [Standalone Mode](../standalone-mode/), which lets you run chaos on bare-metal servers, RHEL/CentOS VMs, or any other Linux host.
+
+**Supported actions via SSH:**
+- `node_reboot_scenario` (hard reboot via sysrq or soft reboot via `sudo reboot`)
+- `node_stop_scenario` (graceful shutdown via `sudo shutdown -h now`)
+- `node_crash_scenario` (kernel crash via sysrq trigger)
+- `stop_kubelet_scenario` (stop kubelet service if present)
+- `restart_kubelet_scenario` (restart kubelet service if present)
+
+{{% alert title="Note" %}}`node_start_scenario` and `node_termination_scenario` are not supported via SSH. These actions require a cloud provider API to power on or destroy instances.{{% /alert %}}
+
+Sample scenario config:
+```yaml
+node_scenarios:
+  - actions:
+      - node_reboot_scenario
+    cloud_type: ssh
+    targets:
+      - 192.168.1.100
+      - 192.168.1.101
+    ssh_user: root
+    ssh_private_key: ~/.ssh/id_rsa
+    ssh_port: 22
+    runs: 1
+    timeout: 360
+    kube_check: false
+    soft_reboot: true
+```
+
+{{% alert title="Note" %}}When using `cloud_type: ssh`, set `kube_check: false` unless the target hosts are Kubernetes nodes with a working kubeconfig. The SSH provider uses SSH connectivity checks instead of Kubernetes API calls to verify node recovery.{{% /alert %}}
+
+
 ## General
 {{% alert title="Note" %}} The `node_crash_scenario` and `stop_kubelet_scenario` scenarios are supported independent of the cloud platform.{{% /alert %}}
 

--- a/content/en/docs/scenarios/standalone-mode/_index.md
+++ b/content/en/docs/scenarios/standalone-mode/_index.md
@@ -1,0 +1,281 @@
+---
+type: "docs/scenarios"
+title: Standalone Mode
+description: Run chaos experiments on bare-metal, RHEL, and VM hosts without Kubernetes
+date: 2017-01-04
+weight: 12
+---
+
+Standalone mode lets krkn run chaos experiments on any Linux host reachable via SSH — no Kubernetes or OpenShift required. Use it for bare-metal servers, RHEL/CentOS VMs, VMware-to-KVM migrations, hyperconverged infrastructure, or any environment where you need to validate host resilience outside a container orchestrator.
+
+## Architecture
+
+The krkn controller machine connects to one or more target hosts over SSH using key-based authentication. All chaos operations (reboots, CPU stress, disk fill, network faults, time skew, file corruption) are executed remotely via paramiko SSH. No agent or daemon is installed on the target hosts.
+
+```
+   Controller (krkn)
+        |
+        | SSH (paramiko)
+        |
+   +----+----+----+
+   |    |    |    |
+ Host  Host Host Host
+  A     B    C    D
+```
+
+The controller orchestrates all scenario execution, health checks, and rollback from a single machine. Target hosts only need an SSH server and the standard Linux utilities used by each scenario.
+
+## Prerequisites
+
+- Python 3.11+ on the controller machine
+- SSH key-based access to all target hosts (password authentication is not supported)
+- root or sudo access on target hosts (most scenarios require privileged operations)
+- `stress-ng` installed on target hosts (required for hog and IO scenarios)
+- Target hosts must be Linux (RHEL, CentOS, Ubuntu, Fedora, etc.)
+
+## Configuration
+
+Set `execution_mode: standalone` in your config file to skip Kubernetes API initialization and operate purely over SSH.
+
+```yaml
+kraken:
+    execution_mode: standalone
+    kubeconfig_path:        # Leave empty for standalone
+    exit_on_failure: False
+    chaos_scenarios:
+        - node_scenarios:
+            - scenarios/standalone/ssh_node_reboot.yml
+        - hog_scenarios:
+            - scenarios/standalone/hog_cpu.yml
+        - network_chaos_scenarios:
+            - scenarios/standalone/network_chaos_latency.yml
+        - time_scenarios:
+            - scenarios/standalone/time_skew.yml
+        - standalone_disk_fill_scenarios:
+            - scenarios/standalone/disk_fill.yml
+        - standalone_file_scenarios:
+            - scenarios/standalone/file_chmod.yml
+```
+
+{{% alert title="Note" %}}
+`execution_mode: standalone` is the key setting. When set, krkn skips Kubernetes API initialization and operates purely over SSH. You do not need a kubeconfig or access to any cluster.
+{{% /alert %}}
+
+## SSH Configuration Reference
+
+All standalone scenarios share these SSH parameters in their scenario YAML files:
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `ssh_user` | string | `root` | SSH username on target hosts |
+| `ssh_private_key` | string | `~/.ssh/id_rsa` | Path to SSH private key |
+| `ssh_port` | int | `22` | SSH port on target hosts |
+| `ssh_connect_timeout` | int | `30` | Connection timeout in seconds |
+| `targets` | list | required | List of target host IPs or hostnames |
+
+## Supported Scenarios
+
+### Node Scenarios (cloud_type: ssh)
+
+Use `cloud_type: ssh` in the node scenario config to run node-level chaos over SSH. Supported actions:
+
+- `node_reboot_scenario` — Hard or soft reboot via SSH (sysrq trigger or `sudo reboot`)
+- `node_stop_scenario` — Graceful shutdown via `sudo shutdown -h now`
+- `node_crash_scenario` — Kernel crash via sysrq trigger
+- `stop_kubelet_scenario` — Stop kubelet service (if present on the host)
+- `restart_kubelet_scenario` — Restart kubelet service (if present on the host)
+
+{{% alert title="Note" %}}
+`node_start_scenario` and `node_termination_scenario` are NOT supported via SSH. These actions require cloud provider APIs to power on or destroy instances.
+{{% /alert %}}
+
+Sample scenario file:
+
+```yaml
+node_scenarios:
+  - actions:
+      - node_reboot_scenario
+    cloud_type: ssh
+    targets:
+      - 192.168.1.100
+      - 192.168.1.101
+    ssh_user: root
+    ssh_private_key: ~/.ssh/id_rsa
+    ssh_port: 22
+    runs: 1
+    timeout: 360
+    kube_check: false
+    soft_reboot: true
+```
+
+### Network Chaos
+
+SSH-based network chaos using `tc` and `netem`. Injects latency, packet loss, and bandwidth restrictions on target hosts.
+
+Sample scenario file:
+
+```yaml
+network_chaos:
+  targets:
+    - 192.168.1.100
+  ssh_user: root
+  ssh_private_key: ~/.ssh/id_rsa
+  duration: 300
+  interfaces: []
+  execution: serial
+  egress:
+    latency: 100ms
+```
+
+### CPU/Memory/IO Hog
+
+Deploys `stress-ng` workloads on target hosts via SSH. Supports CPU, memory, and IO stress types.
+
+Sample scenario file:
+
+```yaml
+hog-type: cpu
+targets:
+  - 192.168.1.100
+ssh_user: root
+ssh_private_key: ~/.ssh/id_rsa
+duration: 300
+workers: 0
+cpu-load-percentage: 90
+```
+
+### Time Skew
+
+Skews system time on remote hosts via SSH. Useful for testing time-sensitive applications, certificate validation, and scheduled job behavior.
+
+Sample scenario file:
+
+```yaml
+time_scenarios:
+  - action: skew_time
+    targets:
+      - 192.168.1.100
+    ssh_user: root
+    ssh_private_key: ~/.ssh/id_rsa
+    duration: 300
+    disable_ntp: true
+```
+
+### Disk Fill (Standalone-Only)
+
+Fills disk space on target hosts to a specified percentage or absolute size. Uses `fallocate` with `dd` fallback for compatibility across distributions.
+
+Scenario type: `standalone_disk_fill_scenarios`
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `targets` | list | required | List of target host IPs |
+| `fill_path` | string | `/tmp` | Path to fill on target hosts |
+| `fill_size` | string | | Absolute size to fill (e.g., `5G`, `500M`) |
+| `fill_percentage` | int | | Fill disk to this percentage |
+| `duration` | int | `60` | How long to keep the fill active (seconds) |
+
+{{% alert title="Note" %}}
+Either `fill_size` or `fill_percentage` is required. If both are provided, `fill_size` takes precedence.
+{{% /alert %}}
+
+Sample scenario file:
+
+```yaml
+targets:
+  - 192.168.1.100
+ssh_user: root
+ssh_private_key: ~/.ssh/id_rsa
+fill_path: /tmp
+fill_percentage: 90
+duration: 120
+```
+
+### File Chaos (Standalone-Only)
+
+Manipulates files on remote hosts to simulate configuration corruption, permission changes, file deletion, and content injection.
+
+Scenario type: `standalone_file_scenarios`
+
+Supported actions: `chmod`, `rename`, `append`, `delete`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `targets` | list | Target host IPs |
+| `action` | string | One of: `chmod`, `rename`, `append`, `delete` |
+| `file_path` | string | Path to the target file |
+| `permissions` | string | New permissions for `chmod` action (e.g., `000`) |
+| `target_path` | string | Destination path for `rename` action |
+| `content` | string | Content to inject for `append` action |
+| `count` | int | Number of lines to append (`append` action only) |
+| `duration` | int | Seconds before automatic revert (0 = no revert) |
+
+All actions (including `append`) are automatically reverted when `duration > 0`. When `duration` is `0`, no revert occurs for any action.
+
+Sample scenario file:
+
+```yaml
+targets:
+  - 192.168.1.100
+ssh_user: root
+ssh_private_key: ~/.ssh/id_rsa
+action: chmod
+file_path: /etc/nginx/nginx.conf
+permissions: "000"
+duration: 60
+```
+
+## Health Check Plugin
+
+Standalone mode includes an SSH-based health check plugin that monitors target hosts during chaos experiments. Unlike the Kubernetes-based Cerberus health checks, this plugin connects directly to target hosts over SSH to verify service availability and host health.
+
+Configure it in your `config.yaml`:
+
+```yaml
+standalone_health_checks:
+  interval: 5
+  ssh_user: root
+  ssh_private_key: ~/.ssh/id_rsa
+  ssh_port: 22
+  config:
+    - host: 192.168.1.100
+      exit_on_failure: true
+      checks:
+        - type: tcp
+          port: 8080
+        - type: process
+          name: nginx
+        - type: http
+          url: http://192.168.1.100:8080/health
+        - type: host_metrics
+        - type: command
+          cmd: systemctl is-active myapp
+```
+
+### Supported Check Types
+
+| Type | Description |
+|------|-------------|
+| `tcp` | Tests TCP connectivity to a port |
+| `process` | Verifies a process is running (via `pgrep`) |
+| `http` | Sends HTTP GET and checks for 200 response |
+| `host_metrics` | Collects CPU load, memory, and disk usage |
+| `command` | Runs an allowed command and checks exit code |
+
+The `command` check type restricts commands to a safe allowlist: `systemctl status/is-active`, `pgrep`, `pidof`, `test`, `cat /proc/loadavg`, `uptime`, `df`, `free`, `who`, `ss`, `ip`.
+
+## How to Run Standalone Scenarios
+
+Choose your preferred method to run standalone scenarios:
+
+{{< tabpane text=true >}}
+  {{< tab header="**Krkn**" lang="krkn" >}}
+{{< readfile file="_tab-krkn.md" >}}
+  {{< /tab >}}
+  {{< tab header="**Krkn-hub**" lang="krkn-hub" >}}
+{{< readfile file="_tab-krkn-hub.md" >}}
+  {{< /tab >}}
+  {{< tab header="**Krknctl**" lang="krknctl" >}}
+{{< readfile file="_tab-krknctl.md" >}}
+  {{< /tab >}}
+{{< /tabpane >}}

--- a/content/en/docs/scenarios/standalone-mode/_tab-krkn-hub.md
+++ b/content/en/docs/scenarios/standalone-mode/_tab-krkn-hub.md
@@ -1,0 +1,1 @@
+Standalone containers available in krkn-hub. See baremetal-* containers.

--- a/content/en/docs/scenarios/standalone-mode/_tab-krkn.md
+++ b/content/en/docs/scenarios/standalone-mode/_tab-krkn.md
@@ -1,0 +1,52 @@
+Add the scenario type and scenario file(s) to the `chaos_scenarios` section in your config file:
+```yaml
+kraken:
+    execution_mode: standalone
+    kubeconfig_path:
+    chaos_scenarios:
+        - node_scenarios:
+            - scenarios/standalone/ssh_node_reboot.yml
+```
+
+{{% alert title="Note" %}}
+You can specify multiple scenario files of the same type by adding additional paths to the list:
+```yaml
+kraken:
+    chaos_scenarios:
+        - hog_scenarios:
+            - scenarios/standalone/hog_cpu.yml
+            - scenarios/standalone/hog_memory.yml
+            - scenarios/standalone/hog_io.yml
+```
+
+You can also combine multiple different scenario types in the same config file. Scenario types can be specified in any order, and you can include the same scenario type multiple times:
+```yaml
+kraken:
+    execution_mode: standalone
+    chaos_scenarios:
+        - node_scenarios:
+            - scenarios/standalone/ssh_node_reboot.yml
+        - hog_scenarios:
+            - scenarios/standalone/hog_cpu.yml
+        - network_chaos_scenarios:
+            - scenarios/standalone/network_chaos_latency.yml
+        - standalone_disk_fill_scenarios:
+            - scenarios/standalone/disk_fill.yml
+        - node_scenarios:  # Same type can appear multiple times
+            - scenarios/standalone/ssh_node_stop.yml
+```
+{{% /alert %}}
+
+### Run
+
+```bash
+# Activate virtual environment
+source venv/bin/activate
+
+# Run with standalone config
+python run_kraken.py --config config/config_standalone.yaml
+```
+
+{{% alert title="Note" %}}
+When `execution_mode: standalone` is set, Kubernetes clients are not initialized. Only scenarios that support standalone mode (SSH-based chaos) will run. To use Kubernetes-based scenarios, use the default `execution_mode: kubernetes` with a valid `kubeconfig_path`.
+{{% /alert %}}

--- a/content/en/docs/scenarios/standalone-mode/_tab-krknctl.md
+++ b/content/en/docs/scenarios/standalone-mode/_tab-krknctl.md
@@ -1,0 +1,1 @@
+Coming soon.

--- a/content/en/docs/scenarios/vm-migration-chaos/_index.md
+++ b/content/en/docs/scenarios/vm-migration-chaos/_index.md
@@ -1,0 +1,140 @@
+---
+type: "docs/scenarios"
+title: VM Migration Chaos
+description: Test live migration resilience in OpenShift Virtualization environments
+date: 2017-01-04
+weight: 15
+---
+
+## Overview
+
+The VM Migration Chaos scenarios test the resilience of KubeVirt/OpenShift Virtualization live migration under adverse conditions. Live migration is one of the most complex operations in a virtualization platform -- it moves an active VM's memory, CPU state, and device state from one host to another while the VM continues running. Network disruptions, CPU pressure, or storage issues during this process can cause data corruption or VM outages.
+
+These scenarios are critical for:
+- Validating live migration correctness under network stress
+- Testing node drain and evacuation behavior
+- Detecting dual virt-launcher pod bugs (VM corruption risk)
+- Ensuring migration completes or fails cleanly (no partial state)
+
+**Scenario type:** `vm_migration_chaos_scenarios`
+
+## Bug References
+
+| Bug | Description | Scenario |
+|-----|-------------|----------|
+| CNV-89391 | Network disruption during migration leaves two virt-launcher pods (disk corruption risk) | `trigger_and_disrupt` |
+| CNV-81533 | VM not evacuated during node drain, stuck in migrating state | `drain_node` |
+
+## Prerequisites
+
+- OpenShift cluster with CNV (OpenShift Virtualization) installed
+- Target VM must be running and managed by a VirtualMachine resource
+- SSH key-based access to worker nodes (for fault injection)
+- `kubeconfig` with permissions to create VirtualMachineInstanceMigration objects
+- VM must have a `LiveMigrate` eviction strategy configured
+
+## Actions
+
+### trigger_and_disrupt
+
+Triggers a live migration for the specified VM and simultaneously injects a fault on the source node. This tests whether migration completes correctly under adverse conditions.
+
+The sequence is:
+1. Identify the source node where the VM is running
+2. Create a VirtualMachineInstanceMigration (VMIM) object to trigger migration
+3. Wait 5 seconds for migration to start
+4. Inject the specified fault on the source node (runs in a background thread)
+5. Wait for migration to complete or fail
+6. Check for dual virt-launcher pods (if `verify_no_dual_pods: true`)
+7. Clean up the VMIM object
+
+Sample scenario file:
+```yaml
+vm_migration_chaos:
+  vm_name: my-vm
+  vm_namespace: default
+  migration_action: trigger_and_disrupt
+  fault_type: network_latency
+  fault_params:
+    latency: 200ms
+    interface: br-ex
+    duration: 30
+  ssh_user: core
+  ssh_private_key: ~/.ssh/id_rsa
+  verify_no_dual_pods: true
+  timeout: 600
+```
+
+#### Fault Types
+
+| Fault Type | Description | Parameters |
+|------------|-------------|------------|
+| `network_latency` | Adds network latency using `tc netem` | `latency` (e.g., `200ms`), `interface` (e.g., `br-ex`), `duration` |
+| `network_partition` | Blocks traffic to a specific IP using iptables | `target_ip`, `duration` |
+| `node_cpu_stress` | Saturates CPU using `stress-ng` | `duration` |
+
+{{% alert title="Note" %}}The `verify_no_dual_pods: true` setting is critical for detecting CNV-89391. When a network disruption occurs during migration, the migration controller may lose track of the source pod, leaving two virt-launcher pods running for the same VM. This can cause disk corruption as both pods may write to the same storage volume.{{% /alert %}}
+
+### drain_node
+
+Cordons and drains the node where the VM is running, forcing an evacuation-triggered migration. This tests whether the VM migrates correctly when a node is taken out of service for maintenance.
+
+Sample scenario file:
+```yaml
+vm_migration_chaos:
+  vm_name: my-vm
+  vm_namespace: default
+  migration_action: drain_node
+  timeout: 600
+  verify_no_dual_pods: true
+```
+
+{{% alert title="Note" %}}This scenario catches CNV-81533, where VMs with certain configurations would get stuck in a "Migrating" state during node drain and never complete the migration. The node drain would also hang, blocking maintenance operations.{{% /alert %}}
+
+The sequence is:
+1. Identify the node where the VM is running
+2. Cordon the node (prevent new pod scheduling)
+3. Drain the node (evict all pods, triggering VM migration)
+4. Wait for migration to complete
+5. Uncordon the node (restore scheduling)
+
+## Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `vm_name` | string | required | Name of the VirtualMachineInstance to migrate |
+| `vm_namespace` | string | `default` | Namespace of the VM |
+| `migration_action` | string | `trigger_and_disrupt` | Action: `trigger_and_disrupt` or `drain_node` |
+| `fault_type` | string | `network_latency` | Type of fault to inject (for `trigger_and_disrupt` only) |
+| `fault_params` | dict | `{}` | Fault-specific parameters |
+| `timeout` | int | `600` | Maximum seconds to wait for migration |
+| `verify_no_dual_pods` | bool | `true` | Check for duplicate virt-launcher pods after migration |
+| `ssh_user` | string | `core` | SSH username for fault injection |
+| `ssh_private_key` | string | `~/.ssh/id_rsa` | Path to SSH private key |
+| `ssh_port` | int | `22` | SSH port |
+
+## Telemetry
+
+Migration scenarios report affected node telemetry with the following statuses:
+- `migrated` -- Migration completed successfully
+- `migration_failed` -- Migration did not complete within the timeout
+- `evacuated` -- VM was successfully evacuated during node drain
+- `evacuation_failed` -- VM was not evacuated (stuck in migrating state)
+
+Recovery time is measured from the start of the migration trigger to the VM being fully running on the target node.
+
+## How to Run VM Migration Chaos Scenarios
+
+Choose your preferred method to run VM migration chaos scenarios:
+
+{{< tabpane text=true >}}
+  {{< tab header="**Krkn**" lang="krkn" >}}
+{{< readfile file="_tab-krkn.md" >}}
+  {{< /tab >}}
+  {{< tab header="**Krkn-hub**" lang="krkn-hub" >}}
+{{< readfile file="_tab-krkn-hub.md" >}}
+  {{< /tab >}}
+  {{< tab header="**Krknctl**" lang="krknctl" >}}
+{{< readfile file="_tab-krknctl.md" >}}
+  {{< /tab >}}
+{{< /tabpane >}}

--- a/content/en/docs/scenarios/vm-migration-chaos/_tab-krkn-hub.md
+++ b/content/en/docs/scenarios/vm-migration-chaos/_tab-krkn-hub.md
@@ -1,0 +1,1 @@
+VM Migration Chaos containers are not yet available in krkn-hub. Support is planned for a future release.

--- a/content/en/docs/scenarios/vm-migration-chaos/_tab-krkn.md
+++ b/content/en/docs/scenarios/vm-migration-chaos/_tab-krkn.md
@@ -1,0 +1,41 @@
+Add the scenario type and scenario file(s) to the `chaos_scenarios` section in your `config/config.yaml`:
+
+```yaml
+kraken:
+    chaos_scenarios:
+        - vm_migration_chaos_scenarios:
+            - scenarios/openshift/vm_migration_network_disruption.yml
+```
+
+{{% alert title="Note" %}}
+You can specify multiple scenario files of the same type by adding additional paths to the list:
+```yaml
+kraken:
+    chaos_scenarios:
+        - vm_migration_chaos_scenarios:
+            - scenarios/openshift/vm_migration_network_disruption.yml
+            - scenarios/openshift/vm_migration_drain.yml
+```
+
+You can also combine multiple different scenario types in the same config file. Scenario types can be specified in any order, and you can include the same scenario type multiple times:
+```yaml
+kraken:
+    chaos_scenarios:
+        - vm_migration_chaos_scenarios:
+            - scenarios/openshift/vm_migration_network_disruption.yml
+        - pod_disruption_scenarios:
+            - scenarios/pod-kill.yaml
+        - vm_storage_chaos_scenarios:
+            - scenarios/openshift/vm_storage_nfs_failover.yml
+        - vm_migration_chaos_scenarios:  # Same type can appear multiple times
+            - scenarios/openshift/vm_migration_drain.yml
+```
+{{% /alert %}}
+
+Run krkn:
+
+```bash
+python run_kraken.py --config config/config.yaml
+```
+
+{{% alert title="Tip" %}}For comprehensive VMware migration validation, use this as Step 5 in the [VMware Migration Validation](../vmware-migration-validation/) pack. Live migration under stress is the most demanding test and should be run after the other steps pass.{{% /alert %}}

--- a/content/en/docs/scenarios/vm-migration-chaos/_tab-krknctl.md
+++ b/content/en/docs/scenarios/vm-migration-chaos/_tab-krknctl.md
@@ -1,0 +1,1 @@
+Coming soon.

--- a/content/en/docs/scenarios/vm-storage-chaos/_index.md
+++ b/content/en/docs/scenarios/vm-storage-chaos/_index.md
@@ -1,0 +1,146 @@
+---
+type: "docs/scenarios"
+title: VM Storage Chaos
+description: Storage disruption scenarios for OpenShift Virtualization environments
+date: 2017-01-04
+weight: 14
+---
+
+## Overview
+
+The VM Storage Chaos scenarios target storage subsystems in OpenShift Virtualization (CNV) environments. These scenarios inject storage-layer faults — killing NFS/storage services, generating IO bursts, and filling storage volumes — to validate that VMs and their storage backends handle disruptions gracefully.
+
+These scenarios are particularly valuable for:
+- Validating NFS failover and recovery behavior
+- Testing VM resilience under IO pressure
+- Verifying storage capacity management and alerts
+- Catching storage-related bugs in CNV environments
+
+**Scenario type:** `vm_storage_chaos_scenarios`
+
+## Bug References
+
+| Bug | Description | Scenario |
+|-----|-------------|----------|
+| CNV-83991 | NFS server crash causes permanent VM disk disconnect | `kill_storage_service` |
+| CNV-79002 | IO burst on host storage crashes VMI | `io_burst` |
+
+## Prerequisites
+
+- OpenShift cluster with CNV installed
+- SSH key-based access to storage hosts and worker nodes
+- `stress-ng` installed on target hosts (for IO burst scenarios)
+- root or sudo access on target hosts
+
+## Actions
+
+### kill_storage_service
+
+Stops a storage service (e.g., NFS server, Ceph OSD) on the target host for a specified duration, then restarts it. Tests whether VMs reconnect to storage after service recovery.
+
+Sample scenario file:
+```yaml
+vm_storage_chaos:
+  action: kill_storage_service
+  storage_targets:
+    - host: 192.168.1.50
+      service: nfs-server
+  ssh_user: root
+  ssh_private_key: ~/.ssh/id_rsa
+  duration: 300
+```
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `storage_targets[].host` | string | required | IP or hostname of the storage server |
+| `storage_targets[].service` | string | `nfs-server` | systemd service name to stop |
+| `duration` | int | `300` | Seconds to keep the service stopped |
+
+{{% alert title="Note" %}}This scenario catches CNV-83991, where NFS server crashes caused permanent VM disk disconnection that did not self-heal even after the NFS server recovered. Validating this is critical for any environment using shared storage for VM disks.{{% /alert %}}
+
+### io_burst
+
+Generates heavy IO load on the storage path using `stress-ng`, simulating IO contention from noisy neighbors or bulk data operations.
+
+Sample scenario file:
+```yaml
+vm_storage_chaos:
+  action: io_burst
+  storage_targets:
+    - host: 192.168.1.100
+      path: /var/lib/containers
+  ssh_user: root
+  ssh_private_key: ~/.ssh/id_rsa
+  duration: 300
+  io_workers: 4
+  io_bytes: 1G
+```
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `storage_targets[].host` | string | required | IP or hostname of the target host |
+| `storage_targets[].path` | string | `/var/lib/containers` | Path to stress with IO |
+| `io_workers` | int | `4` | Number of IO worker threads |
+| `io_bytes` | string | `1G` | Amount of data each worker processes |
+| `duration` | int | `300` | Duration of the IO burst in seconds |
+
+{{% alert title="Note" %}}This scenario catches CNV-79002, where IO bursts on the host storage path caused VMI crashes due to storage timeout misconfigurations.{{% /alert %}}
+
+### fill_storage
+
+Fills a storage path to a specified percentage using `fallocate`, simulating disk space exhaustion. Cleans up after the duration expires.
+
+Sample scenario file:
+```yaml
+vm_storage_chaos:
+  action: fill_storage
+  storage_targets:
+    - host: 192.168.1.100
+      path: /var/lib/containers
+  ssh_user: root
+  ssh_private_key: ~/.ssh/id_rsa
+  fill_percentage: 95
+  duration: 300
+```
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `storage_targets[].host` | string | required | IP or hostname of the target host |
+| `storage_targets[].path` | string | `/var/lib/containers` | Path to fill |
+| `fill_percentage` | int | `90` | Target disk usage percentage |
+| `duration` | int | `300` | Seconds to keep the fill active |
+
+## Common SSH Parameters
+
+All VM Storage Chaos scenarios share these SSH configuration parameters:
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `ssh_user` | string | `root` | SSH username |
+| `ssh_private_key` | string | `~/.ssh/id_rsa` | Path to SSH private key |
+| `ssh_port` | int | `22` | SSH port |
+
+## Optional Parameters
+
+The following parameters are parsed by the plugin but are **not yet implemented**. They are reserved for future use:
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `verify_vm_recovery` | bool | `true` | (Not yet implemented) Will verify VM recovery after storage disruption |
+| `recovery_timeout` | int | `600` | (Not yet implemented) Timeout in seconds for VM recovery verification |
+
+## How to Run VM Storage Chaos Scenarios
+
+Choose your preferred method to run VM storage chaos scenarios:
+
+{{< tabpane text=true >}}
+  {{< tab header="**Krkn**" lang="krkn" >}}
+{{< readfile file="_tab-krkn.md" >}}
+  {{< /tab >}}
+  {{< tab header="**Krkn-hub**" lang="krkn-hub" >}}
+{{< readfile file="_tab-krkn-hub.md" >}}
+  {{< /tab >}}
+  {{< tab header="**Krknctl**" lang="krknctl" >}}
+{{< readfile file="_tab-krknctl.md" >}}
+  {{< /tab >}}
+{{< /tabpane >}}

--- a/content/en/docs/scenarios/vm-storage-chaos/_tab-krkn-hub.md
+++ b/content/en/docs/scenarios/vm-storage-chaos/_tab-krkn-hub.md
@@ -1,0 +1,1 @@
+VM Storage Chaos containers are not yet available in krkn-hub. Support is planned for a future release.

--- a/content/en/docs/scenarios/vm-storage-chaos/_tab-krkn.md
+++ b/content/en/docs/scenarios/vm-storage-chaos/_tab-krkn.md
@@ -1,0 +1,39 @@
+Add the scenario type and scenario file(s) to the `chaos_scenarios` section in your `config/config.yaml`:
+
+```yaml
+kraken:
+    chaos_scenarios:
+        - vm_storage_chaos_scenarios:
+            - scenarios/openshift/vm_storage_nfs_failover.yml
+```
+
+{{% alert title="Note" %}}
+You can specify multiple scenario files of the same type by adding additional paths to the list:
+```yaml
+kraken:
+    chaos_scenarios:
+        - vm_storage_chaos_scenarios:
+            - scenarios/openshift/vm_storage_nfs_failover.yml
+            - scenarios/openshift/vm_storage_io_burst.yml
+```
+
+You can also combine multiple different scenario types in the same config file. Scenario types can be specified in any order, and you can include the same scenario type multiple times:
+```yaml
+kraken:
+    chaos_scenarios:
+        - vm_storage_chaos_scenarios:
+            - scenarios/openshift/vm_storage_nfs_failover.yml
+        - pod_disruption_scenarios:
+            - scenarios/pod-kill.yaml
+        - vm_storage_chaos_scenarios:  # Same type can appear multiple times
+            - scenarios/openshift/vm_storage_io_burst.yml
+```
+{{% /alert %}}
+
+Run krkn:
+
+```bash
+python run_kraken.py --config config/config.yaml
+```
+
+{{% alert title="Tip" %}}For VMware migration validation, combine this scenario with the other steps in the [VMware Migration Validation](../vmware-migration-validation/) pack. Storage resilience (Step 3) is one of the most common failure modes after migration.{{% /alert %}}

--- a/content/en/docs/scenarios/vm-storage-chaos/_tab-krknctl.md
+++ b/content/en/docs/scenarios/vm-storage-chaos/_tab-krknctl.md
@@ -1,0 +1,1 @@
+Coming soon.

--- a/content/en/docs/scenarios/vmware-migration-validation/_index.md
+++ b/content/en/docs/scenarios/vmware-migration-validation/_index.md
@@ -1,0 +1,204 @@
+---
+type: "docs/scenarios"
+title: VMware Migration Validation
+description: Validate VMware-to-OpenShift Virtualization migrations with a 5-step chaos testing process
+date: 2017-01-04
+weight: 13
+---
+
+## Overview
+
+When migrating virtual machines from VMware vSphere to OpenShift Virtualization (CNV), organizations need confidence that the migrated workloads are production-ready. Krkn provides a structured 5-step validation process that systematically tests the resilience of migrated VMs, catching real bugs that have affected production environments.
+
+This validation pack addresses the unique risks of VMware-to-KVM migration: different storage backends, different network stacks, different live migration implementations, and different host resource management. Each step targets a specific failure mode documented in real CNV bug reports.
+
+## Prerequisites
+
+- OpenShift cluster with CNV (OpenShift Virtualization) installed
+- VMs migrated from VMware using MTV (Migration Toolkit for Virtualization)
+- SSH key-based access to OpenShift worker nodes (user: `core`)
+- `stress-ng` installed on worker nodes (for CPU and IO stress steps)
+- `kubeconfig` with access to the cluster
+
+## The 5-Step Validation Process
+
+### Step 1: Reboot All Migrated VM Nodes
+
+**What it validates:** VM disk persistence, boot configuration, and basic VM lifecycle after migration.
+
+**Bug reference:** Catches issues like CNV-83327, where Windows VMs had disks go offline after node reboot due to incorrect storage driver mapping during migration.
+
+**Scenario type:** `node_scenarios` with `cloud_type: ssh`
+
+Sample scenario file:
+```yaml
+node_scenarios:
+  - actions:
+      - node_reboot_scenario
+    cloud_type: ssh
+    targets:
+      - <WORKER_NODE_1>
+      - <WORKER_NODE_2>
+    ssh_user: core
+    ssh_private_key: ~/.ssh/id_rsa
+    runs: 1
+    timeout: 600
+    kube_check: false
+    soft_reboot: true
+```
+
+**What to look for:**
+- All VMs come back to Running state after node reboot
+- VM disks are accessible (not offline or read-only)
+- VM network connectivity is restored
+- Application inside VM is functioning
+
+### Step 2: Network Chaos on Migrated VM Nodes
+
+**What it validates:** Network resilience of migrated VMs under degraded conditions. VMware and OpenShift use different network stacks (NSX vs OVN-Kubernetes), so network behavior under stress can differ.
+
+**Bug reference:** Catches issues like CNV-90425, where migrated VMs experienced severe performance degradation under network stress that did not occur on VMware.
+
+**Scenario type:** `network_chaos_scenarios`
+
+Sample scenario file:
+```yaml
+network_chaos:
+  targets:
+    - <WORKER_NODE_1>
+  ssh_user: core
+  ssh_private_key: ~/.ssh/id_rsa
+  duration: 120
+  interfaces: []
+  execution: serial
+  egress:
+    latency: 100ms
+```
+
+**What to look for:**
+- VM applications remain responsive (within expected latency bounds)
+- No VM crashes or unexpected restarts
+- Network recovers cleanly after chaos ends
+
+### Step 3: Storage IO Stress
+
+**What it validates:** Storage subsystem resilience. VMware VMDK storage and OpenShift PV-backed storage have fundamentally different IO paths. This step ensures the new storage backend handles IO pressure.
+
+**Bug reference:** Catches issues like CNV-79002, where IO burst caused VMI crashes due to storage timeout misconfigurations in the migrated environment.
+
+**Scenario type:** `vm_storage_chaos_scenarios` with action `io_burst`
+
+Sample scenario file:
+```yaml
+vm_storage_chaos:
+  action: io_burst
+  storage_targets:
+    - host: <WORKER_NODE_1>
+      path: /var/lib/containers
+  ssh_user: core
+  ssh_private_key: ~/.ssh/id_rsa
+  duration: 300
+  io_workers: 4
+  io_bytes: 1G
+```
+
+{{% alert title="Note" %}}The `verify_vm_recovery` and `recovery_timeout` parameters are parsed by the plugin but are not yet implemented. They are reserved for future use to automatically verify VM recovery after storage disruption.{{% /alert %}}
+
+**What to look for:**
+- VMs remain running during IO stress
+- No storage timeouts or PV disconnections
+- VM applications remain responsive (may be slower, but not crashed)
+- Storage recovers cleanly after stress ends
+
+### Step 4: Host CPU Stress
+
+**What it validates:** Host resource contention handling. When host CPUs are saturated, virt-handler health checks and kubelet liveness probes can fail, potentially causing unnecessary VM evictions.
+
+**Bug reference:** Catches issues like CNV-89810, where virt-handler liveness probe timeouts under CPU stress caused the virt-handler pod to restart, triggering cascading failures.
+
+**Scenario type:** `hog_scenarios`
+
+Sample scenario file:
+```yaml
+hog-type: cpu
+targets:
+  - <WORKER_NODE_1>
+ssh_user: core
+ssh_private_key: ~/.ssh/id_rsa
+node-selector: ""
+duration: 300
+workers: 0
+cpu-load-percentage: 90
+```
+
+**What to look for:**
+- VMs remain running (not evicted by resource pressure)
+- virt-handler pods remain healthy
+- Kubelet does not restart
+- VMs recover normal performance after stress ends
+
+### Step 5: Live Migration Under Network Stress
+
+**What it validates:** Live migration correctness under adverse conditions. This is the most critical test — live migration moves VM memory and state between hosts, and network disruptions during this process can cause data corruption.
+
+**Bug reference:** Catches issues like CNV-89391, where network disruption during live migration left two virt-launcher pods running simultaneously (one on source, one on target), risking VM disk corruption.
+
+**Scenario type:** `vm_migration_chaos_scenarios`
+
+Sample scenario file:
+```yaml
+vm_migration_chaos:
+  vm_name: <MIGRATED_VM_NAME>
+  vm_namespace: <NAMESPACE>
+  migration_action: trigger_and_disrupt
+  fault_type: network_latency
+  fault_params:
+    latency: 200ms
+    interface: br-ex
+    duration: 30
+  ssh_user: core
+  ssh_private_key: ~/.ssh/id_rsa
+  verify_no_dual_pods: true
+  timeout: 600
+```
+
+**What to look for:**
+- Migration completes successfully (or fails cleanly)
+- No dual virt-launcher pods after migration (the `verify_no_dual_pods` check)
+- VM is running on the target node and accessible
+- No data corruption in VM disks
+
+{{% alert title="Note" %}}The `verify_no_dual_pods: true` setting is critical. If two virt-launcher pods are running for the same VM, this indicates a serious bug that can lead to disk corruption. Krkn will fail the scenario and log a clear error referencing CNV-89391.{{% /alert %}}
+
+## Running the Full Validation
+
+Choose your preferred method to run the full validation:
+
+{{< tabpane text=true >}}
+  {{< tab header="**Krkn**" lang="krkn" >}}
+{{< readfile file="_tab-krkn.md" >}}
+  {{< /tab >}}
+  {{< tab header="**Krkn-hub**" lang="krkn-hub" >}}
+{{< readfile file="_tab-krkn-hub.md" >}}
+  {{< /tab >}}
+  {{< tab header="**Krknctl**" lang="krknctl" >}}
+{{< readfile file="_tab-krknctl.md" >}}
+  {{< /tab >}}
+{{< /tabpane >}}
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | All validation steps passed |
+| 1 | One or more steps failed (check logs for which step and specific failure) |
+
+## Summary of Bugs Caught
+
+| Step | Bug Reference | Failure Mode |
+|------|---------------|-------------|
+| 1 — Node Reboot | CNV-83327 | Windows VM disks go offline after reboot |
+| 2 — Network Chaos | CNV-90425 | Performance degradation differs from VMware |
+| 3 — Storage IO | CNV-79002 | IO burst crashes VMI |
+| 4 — CPU Stress | CNV-89810 | virt-handler liveness probe timeout |
+| 5 — Migration | CNV-89391 | Dual virt-launcher pods, disk corruption risk |

--- a/content/en/docs/scenarios/vmware-migration-validation/_tab-krkn-hub.md
+++ b/content/en/docs/scenarios/vmware-migration-validation/_tab-krkn-hub.md
@@ -1,0 +1,1 @@
+VMware Migration Validation containers are not yet available in krkn-hub. Support is planned for a future release.

--- a/content/en/docs/scenarios/vmware-migration-validation/_tab-krkn.md
+++ b/content/en/docs/scenarios/vmware-migration-validation/_tab-krkn.md
@@ -1,0 +1,24 @@
+Run all 5 steps in sequence using a combined config:
+
+```yaml
+kraken:
+    execution_mode: standalone
+    kubeconfig_path: ~/.kube/config
+    chaos_scenarios:
+        - node_scenarios:
+            - scenarios/vmware_migration_validation/01_reboot_all_vms.yml
+        - network_chaos_scenarios:
+            - scenarios/vmware_migration_validation/02_network_chaos.yml
+        - vm_storage_chaos_scenarios:
+            - scenarios/vmware_migration_validation/03_storage_stress.yml
+        - hog_scenarios:
+            - scenarios/vmware_migration_validation/04_host_cpu_stress.yml
+        - vm_migration_chaos_scenarios:
+            - scenarios/vmware_migration_validation/05_vm_migration_test.yml
+```
+
+```bash
+python run_kraken.py --config config/config_vmware_validation.yaml
+```
+
+{{% alert title="Tip" %}}Run each step individually first to establish a baseline. Once each step passes in isolation, run the full sequence to test cumulative stress on the migrated environment.{{% /alert %}}

--- a/content/en/docs/scenarios/vmware-migration-validation/_tab-krknctl.md
+++ b/content/en/docs/scenarios/vmware-migration-validation/_tab-krknctl.md
@@ -1,0 +1,1 @@
+Coming soon.

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1293,6 +1293,7 @@ $ krknctl run pod-scenarios --kubeconfig ~/.kube/config
             <li><a href="/docs/scenarios/hog-scenarios/io-hog-scenario/">IO Hog</a></li>
             <li><a href="/docs/scenarios/pvc-scenario/">PVC Disk Fill</a></li>
             <li><a href="/docs/scenarios/storage-throttle-scenario/">Storage I/O Throttle</a></li>
+            <li><a href="/docs/scenarios/vm-storage-chaos/">VM Storage Chaos</a></li>
           </ul>
         </div>
 
@@ -1308,6 +1309,24 @@ $ krknctl run pod-scenarios --kubeconfig ~/.kube/config
           </div>
           <ul class="scenario-category__list">
             <li><a href="/docs/scenarios/time-scenarios/">Time Skew</a></li>
+            <li><a href="/docs/scenarios/standalone-mode/">Standalone Mode (SSH)</a></li>
+          </ul>
+        </div>
+
+        <!-- Virtualization & Migration -->
+        <div class="scenario-category reveal" data-delay="400">
+          <div class="scenario-category__header">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+              stroke-width="1.5">
+              <rect x="2" y="3" width="20" height="14" rx="2" />
+              <line x1="8" y1="21" x2="16" y2="21" />
+              <line x1="12" y1="17" x2="12" y2="21" />
+            </svg>
+            <h3>Virtualization & Migration</h3>
+          </div>
+          <ul class="scenario-category__list">
+            <li><a href="/docs/scenarios/vm-migration-chaos/">VM Migration Chaos</a></li>
+            <li><a href="/docs/scenarios/vmware-migration-validation/">VMware Migration Validation</a></li>
           </ul>
         </div>
 


### PR DESCRIPTION
# Description

Documentation for krkn's new standalone execution mode and OpenShift Virtualization chaos scenarios.

## New pages
- **Standalone Mode**: architecture, SSH config, all 6 scenario types, health check plugin
- **VMware Migration Validation**: 5-step validation process with bug references
- **VM Storage Chaos**: NFS failover, IO burst (CNV-83991, CNV-79002)
- **VM Migration Chaos**: migration disruption (CNV-89391, CNV-81533)

## Updated pages
- Node scenarios: added SSH (Standalone) cloud_type section
- Scenarios index: added new scenario cards

## Related PRs
- krkn-chaos/krkn#1458: standalone execution mode

## Test plan
- [x] Hugo builds clean (1.6s)
- [x] All frontmatter valid (type, title, weight)
- [x] YAML examples match plugin implementations
- [x] Style matches existing docs (labels, alert boxes, multi-scenario patterns)