### PR TITLE
Fixing krkn-hub-scenario source markers on 5 scenario pages

### DIFF
--- a/content/en/docs/scenarios/network-chaos-ng-scenarios/node-interface-down/_index.md
+++ b/content/en/docs/scenarios/network-chaos-ng-scenarios/node-interface-down/_index.md
@@ -4,7 +4,11 @@ description:
 date: 2017-01-04
 weight: 2
 ---
+<krkn-hub-scenario id="node-interface-down">
+
 Brings one or more network interfaces down on a target node for a configurable duration, then restores them. Can be used to simulate network partitions, NIC failures, or loss of connectivity at the node level.
+
+</krkn-hub-scenario>
 
 ## How to Run Node Interface Down Scenarios
 

--- a/content/en/docs/scenarios/network-chaos-ng-scenarios/vmi-network-chaos/_index.md
+++ b/content/en/docs/scenarios/network-chaos-ng-scenarios/vmi-network-chaos/_index.md
@@ -4,7 +4,7 @@ description:
 date: 2017-01-04
 weight: 2
 ---
-<krkn-hub-scenario id="vmi-network-chaos">
+<krkn-hub-scenario id="vmi-network">
 Injects network degradation into a KubeVirt Virtual Machine Instance (VMI) by shaping traffic on the VM's tap interface inside the virt-launcher network namespace. Supports configurable bandwidth limiting, latency injection, and packet loss. Unlike node or pod network chaos, this scenario targets the tap device that connects QEMU to the bridge, so only the specific VMI is affected without disrupting OVN's BFD heartbeats or other workloads on the same node.
 </krkn-hub-scenario>
 

--- a/content/en/docs/scenarios/power-outage-scenarios/_index.md
+++ b/content/en/docs/scenarios/power-outage-scenarios/_index.md
@@ -5,7 +5,11 @@ date: 2017-01-04
 weight: 3
 ---
 
+<krkn-hub-scenario id="power-outages">
+
 This scenario shuts down Kubernetes/OpenShift cluster for the specified duration to simulate power outages, brings it back online and checks if it's healthy.
+
+</krkn-hub-scenario>
 
 ## How to Run Power Outage Scenarios
 

--- a/content/en/docs/scenarios/pvc-scenario/_index.md
+++ b/content/en/docs/scenarios/pvc-scenario/_index.md
@@ -4,7 +4,7 @@ description:
 date: 2017-01-04
 weight: 3
 ---
-<krkn-hub-scenario id="pvc-scenarios">
+<krkn-hub-scenario id="pvc-scenario">
 Scenario to fill up a given PersistenVolumeClaim by creating a temp file on the PVC from a pod associated with it. The purpose of this scenario is to fill up a volume to understand faults caused by the application using this volume.
 </krkn-hub-scenario>
 

--- a/content/en/docs/scenarios/storage-throttle-scenario/_index.md
+++ b/content/en/docs/scenarios/storage-throttle-scenario/_index.md
@@ -5,7 +5,11 @@ date: 2017-01-04
 weight: 3
 ---
 
+<krkn-hub-scenario id="storage-throttle">
+
 This scenario throttles storage I/O on a PVC-backed volume used by a target pod. It limits **read/write IOPS** and **bandwidth** (bytes per second) using Linux cgroup controllers, allowing you to observe how your application behaves under degraded disk performance.
+
+</krkn-hub-scenario>
 
 - **cgroups v2:** writes to `io.max`
 - **cgroups v1:** writes to `blkio.throttle.*_device`


### PR DESCRIPTION
## Documentation Update

**Related Feature:**

Metadata fix for the docs-sync bot ([#320](https://github.com/krkn-chaos/website/issues/320)), which resolves a scenario page to its krkn-hub source via the `<krkn-hub-scenario id="...">` marker, not the folder name. Full context and the naming analysis are in the linked [issue](https://github.com/krkn-chaos/website/issues/545).

**Changes:**

Five pages had a missing or wrong marker. Corrected so each id matches the krkn-hub scenario directory name:

| Page | Change |
|---|---|
| `power-outage-scenarios` | add `id="power-outages"` |
| `storage-throttle-scenario` | add `id="storage-throttle"` |
| `network-chaos-ng-scenarios/node-interface-down` | add `id="node-interface-down"` |
| `pvc-scenario` | `id="pvc-scenarios"` -> `id="pvc-scenario"` |
| `network-chaos-ng-scenarios/vmi-network-chaos` | `id="vmi-network-chaos"` -> `id="vmi-network"` |

The marker is invisible, so no rendered output changes. 
The `pod-network-chaos` collision needs a maintainer decision and is left for the issue.
