### PR TITLE
Removal of  Kubevirt rollback references

### DIFF
--- a/content/en/docs/rollback-scenarios/_index.md
+++ b/content/en/docs/rollback-scenarios/_index.md
@@ -36,7 +36,6 @@ With this approach, Krkn ensures:
 Krkn supports rollback for the following scenarios.
 
 - [Application outages](../scenarios/application-outage/_index.md)
-- [KubeVirt VM Outage](../scenarios/kubevirt-vm-outage-scenario/_index.md)
 - [Hog Scenarios](../scenarios/hog-scenarios/_index.md)
     - [Node CPU Hog](../scenarios/hog-scenarios/cpu-hog-scenario/_index.md)
     - [Node IO Hog](../scenarios/hog-scenarios/io-hog-scenario/_index.md)

--- a/content/en/docs/scenarios/kubevirt-vm-outage-scenario/_index.md
+++ b/content/en/docs/scenarios/kubevirt-vm-outage-scenario/_index.md
@@ -17,7 +17,6 @@ This scenario enables the simulation of VM-level disruptions in clusters where K
 - [Expected Behavior](#expected-behavior)
 - [Advanced Use Cases](#advanced-use-cases)
 - [Recovery Strategies](#recovery-strategies)
-- [Rollback Scenario Support](#rollback-scenario-support)
 - [Limitations](#limitations)
 - [Troubleshooting](#troubleshooting)
 
@@ -118,10 +117,6 @@ These metrics appear in the telemetry output under `PodsStatus.recovered` for su
   "unrecovered": []
 }
 ```
-
-## Rollback Scenario Support
-
-Krkn supports rollback for KubeVirt VM Outage Scenario. For more details, please refer to the [Rollback Scenarios](../../rollback-scenarios/_index.md) documentation.
 
 ## Limitations
 


### PR DESCRIPTION
## Changes

### Removed incorrect KubeVirt rollback references

The documentation previously implied that KubeVirt VM outage scenarios participate in the rollback framework.

After reviewing the implementation, KubeVirt VM outage scenarios do not register rollback callables and therefore are not managed through the rollback framework. 

## Sources

### KubeVirt VM Outage Scenario Implementation

The scenario does not:

* register rollback callables using `self.rollback_handler.set_rollback_callable(...)`
* participate in the rollback version-file framework

## Documentation Pages Updated

* `content/en/docs/rollback-scenarios/index.md`
* `content/en/docs/scenarios/kubevirt-vm-outage-scenario/index.md`