### PR TITLE
fix-etcd-split-brain-docs in _tab-krkn.md 

### DIFF
--- a/content/en/docs/scenarios/etcd-split-brain/_tab-krkn.md
+++ b/content/en/docs/scenarios/etcd-split-brain/_tab-krkn.md
@@ -69,5 +69,3 @@ kraken:
 ```bash
 python run_kraken.py --config config/config.yaml
 ```
-
-{{< notice type="danger" >}} This scenario carries a significant risk: it **might break the cluster API**, making it impossible to automatically revert the applied network rules. The `iptables` rules will be printed to the console, allowing for manual reversal via a shell on the affected node. This scenario is **best suited for disposable clusters** and should be **used at your own risk**. {{< /notice >}}


### PR DESCRIPTION
## Documentation Update

fixes #535 

**Changes:** 

-Updated content/en/docs/scenarios/etcd-split-brain/_tab-krkn.md
-Removed the duplicate Danger section from the documentation to avoid redundant information and improve readability.
-No functional changes were made; this is a documentation cleanup and consistency update.
