### PR TITLE
feat: resizable sidebar and collapsible TOC panel for docs

### DIFF
--- a/assets/scss/_custom_docs.scss
+++ b/assets/scss/_custom_docs.scss
@@ -1967,6 +1967,52 @@ table tbody tr:hover {
   }
 }
 
+// ---------------------------------------------------------------------------
+// Resizable Left Sidebar
+// ---------------------------------------------------------------------------
+
+@media (min-width: 1200px) {
+  .td-main .row.flex-xl-nowrap {
+    flex-wrap: nowrap !important;
+  }
+
+  .td-sidebar {
+    flex: 0 0 auto !important;
+    width: var(--krkn-sidebar-width, 16.667%);
+    min-width: 140px;
+    max-width: 400px !important;
+    position: relative;
+  }
+
+  .td-main .row.flex-xl-nowrap > main {
+    flex: 1 1 0% !important;
+    max-width: none !important;
+    min-width: 0;
+  }
+}
+
+.krkn-resize-handle {
+  display: none;
+
+  @media (min-width: 1200px) {
+    display: block;
+    position: absolute;
+    top: 0;
+    right: -3px;
+    width: 6px;
+    height: 100%;
+    cursor: col-resize;
+    z-index: 20;
+    background: transparent;
+    transition: background 0.15s ease;
+
+    &:hover,
+    &.krkn-dragging {
+      background: var(--krkn-secondary-alpha);
+    }
+  }
+}
+
 // -----------------------------------------------------------------------------
 // Video Embed (Krkn Operator docs)
 // -----------------------------------------------------------------------------
@@ -2473,5 +2519,72 @@ table tbody tr:hover {
 
   .krkn-roadmap__card {
     padding: 1rem;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Collapsible TOC Sidebar
+// ---------------------------------------------------------------------------
+
+.td-sidebar-toc {
+  transition: flex 0.3s ease, opacity 0.3s ease, padding 0.3s ease;
+}
+
+.krkn-toc-toggle {
+  display: none;
+
+  @media (min-width: 1200px) {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: fixed;
+    right: var(--krkn-toc-btn-right, calc(16.667% - 16px));
+    top: 5.5rem;
+    z-index: 1040;
+    width: 32px;
+    height: 32px;
+    border-radius: 0.375rem;
+    border: 1px solid var(--krkn-border-prominent);
+    background: var(--krkn-surface);
+    color: var(--krkn-text-muted);
+    cursor: pointer;
+    box-shadow: 0 2px 8px var(--krkn-shadow);
+    transition: background 0.2s ease, color 0.2s ease, right 0.3s ease;
+
+    &:hover {
+      background: var(--krkn-elevated);
+      color: var(--krkn-text);
+    }
+
+    svg {
+      width: 16px;
+      height: 16px;
+      transition: transform 0.3s ease;
+    }
+  }
+}
+
+@media (min-width: 1200px) {
+  .row.flex-xl-nowrap.krkn-toc-collapsed {
+    > .td-sidebar-toc {
+      flex: 0 0 0px !important;
+      width: 0 !important;
+      min-width: 0 !important;
+      max-width: 0 !important;
+      overflow: hidden;
+      opacity: 0;
+      padding: 0 !important;
+      border: none !important;
+    }
+  }
+
+  .row.flex-xl-nowrap.krkn-toc-collapsed > .krkn-toc-toggle,
+  body.krkn-toc-collapsed > .krkn-toc-toggle {
+    right: 0.5rem;
+  }
+
+  .krkn-toc-collapsed .krkn-toc-toggle svg,
+  body.krkn-toc-collapsed .krkn-toc-toggle svg {
+    transform: rotate(180deg);
   }
 }

--- a/layouts/_partials/hooks/body-end.html
+++ b/layouts/_partials/hooks/body-end.html
@@ -456,6 +456,105 @@
 })();
 </script>
 
+<!-- Resizable left sidebar -->
+<script>
+(function() {
+  var sidebar = document.querySelector('.td-main .td-sidebar');
+  if (!sidebar) return;
+
+  var handle = null;
+  var startX, startW;
+
+  function getX(e) {
+    return e.touches ? e.touches[0].clientX : e.clientX;
+  }
+
+  function onDrag(e) {
+    var w = Math.min(400, Math.max(140, startW + (getX(e) - startX)));
+    sidebar.style.setProperty('--krkn-sidebar-width', w + 'px');
+  }
+
+  function onUp() {
+    handle.classList.remove('dragging');
+    document.body.style.userSelect = '';
+    document.removeEventListener('mousemove', onDrag);
+    document.removeEventListener('mouseup', onUp);
+    document.removeEventListener('touchmove', onDrag);
+    document.removeEventListener('touchend', onUp);
+    localStorage.setItem('krkn-sidebar-width', sidebar.offsetWidth);
+  }
+
+  function onStart(e) {
+    e.preventDefault();
+    startX = getX(e);
+    startW = sidebar.offsetWidth;
+    handle.classList.add('dragging');
+    document.body.style.userSelect = 'none';
+    document.addEventListener('mousemove', onDrag);
+    document.addEventListener('mouseup', onUp);
+    document.addEventListener('touchmove', onDrag, { passive: false });
+    document.addEventListener('touchend', onUp);
+  }
+
+  function setup() {
+    if (window.innerWidth >= 1200 && !handle) {
+      handle = document.createElement('div');
+      handle.className = 'krkn-resize-handle';
+      sidebar.appendChild(handle);
+      handle.addEventListener('mousedown', onStart);
+      handle.addEventListener('touchstart', onStart, { passive: false });
+      var saved = localStorage.getItem('krkn-sidebar-width');
+      if (saved) sidebar.style.setProperty('--krkn-sidebar-width', saved + 'px');
+    } else if (window.innerWidth < 1200 && handle) {
+      handle.remove();
+      handle = null;
+      sidebar.style.removeProperty('--krkn-sidebar-width');
+    }
+  }
+
+  setup();
+  window.addEventListener('resize', setup);
+})();
+</script>
+
+<!-- TOC sidebar toggle -->
+<script>
+(function() {
+  var row = document.querySelector('.td-main .row.flex-xl-nowrap');
+  var toc = row && row.querySelector('.td-sidebar-toc');
+  var main = row && row.querySelector('main');
+  if (!row || !toc || !main) return;
+
+  var btn = document.createElement('button');
+  btn.className = 'krkn-toc-toggle';
+  btn.setAttribute('aria-label', 'Toggle sidebar');
+  btn.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"/></svg>';
+  document.body.appendChild(btn);
+
+  function positionBtn() {
+    if (window.innerWidth < 1200 || row.classList.contains('toc-collapsed')) return;
+    var tocLeft = toc.getBoundingClientRect().left;
+    btn.style.setProperty('--krkn-toc-btn-right', (window.innerWidth - tocLeft - 16) + 'px');
+  }
+
+  function applyState(collapsed) {
+    row.classList.toggle('toc-collapsed', collapsed);
+    document.body.classList.toggle('toc-collapsed', collapsed);
+    if (!collapsed) requestAnimationFrame(function() { setTimeout(positionBtn, 320); });
+  }
+
+  applyState(localStorage.getItem('krkn-toc-collapsed') === 'true');
+  positionBtn();
+  window.addEventListener('resize', positionBtn);
+
+  btn.addEventListener('click', function() {
+    var collapsed = !row.classList.contains('toc-collapsed');
+    applyState(collapsed);
+    localStorage.setItem('krkn-toc-collapsed', collapsed);
+  });
+})();
+</script>
+
 <!-- Scroll animations -->
 <script src="{{ "js/scroll-animations.js" | relURL }}" defer></script>
 

--- a/layouts/_partials/hooks/body-end.html
+++ b/layouts/_partials/hooks/body-end.html
@@ -463,6 +463,7 @@
   if (!sidebar) return;
 
   var handle = null;
+  var isDragging = false;
   var startX, startW;
 
   function getX(e) {
@@ -474,26 +475,30 @@
     sidebar.style.setProperty('--krkn-sidebar-width', w + 'px');
   }
 
-  function onUp() {
-    handle.classList.remove('dragging');
+  function cleanupDrag() {
+    isDragging = false;
+    if (handle) handle.classList.remove('krkn-dragging');
     document.body.style.userSelect = '';
     document.removeEventListener('mousemove', onDrag);
-    document.removeEventListener('mouseup', onUp);
+    document.removeEventListener('mouseup', cleanupDrag);
     document.removeEventListener('touchmove', onDrag);
-    document.removeEventListener('touchend', onUp);
+    document.removeEventListener('touchend', cleanupDrag);
+    document.removeEventListener('touchcancel', cleanupDrag);
     localStorage.setItem('krkn-sidebar-width', sidebar.offsetWidth);
   }
 
   function onStart(e) {
     e.preventDefault();
+    isDragging = true;
     startX = getX(e);
     startW = sidebar.offsetWidth;
-    handle.classList.add('dragging');
+    if (handle) handle.classList.add('krkn-dragging');
     document.body.style.userSelect = 'none';
     document.addEventListener('mousemove', onDrag);
-    document.addEventListener('mouseup', onUp);
+    document.addEventListener('mouseup', cleanupDrag);
     document.addEventListener('touchmove', onDrag, { passive: false });
-    document.addEventListener('touchend', onUp);
+    document.addEventListener('touchend', cleanupDrag);
+    document.addEventListener('touchcancel', cleanupDrag);
   }
 
   function setup() {
@@ -506,6 +511,7 @@
       var saved = localStorage.getItem('krkn-sidebar-width');
       if (saved) sidebar.style.setProperty('--krkn-sidebar-width', saved + 'px');
     } else if (window.innerWidth < 1200 && handle) {
+      if (isDragging) cleanupDrag();
       handle.remove();
       handle = null;
       sidebar.style.removeProperty('--krkn-sidebar-width');
@@ -532,14 +538,14 @@
   document.body.appendChild(btn);
 
   function positionBtn() {
-    if (window.innerWidth < 1200 || row.classList.contains('toc-collapsed')) return;
+    if (window.innerWidth < 1200 || row.classList.contains('krkn-toc-collapsed')) return;
     var tocLeft = toc.getBoundingClientRect().left;
     btn.style.setProperty('--krkn-toc-btn-right', (window.innerWidth - tocLeft - 16) + 'px');
   }
 
   function applyState(collapsed) {
-    row.classList.toggle('toc-collapsed', collapsed);
-    document.body.classList.toggle('toc-collapsed', collapsed);
+    row.classList.toggle('krkn-toc-collapsed', collapsed);
+    document.body.classList.toggle('krkn-toc-collapsed', collapsed);
     if (!collapsed) requestAnimationFrame(function() { setTimeout(positionBtn, 320); });
   }
 
@@ -548,7 +554,7 @@
   window.addEventListener('resize', positionBtn);
 
   btn.addEventListener('click', function() {
-    var collapsed = !row.classList.contains('toc-collapsed');
+    var collapsed = !row.classList.contains('krkn-toc-collapsed');
     applyState(collapsed);
     localStorage.setItem('krkn-toc-collapsed', collapsed);
   });


### PR DESCRIPTION
## Summary

- **Resizable left sidebar**: drag handle at the right edge of the nav column lets users adjust width (140px–400px), width persisted in localStorage
- **Collapsible right TOC**: toggle button at the sidebar border collapses the TOC/tag-cloud/meta-links column; main content expands dynamically to fill the freed space
- Both features only activate at `xl` breakpoint (≥1200px) — mobile layout unchanged

## Details

- Touch support for resize (touchstart/touchmove/touchend)
- Text selection prevented during drag (`userSelect = 'none'`)
- Responsive: resize handle created/removed when crossing 1200px breakpoint
- Toggle button position calculated from actual sidebar edge via `getBoundingClientRect`, not hardcoded percentage
- State persisted in localStorage (`krkn-sidebar-width`, `krkn-toc-collapsed`)

## Files changed

| File | Change |
|------|--------|
| `assets/scss/_custom_docs.scss` | Resizable sidebar flex layout, resize handle, collapsible TOC styles, toggle button |
| `layouts/_partials/hooks/body-end.html` | JS for drag-to-resize and TOC toggle with localStorage persistence |

## Test plan

- [x] Hugo build passes
- [x] Docs pages: resize handle visible at right edge of left sidebar
- [x] Drag resize works with mouse, width persists on refresh
- [x] TOC toggle button visible at sidebar border, collapses/expands smoothly
- [x] Main content area expands when TOC collapsed
- [x] Collapse state persists across page loads
- [x] Non-docs pages (homepage, blog, community) unaffected — JS guards return early
- [x] Dark and light themes verified
- [ ] Touch device testing (tablet in landscape)

🤖 Generated with [Claude Code](https://claude.com/claude-code)