### PR TITLE
fix: align Hugo version guards with required v0.146.0 (hugo-version-fix-bug)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -12,4 +12,4 @@
 module:
   hugoVersion:
     extended: true
-    min: 0.110.0
+    min: 0.146.0

--- a/config.yaml
+++ b/config.yaml
@@ -1,7 +1,7 @@
 # THIS IS A TEST CONFIG ONLY!
 # FOR THE CONFIGURATION OF YOUR SITE USE hugo.yaml.
 #
-# As of Docsy 0.7.0, Hugo 0.110.0 or later must be used.
+# As of Docsy 0.12.0, Hugo 0.146.0 or later must be used.
 #
 # The sole purpose of this config file is to detect Hugo-module builds that use
 # an older version of Hugo.

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -208,7 +208,7 @@ module:
   # workspace: docsy.work
   hugoVersion:
     extended: true
-    min: 0.110.0
+    min: 0.146.0
   imports:
     - path: github.com/google/docsy
       disable: false


### PR DESCRIPTION
## Bug Fix

**Related Feature:**
Hugo version validation (`hugo-version-fix-bug`)

**Changes:**

Updated the minimum Hugo version guard from `0.110.0` to `0.146.0` in:

- `hugo.yaml`
- `config.yaml`

I verified the required Hugo version by checking:

- `netlify.toml` (`HUGO_VERSION = "0.146.0"`)
- `README.md`
- `CONTRIBUTING.md`

Previously, contributors using Hugo versions between `0.110.0` and `0.145.x` could pass the configured version check and encounter build failures later in the build process. This change aligns the version guard with the actual supported version and ensures unsupported Hugo versions fail early with a clear error message.