### PR TITLE
fix: correct fallback site URL in rebuild-docs-index workflow

### DIFF
--- a/.github/workflows/rebuild-docs-index.yml
+++ b/.github/workflows/rebuild-docs-index.yml
@@ -40,7 +40,7 @@ jobs:
           # Try to get from Netlify API or use default
           SITE_URL="${{ secrets.NETLIFY_SITE_URL }}"
           if [ -z "$SITE_URL" ]; then
-            SITE_URL="https://krkn-chaos.netlify.app"
+            SITE_URL="https://krkn-chaos.dev"
           fi
           echo "SITE_URL=$SITE_URL" >> $GITHUB_OUTPUT
           echo "🌐 Using site URL: $SITE_URL"


### PR DESCRIPTION
## Bug Fix

**Related Feature:**
Documentation search index rebuild workflow (`rebuild-docs-index.yml`)

**Changes:**

Updated the fallback value of `SITE_URL` in the `rebuild-docs-index` workflow from:

```text
https://krkn-chaos.netlify.app
```

to:

```text
https://krkn-chaos.dev
```

The previous fallback URL was inconsistent with the rest of the repository configuration and documentation. Verification showed that the canonical production URL is `https://krkn-chaos.dev`, as referenced in:

* `hugo.yaml` (`baseURL`)
* `hugo.yaml` (`url_latest_version`)
* `README.md`

Additionally, there are no other references to `krkn-chaos.netlify.app` in the repository.

**Why this change is needed:**

When the `NETLIFY_SITE_URL` secret is unavailable (for example in fork-based PRs, local testing, or after secret rotation), the workflow falls back to the hardcoded `SITE_URL` value before issuing a POST request to:

```text
/api/admin/rebuild-index
```

Using an incorrect fallback host can cause the workflow to send requests to the wrong endpoint, resulting in failed index rebuilds, unexpected responses, or difficult-to-diagnose CI behavior.

**Impact:**

* Aligns the workflow with the project's canonical production URL.
* Ensures fallback behavior targets the correct site when `NETLIFY_SITE_URL` is not configured.
* Improves reliability of documentation index rebuilds in CI and fork-based environments.
* No changes to normal workflow execution when `NETLIFY_SITE_URL` is provided.
