### PR TITLE
docs: align dev workflow with --disableFastRender recommendations

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,6 +70,11 @@ npm run dev
 
 This starts a Hugo development server at `http://localhost:1313` with live reload enabled.
 
+> **Note:** The `--disableFastRender` flag is included so that SCSS compile errors are surfaced
+> immediately during incremental builds, rather than being silently skipped. This matches the
+> practice recommended in `CLAUDE.md` and prevents committing broken styles that only fail in CI.
+
+
 ### Building the Site
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "postbuild:production": "npm run _check:links",
     "serve": "npm run _serve",
     "test": "npm run check:links",
-    "dev": "hugo server --buildDrafts --buildFuture"
+    "dev": "hugo server --buildDrafts --buildFuture --disableFastRender"
   },
   "dependencies": {
     "axios": "^1.6.2",


### PR DESCRIPTION
## Documentation Update

**Related Feature:**
Development workflow / Hugo local development experience

**Changes:**

Aligned the local development workflow with the project's existing Hugo development recommendations.

Changes include:

* Updated the `dev` script in `package.json` to include `--disableFastRender`.
* Added documentation in `CONTRIBUTING.md` explaining why this flag is recommended during development.

Previously, contributors were instructed to run:

```text
npm run dev
```

which mapped to:

```text
hugo server --buildDrafts --buildFuture
```

However, both `CLAUDE.md` and the README recommend using `--disableFastRender` during development because it helps surface SCSS compilation errors immediately.

Without this flag, SCSS-related errors can be missed during incremental builds and may only appear later in CI or Netlify preview deployments.

**Impact:**

* Aligns `package.json`, `CONTRIBUTING.md`, `README.md`, and `CLAUDE.md`.
* Improves visibility of SCSS compilation issues during local development.
* Reduces the likelihood of style-related failures reaching CI or preview environments.
* Makes the contributor setup consistent with the project's documented best practices.
