### PR TITLE
docs: align scenario count references across homepage and docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -300,7 +300,9 @@ Also update the heading count if it changes (currently "20+ Chaos Scenarios").
 If the total number of scenarios crosses a new threshold, update these counts:
 
 - **Homepage title:** `layouts/index.html` — search for "20+ Chaos Scenarios"
-- **Docs landing page:** `content/en/docs/_index.md` — search for "15+ chaos scenarios"
+- **Docs landing page:** `content/en/docs/_index.md` — search for "20+ chaos scenarios"
+
+*(Tip: You can check the exact current count by running: `ls -1 content/en/docs/scenarios/ | grep -v "_index.md" | wc -l` or `find content/en/docs/scenarios -mindepth 1 -maxdepth 1 -type d | wc -l`)*
 
 ### Step 5: Sidebar navigation
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -302,7 +302,7 @@ If the total number of scenarios crosses a new threshold, update these counts:
 - **Homepage title:** `layouts/index.html` — search for "20+ Chaos Scenarios"
 - **Docs landing page:** `content/en/docs/_index.md` — search for "20+ chaos scenarios"
 
-*(Tip: You can check the exact current count by running: `ls -1 content/en/docs/scenarios/ | grep -v "_index.md" | wc -l` or `find content/en/docs/scenarios -mindepth 1 -maxdepth 1 -type d | wc -l`)*
+*(Tip: To get the exact scenario count, run: `find content/en/docs/scenarios -mindepth 1 -maxdepth 1 -type d | wc -l` — this counts only directories, avoiding false positives from stray `.md` files in the same folder.)*
 
 ### Step 5: Sidebar navigation
 

--- a/content/en/docs/_index.md
+++ b/content/en/docs/_index.md
@@ -315,7 +315,7 @@ type: "docs/scenarios"
             <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="7" height="7" x="3" y="3" rx="1"/><rect width="7" height="7" x="14" y="3" rx="1"/><rect width="7" height="7" x="14" y="14" rx="1"/><rect width="7" height="7" x="3" y="14" rx="1"/></svg>
           </div>
           <h3 class="feature-card__title">Browse Scenarios</h3>
-          <p class="feature-card__desc">Explore 25+ chaos scenarios for pods, nodes, network, and more.</p>
+          <p class="feature-card__desc">Explore 20+ chaos scenarios for pods, nodes, network, and more.</p>
         </a>
       </div>
     </div>


### PR DESCRIPTION
## Documentation Update

**Related Feature:**
Scenario catalog documentation consistency

**Changes:**

The homepage advertised "20+ Chaos Scenarios" while the docs landing page advertised "25+ chaos scenarios". A review of the scenario directory showed 23 scenarios, resulting in inconsistent messaging across the site.

This change:
- Updates the docs landing page to use the same "20+" threshold as the homepage.
- Updates `CLAUDE.md` to reflect the current search strings.
- Adds a tip for contributors on how to verify the current scenario count and when count-related messaging should be updated.

This ensures consistent messaging across the website and improves contributor guidance for maintaining count-based content.