### PR TITLE
Add krkn-hub-scenario markers to 6 unmarked scenario pages

### DIFF
--- a/content/en/docs/scenarios/aurora-disruption/_index.md
+++ b/content/en/docs/scenarios/aurora-disruption/_index.md
@@ -5,7 +5,11 @@ date: 2017-01-04
 weight: 3
 ---
 
+<krkn-hub-scenario id="pod-network-filter">
+
 This scenario blocks a pod's outgoing MySQL and PostgreSQL traffic, effectively preventing it from connecting to any AWS Aurora SQL engine. It works just as well for standard MySQL and PostgreSQL connections too.
+
+</krkn-hub-scenario>
 
 This uses the pod network filter scenario but set with specific parameters to disrupt aurora
 

--- a/content/en/docs/scenarios/dns-outage/_index.md
+++ b/content/en/docs/scenarios/dns-outage/_index.md
@@ -5,7 +5,11 @@ date: 2017-01-04
 weight: 3
 ---
 
+<krkn-hub-scenario id="pod-network-filter">
+
 This scenario blocks all outgoing DNS traffic from a specific pod, effectively preventing it from resolving any hostnames or service names.
+
+</krkn-hub-scenario>
 
 ## How to Run DNS Outage Scenarios
 

--- a/content/en/docs/scenarios/efs-disruption/_index.md
+++ b/content/en/docs/scenarios/efs-disruption/_index.md
@@ -4,7 +4,12 @@ description:
 date: 2017-01-04
 weight: 3
 ---
+
+<krkn-hub-scenario id="node-network-filter">
+
 This scenario creates an outgoing firewall rule on specific nodes in your cluster, chosen by node name or a selector. This rule blocks connections to AWS EFS, leading to a temporary failure of any EFS volumes mounted on those affected nodes.
+
+</krkn-hub-scenario>
 
 ## How to Run EFS Disruption Scenarios
 

--- a/content/en/docs/scenarios/etcd-split-brain/_index.md
+++ b/content/en/docs/scenarios/etcd-split-brain/_index.md
@@ -5,7 +5,11 @@ date: 2017-01-04
 weight: 3
 ---
 
+<krkn-hub-scenario id="node-network-filter">
+
 This scenario isolates an etcd node by blocking its network traffic. This action forces an etcd leader re-election. Once the scenario concludes, the cluster should temporarily exhibit a split-brain condition, with two etcd leaders active simultaneously. This is particularly useful for testing the etcd cluster's resilience under such a challenging state.
+
+</krkn-hub-scenario>
 
 {{< notice type="danger" >}} This scenario carries a significant risk: it **might break the cluster API**, making it impossible to automatically revert the applied network rules. The `iptables` rules will be printed to the console, allowing for manual reversal via a shell on the affected node. This scenario is **best suited for disposable clusters** and should be **used at your own risk**. {{< /notice >}}
 

--- a/content/en/docs/scenarios/network-chaos-ng-scenarios/node-network-chaos/_index.md
+++ b/content/en/docs/scenarios/network-chaos-ng-scenarios/node-network-chaos/_index.md
@@ -4,7 +4,12 @@ description: "Injects network degradation (latency, packet loss, bandwidth) into
 date: 2017-01-04
 weight: 2
 ---
+
+<krkn-hub-scenario id="node-network-chaos">
+
 Injects network degradation (latency, packet loss, bandwidth restriction) into a target node's network interfaces using Linux `tc` (traffic control) rules. Unlike node-network-filter which blocks specific ports via iptables, this module shapes traffic at the interface level. Includes safety checks for existing `tc` rules on the node.
+
+</krkn-hub-scenario>
 
 ## How to Run Node Network Chaos Scenarios
 

--- a/content/en/docs/scenarios/network-chaos-ng-scenarios/pod-network-chaos/_index.md
+++ b/content/en/docs/scenarios/network-chaos-ng-scenarios/pod-network-chaos/_index.md
@@ -4,7 +4,12 @@ description: "Injects network degradation (latency, packet loss, bandwidth) into
 date: 2017-01-04
 weight: 2
 ---
+
+<krkn-hub-scenario id="pod-network-chaos">
+
 Injects network degradation (latency, packet loss, bandwidth restriction) into a target pod's network interfaces using Linux `tc` (traffic control) rules. Unlike pod-network-filter which blocks specific ports via iptables, this module shapes traffic at the interface level.
+
+</krkn-hub-scenario>
 
 ## How to Run Pod Network Chaos Scenarios
 


### PR DESCRIPTION
While verifying markers for [#545](https://github.com/krkn-chaos/website/issues/545), an extra sweep of every scenario page turned up **6 more pages with no `<krkn-hub-scenario id="...">` marker**, beyond the set #545 listed (most of which are already fixed on `main`). 
This PR adds a marker to each.

&ensp;

None of these are source-less. Each page's krkn-hub tab and prose already name a real krkn-hub source:

| Page | Marker added | krkn-hub source |
| --- | --- | --- |
| network-chaos-ng-scenarios/node-network-chaos | `node-network-chaos` | own folder (unique) |
| aurora-disruption | `pod-network-filter` | shared |
| dns-outage | `pod-network-filter` | shared |
| efs-disruption | `node-network-filter` | shared |
| etcd-split-brain | `node-network-filter` | shared |
| network-chaos-ng-scenarios/pod-network-chaos | `pod-network-chaos` | shared with pod-network-scenario |

&ensp;

### The thing to confirm:- 

Five of the six **reuse a shared krkn-hub scenario** with different env vars, so several pages point at one source (many-to-one). Two questions for maintainers:

1. Is many-to-one the right model here, or should these pages map differently?
2. The bot's [`_find_scenario_dir`](https://github.com/krkn-chaos/docsync-bot/blob/main/bot/scaffold.py) returns the **first** matching page and stops, so a shared source currently updates only one page and silently skips the rest. Adding these markers is safe, but a small bot change (return all matches, loop) is needed before the shared pages fully sync.

### Verification

- All 6 markers resolve to a real folder in [krkn-hub](https://github.com/krkn-chaos/krkn-hub) `main`.
- Every scenario page that has a krkn-hub tab now carries a marker.
- `hugo` production build passes (290 pages, 0 errors).


Part of [Doc-sync Bot](https://github.com/krkn-chaos/website/issues/320) Work