### PR TITLE
docs(krkn/feat/http-trigger): add comprehensive guide for event-driven triggers

### DIFF
--- a/content/en/docs/krkn/_index.md
+++ b/content/en/docs/krkn/_index.md
@@ -72,6 +72,10 @@ Information on enabling and leveraging this feature can be found [here](SLOs_val
 Health checks provide real-time visibility into the impact of chaos scenarios on application availability and performance. The system periodically checks the provided URLs based on the defined interval and records the results in Telemetry. To read more about how to properly configure health checks in your krkn run and sample output see [health checks](health-checks.md) document. 
 
 
+### Event-Driven Triggers
+Triggers allow Krkn to delay chaos injection until specific environmental conditions are met. Instead of using a fixed wait time, Krkn can actively poll command outputs or HTTP endpoints and automatically proceed once your conditions are satisfied. This is useful for synchronizing chaos with deployments, health checks, or external CI/CD pipelines. Find detailed configuration options and examples [here](triggers.md).
+
+
 ### Telemetry
 We gather some basic details of the cluster configuration and scenarios ran as part of a `telemetry` set of data that is printed off at the end of each krkn run. You can also opt in to the telemetry being stored in AWS S3 bucket or elasticsearch for long term storage. Find more details and configuration specifics [here](telemetry.md)
 

--- a/content/en/docs/krkn/triggers.md
+++ b/content/en/docs/krkn/triggers.md
@@ -1,0 +1,75 @@
+---
+title: Event-Driven Triggers
+description: Delay chaos injection until specific conditions are met
+weight: 10
+---
+
+The Triggers framework allows you to delay chaos injection until specific environmental conditions are met. Instead of simply waiting a fixed amount of time or relying entirely on manual signaling, Krkn can actively poll your environment and automatically proceed with the scenario once all your defined triggers are satisfied.
+
+This is especially useful for event-driven chaos, such as waiting for a background deployment to finish, waiting for a service to become healthy, or synchronizing Krkn with an external CI/CD pipeline.
+
+## Configuration
+
+Triggers are configured inside your Krkn scenario files under the `triggers` block.
+
+```yaml
+triggers:
+  mode: all_of      # Optional: all_of | any_of (default: all_of)
+  timeout: 300      # Optional: Max time to wait in seconds (default: 300)
+  interval: 5       # Optional: Polling interval in seconds (default: 5)
+  on_timeout: skip  # Optional: skip | fail | run_anyway (default: skip)
+  conditions:
+    - type: command
+      cmd: "kubectl get pods -n my-app | grep Running"
+    - type: http
+      url: "http://my-service.default.svc:8080/health"
+      expected_status: 200
+```
+
+### Global Trigger Settings
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `mode` | `all_of` requires all conditions to pass. `any_of` proceeds when at least one condition passes. | `all_of` |
+| `timeout` | Maximum time (in seconds) to wait for conditions to be met before timing out. | `300` |
+| `interval` | How often (in seconds) Krkn polls the conditions. | `5` |
+| `on_timeout`| Behavior if timeout is reached. `skip`: skips scenario. `fail`: fails scenario. `run_anyway`: proceeds with chaos anyway. | `skip` |
+
+## Trigger Types
+
+### 1. Command Trigger
+
+The `command` trigger runs a shell command and passes if the command exits with a `0` (success) return code.
+
+```yaml
+  - type: command
+    cmd: "kubectl get nodes | grep Ready"
+```
+
+| Field | Description |
+|-------|-------------|
+| `type` | Must be `command` |
+| `cmd` | The shell command to execute. |
+
+### 2. HTTP Trigger
+
+The `http` trigger polls an HTTP/HTTPS endpoint and passes when the endpoint returns the expected status code and (optionally) matches a substring in the response body.
+
+```yaml
+  - type: http
+    url: "https://api.my-app.com/ready"
+    method: "GET"
+    expected_status: 200
+    bearer_token: "my-secret-token"
+    body_contains: "status: healthy"
+```
+
+| Field | Description | Default |
+|-------|-------------|---------|
+| `type` | Must be `http` | |
+| `url` | The URL to poll. | (Required) |
+| `method` | The HTTP method (`GET`, `POST`, etc.). | `GET` |
+| `expected_status` | The HTTP status code required to pass. | `200` |
+| `headers` | A dictionary of custom HTTP headers. | `{}` |
+| `bearer_token` | Automatically sets the `Authorization: Bearer <token>` header. | |
+| `body_contains` | If set, the response body must contain this exact substring. | |


### PR DESCRIPTION
## Documentation Update
**Related Feature:** https://github.com/krkn-chaos/krkn/pull/1504

**Changes:** 
- Created `content/en/docs/krkn/triggers.md` to document the Event-Driven Trigger framework, including global configurations and specific trigger types (`command` and `http`).
- Added an 'Event-Driven Triggers' entry to the Krkn Features section in `content/en/docs/krkn/_index.md` for proper discoverability.
