### PR TITLE
fix: return 400 instead of 500 for invalid JSON in chat function

### DIFF
--- a/netlify/functions/chat.js
+++ b/netlify/functions/chat.js
@@ -92,6 +92,29 @@ exports.handler = async (event, context) => {
         };
     }
 
+    // Parse and validate the request body before the main processing path.
+    // Invalid JSON is a client error (400), not a server error (500).
+    let parsedBody;
+    try {
+        parsedBody = JSON.parse(event.body);
+    } catch (parseError) {
+        return {
+            statusCode: 400,
+            headers,
+            body: JSON.stringify({ error: 'Invalid JSON in request body' })
+        };
+    }
+
+    const { message, conversationHistory = [] } = parsedBody || {};
+
+    if (!message || typeof message !== 'string') {
+        return {
+            statusCode: 400,
+            headers,
+            body: JSON.stringify({ error: 'Message is required' })
+        };
+    }
+
     try {
         // Check daily limit first
         if (!checkDailyLimit()) {
@@ -112,17 +135,6 @@ exports.handler = async (event, context) => {
 
         // Initialize services
         await initializeServices();
-
-        // Parse request body
-        const { message, conversationHistory = [] } = JSON.parse(event.body);
-
-        if (!message || typeof message !== 'string') {
-            return {
-                statusCode: 400,
-                headers,
-                body: JSON.stringify({ error: 'Message is required' })
-            };
-        }
 
         // Process message
         const response = await chatService.processMessage(message, {


### PR DESCRIPTION

**Related Feature:** `fix/chat-invalid-json-returns-500`

fixes: #573 

**Changes:**

- fixed error handling in the chat Netlify function (`netlify/functions/chat.js`). Moved `JSON.parse` out of the main `try/catch` block into its own `try/catch` so that malformed request bodies return `400 Bad Request` instead of `500 Internal Server Error`. 
- The `500` path is now reserved for genuine server-side failures only. 
- No documentation pages were changed 
