### PR TITLE
update generate_pdf_report parameter information

### DIFF
--- a/content/en/docs/krkn/config.md
+++ b/content/en/docs/krkn/config.md
@@ -44,6 +44,9 @@ Refer to [signal.md](signal.md) for more details
 
 **port**: port to listen/post the signal state to
 
+**generate_pdf_report**: Generates a PDF summary report after the run if set to True
+
+
 ### Auto Rollback
 
 **auto_rollback**: Enable auto rollback for scenarios. When set to True, krkn will attempt to roll back changes made by a scenario if it fails.
@@ -270,6 +273,7 @@ kraken:
     signal_state: RUN                                      # Will wait for the RUN signal when set to PAUSE before running the scenarios, refer docs/signal.md for more details
     signal_address: 0.0.0.0                                # Signal listening address
     port: 8081                                             # Signal port
+    generate_pdf_report: True                              # Generate a PDF summary report after the run
     chaos_scenarios:
         # List of policies/chaos scenarios to load
         - hog_scenarios:


### PR DESCRIPTION
## Documentation Update

**Description:** 
The generate_pdf_report field has been added to Krkn's telemetry configuration. When enabled, a PDF report summarizing the chaos run results is generated at the end of each scenario run.

  Changes:

 - Added generate_pdf_report parameter documentation to the Telemetry section in content/en/docs/krkn/config.md (field description and sample config YAML)

**Related Feature:** 

branch name: tejugang:improve-krkn-output-to-summarize-key-areas
PR: https://github.com/krkn-chaos/krkn/pull/1532 (merged)
