### PR TITLE
added generate_pdf_report parameter information to all-scenario-env docs

### DIFF
--- a/content/en/docs/scenarios/all-scenario-env-krknctl.md
+++ b/content/en/docs/scenarios/all-scenario-env-krknctl.md
@@ -61,6 +61,7 @@ General run settings. See [Kraken config](../krkn/config.md#kraken) for full det
 | `--krkn-kubeconfig` | Sets the path where krkn will search for kubeconfig in container | string | - | /home/krkn/.kube/config |
 | `--uuid` | Sets krkn run uuid instead of generating it | string | - | - |
 | `--krkn-debug` | Enables debug mode for Krkn | enum | True/False | False |
+| `--generate-pdf-report` | When enabled, generates a PDF report summarizing the chaos run results at the end of each scenario | enum | True/False | False |
 
 </div>
 

--- a/content/en/docs/scenarios/all-scenario-env.md
+++ b/content/en/docs/scenarios/all-scenario-env.md
@@ -25,6 +25,7 @@ Parameter | Description | Default
 `SIGNAL_ADDRESS` | Address to publish kraken status to | 0.0.0.0
 `PORT` | Port to publish kraken status to | 8081
 `SIGNAL_STATE` | Waits for the RUN signal when set to PAUSE before running the scenarios, refer [docs](../krkn/signal.md) for more details | RUN
+`GENERATE_PDF_REPORT` | When enabled, generates a PDF report summarizing the chaos run results at the end of each scenario | False
 
 ---
 


### PR DESCRIPTION
## Documentation Update
**Related Feature:** 

 branch name: tejugang:improve-krkn-output-to-summarize-key-areas

**Changes:** 

 - Added GENERATE_PDF_REPORT environment variable to the Kraken section in content/en/docs/scenarios/all-scenario env.md
 - Added --generate-pdf-report CLI flag to the Kraken section in content/en/docs/scenarios/all-scenario-env-krknctl.md