### PR TITLE
make vmi-network-chaos use the image tag that actually exists (#580)

### DIFF
--- a/content/en/docs/scenarios/network-chaos-ng-scenarios/vmi-network/_tab-krkn-hub.md
+++ b/content/en/docs/scenarios/network-chaos-ng-scenarios/vmi-network/_tab-krkn-hub.md
@@ -2,22 +2,22 @@
 #### Run
 
 ```bash
-$ podman run --name=<container_name> --net=host --pull=always --env-host=true -v <path-to-kube-config>:/home/krkn/.kube/config:Z -d containers.krkn-chaos.dev/krkn-chaos/krkn-hub:vmi-network-chaos
+$ podman run --name=<container_name> --net=host --pull=always --env-host=true -v <path-to-kube-config>:/home/krkn/.kube/config:Z -d containers.krkn-chaos.dev/krkn-chaos/krkn-hub:vmi-network
 $ podman logs -f <container_name or container_id> # Streams Kraken logs
 $ podman inspect <container-name or container-id> --format "{{.State.ExitCode}}" # Outputs exit code which can considered as pass/fail for the scenario
 ```
 
 ```bash
-$ docker run $(./get_docker_params.sh) --name=<container_name> --net=host --pull=always -v <path-to-kube-config>:/home/krkn/.kube/config:Z -d containers.krkn-chaos.dev/krkn-chaos/krkn-hub:vmi-network-chaos
+$ docker run $(./get_docker_params.sh) --name=<container_name> --net=host --pull=always -v <path-to-kube-config>:/home/krkn/.kube/config:Z -d containers.krkn-chaos.dev/krkn-chaos/krkn-hub:vmi-network
 OR
-$ docker run -e <VARIABLE>=<value> --net=host --pull=always -v <path-to-kube-config>:/home/krkn/.kube/config:Z -d containers.krkn-chaos.dev/krkn-chaos/krkn-hub:vmi-network-chaos
+$ docker run -e <VARIABLE>=<value> --net=host --pull=always -v <path-to-kube-config>:/home/krkn/.kube/config:Z -d containers.krkn-chaos.dev/krkn-chaos/krkn-hub:vmi-network
 $ docker logs -f <container_name or container_id> # Streams Kraken logs
 $ docker inspect <container-name or container-id> --format "{{.State.ExitCode}}" # Outputs exit code which can considered as pass/fail for the scenario
 ```
 
 **TIP**: Because the container runs with a non-root user, ensure the kube config is globally readable before mounting it in the container. You can achieve this with the following commands:
 ```bash
-kubectl config view --flatten > ~/kubeconfig && chmod 444 ~/kubeconfig && docker run $(./get_docker_params.sh) --name=<container_name> --net=host --pull=always -v ~/kubeconfig:/home/krkn/.kube/config:Z -d containers.krkn-chaos.dev/krkn-chaos/krkn-hub:vmi-network-chaos
+kubectl config view --flatten > ~/kubeconfig && chmod 444 ~/kubeconfig && docker run $(./get_docker_params.sh) --name=<container_name> --net=host --pull=always -v ~/kubeconfig:/home/krkn/.kube/config:Z -d containers.krkn-chaos.dev/krkn-chaos/krkn-hub:vmi-network
 ```
 
 
@@ -51,5 +51,5 @@ See list of variables that apply to all scenarios [here](/docs/scenarios/all-sce
 
 **NOTE** In case of using custom metrics profile or alerts profile when `CAPTURE_METRICS` or `ENABLE_ALERTS` is enabled, mount the metrics profile from the host on which the container is run using podman/docker under `/home/krkn/kraken/config/metrics-aggregated.yaml` and `/home/krkn/kraken/config/alerts`. For example:
 ```bash
-$ podman run --name=<container_name> --net=host --pull=always --env-host=true -v <path-to-custom-metrics-profile>:/home/krkn/kraken/config/metrics-aggregated.yaml -v <path-to-custom-alerts-profile>:/home/krkn/kraken/config/alerts -v <path-to-kube-config>:/home/krkn/.kube/config:Z -d containers.krkn-chaos.dev/krkn-chaos/krkn-hub:vmi-network-chaos
+$ podman run --name=<container_name> --net=host --pull=always --env-host=true -v <path-to-custom-metrics-profile>:/home/krkn/kraken/config/metrics-aggregated.yaml -v <path-to-custom-alerts-profile>:/home/krkn/kraken/config/alerts -v <path-to-kube-config>:/home/krkn/.kube/config:Z -d containers.krkn-chaos.dev/krkn-chaos/krkn-hub:vmi-network
 ```

--- a/content/en/docs/scenarios/network-chaos-ng-scenarios/vmi-network/_tab-krknctl.md
+++ b/content/en/docs/scenarios/network-chaos-ng-scenarios/vmi-network/_tab-krknctl.md
@@ -1,5 +1,5 @@
 ```bash
-krknctl run vmi-network-chaos [--<parameter> <value>]
+krknctl run vmi-network [--<parameter> <value>]
 ```
 
 Can also set any global variable listed [here](../../all-scenario-env-krknctl.md)
@@ -47,7 +47,7 @@ Can also set any global variable listed [here](../../all-scenario-env-krknctl.md
 
 **Add latency and packet loss to all VMIs in a namespace:**
 ```bash
-krknctl run vmi-network-chaos \
+krknctl run vmi-network \
   --namespace <namespace> \
   --target ".*" \
   --latency 100ms \
@@ -57,7 +57,7 @@ krknctl run vmi-network-chaos \
 
 **Bandwidth cap on a specific VMI:**
 ```bash
-krknctl run vmi-network-chaos \
+krknctl run vmi-network \
   --namespace <namespace> \
   --target "<vmi-name>" \
   --bandwidth 1mbit \
@@ -68,7 +68,7 @@ krknctl run vmi-network-chaos \
 
 **Catastrophic combined degradation:**
 ```bash
-krknctl run vmi-network-chaos \
+krknctl run vmi-network \
   --namespace <namespace> \
   --target "<vmi-name-prefix>-.*" \
   --instance-count 3 \
@@ -81,7 +81,7 @@ krknctl run vmi-network-chaos \
 
 **DNS blackout simulation (high latency, no packet drop):**
 ```bash
-krknctl run vmi-network-chaos \
+krknctl run vmi-network \
   --namespace <namespace> \
   --target ".*" \
   --latency 5000ms \


### PR DESCRIPTION
Fixes #580, see the issue for the details.

- `_tab-krkn-hub.md`: 5 image references now use `krkn-hub:vmi-network`
- `_tab-krknctl.md`: 5 commands now use `krknctl run vmi-network`

`_tab-krkn.md`, the page name and the page title are unchanged.

Verified with a full `hugo --minify` build (291 pages, 0 errors). 
I also checked every other scenario page against the quay.io tag list, and this was the only one pointing at a tag that was never built.
