### PR TITLE
docs(pod-scenario): add execution configuration documentation

### DIFF
--- a/content/en/docs/scenarios/pod-scenarios/_index.md
+++ b/content/en/docs/scenarios/pod-scenarios/_index.md
@@ -90,6 +90,30 @@ exclude_label: "key=value"
         kill: 2
 ```
 
+## Serial vs Parallel Execution
+
+By default, when `kill` is set to greater than 1, pods are deleted **serially** (one by one). This is useful for testing how an application handles rolling disruptions and allowing the cluster time to reschedule each pod before deleting the next one.
+
+However, some chaos scenarios require true simultaneous failure, such as simulating an etcd quorum loss or an availability zone outage. To achieve this, you can set the `execution` configuration to `parallel`.
+
+**Format:**
+
+```yaml
+execution: parallel    # optional: serial (default) | parallel
+```
+
+### Example: Simulate etcd Quorum Loss
+
+```yaml
+- id: kill_pods
+  config:
+    namespace_pattern: ^openshift-etcd$
+    label_selector: k8s-app=etcd
+    krkn_pod_recovery_time: 120
+    kill: 2
+    execution: parallel
+```
+
 ## Targeting Pods on Specific Nodes
 
 By default, pod scenarios target all pods matching the namespace and label selectors regardless of which node they run on. However, you can narrow down the scope to only affect pods running on specific nodes using two options:

--- a/content/en/docs/scenarios/pod-scenarios/_tab-krkn-hub.md
+++ b/content/en/docs/scenarios/pod-scenarios/_tab-krkn-hub.md
@@ -68,6 +68,7 @@ NAME_PATTERN            | Regex pattern to match the pods in NAMESPACE  when POD
 DISRUPTION_COUNT        | Number of pods to disrupt                                             | number | 1                                    |
 KILL_TIMEOUT            | Timeout to wait for the target pod(s) to be removed in seconds        | number | 180                                  |
 EXPECTED_RECOVERY_TIME           | Fails if the pod disrupted do not recover within the timeout set      | number | 120                                  |
+EXECUTION               | Execution mode for pod deletion (serial or parallel)                                         | enum | serial                                   |
 NODE_LABEL_SELECTOR           | Label of the node(s) to target                                         | string | ""                                   |
 NODE_NAMES            | Name of the node(s) to target. Example: ["worker-node-1","worker-node-2","master-node-1"]                                         | string | []                                   |
 

--- a/content/en/docs/scenarios/pod-scenarios/_tab-krknctl.md
+++ b/content/en/docs/scenarios/pod-scenarios/_tab-krknctl.md
@@ -15,6 +15,7 @@ Scenario specific parameters:
 `--disruption-count` | Number of pods to disrupt | number | No | 1 |
 `--kill-timeout` | Timeout to wait for the target pod(s) to be removed in seconds | number | No | 180 |
 `--expected-recovery-time` | Fails if the pod disrupted do not recover within the timeout set | number | No | 120 |
+`--execution` | Execution mode for pod deletion (serial or parallel) | enum | No | serial |
 `--node-label-selector` | Label of the node(s) to target | string | No | "" |
 `--node-names` | Name of the node(s) to target. Example: ["worker-node-1","worker-node-2","master-node-1"] | string | No | [] |
 


### PR DESCRIPTION
## Description
This PR documents the new `execution` parameter for Pod Disruption scenarios, which allows users to delete pods in `parallel` (e.g., simulating immediate quorum loss) rather than the default `serial` rolling deletion.

Changes:
- Added a "Serial vs Parallel Execution" section to `pod-scenario/_index.md` with an etcd quorum loss example.
- Added `EXECUTION` to the supported parameters table in `_tab-krkn-hub.md`.
- Added `--execution` to the scenario-specific parameters table in `_tab-krknctl.md`.

This accompanies the `krkn` and `krkn-hub` PRs for the parallel pod deletion feature.
