### PR TITLE
docs(krkn_ai): dynamic discover — scenarios, health checks, fitness queries

### DIFF
--- a/content/en/docs/krkn_ai/config/fitness_function.md
+++ b/content/en/docs/krkn_ai/config/fitness_function.md
@@ -9,6 +9,7 @@ The **fitness function** is a crucial element in the Krkn-AI algorithm. It evalu
 - The fitness function can be defined as an SLO or as cluster metrics using a Prometheus query.
 - Fitness scores are calculated for the time range during which the Chaos scenario is executed.
 
+
 ## Example
 
 Let's look at a simple fitness function that calculates the total number of restarts in a namespace:
@@ -91,6 +92,8 @@ fitness_function:
     type: point
 ```
 
+> **Note:** `query` and `items` are alternatives. If both are set, `query` is used and `items` is ignored.
+
 ## Krkn Failures
 
 Krkn-AI uses [krknctl](../../krknctl/) under the hood to trigger Chaos testing experiments on the cluster. As part of the CLI, it captures various feedback and returns a non-zero status code (exit status 2) when a failure occurs. By default, feedback from these failures is included in the Krkn-AI Fitness Score calculation.
@@ -108,7 +111,100 @@ fitness_function:
 
 ## Health Check
 
-Results from application health checks are also incorporated into the fitness score. You can learn more about health checks and how to configure them in more detail [here](./health_check.md).
+Results from application health checks are also incorporated into the fitness score, controlled by `include_health_check_failure` and `include_health_check_response_time`. Both default to `true`. You can learn more about health checks and how to configure them in more detail [here](./health_check.md).
+
+## Automatic Recommendations
+
+Writing valid PromQL for an unfamiliar cluster is usually the slowest part of a first run, so [discover](../discover.md) proposes fitness queries that are already verified against your cluster's Prometheus.
+
+Krkn-AI ships a catalog of queries covering common failure signals, in [catalog.yaml](https://github.com/krkn-chaos/krkn-ai/blob/main/krkn_ai/utils/catalog.yaml). Each entry is a PromQL template plus the metrics it depends on.
+
+| Category | Example queries |
+|-----------------|-----------------------------------------------------------------|
+| `availability`  | `pod-restarts`, `crashloop-pods`, `deployment-replicas-missing` |
+| `resource`      | `oom-kills`, `cpu-throttle`                                     |
+| `node`          | `node-pressure`, `node-not-ready`                               |
+| `control_plane` | `apiserver-errors`, `apiserver-latency`                         |
+| `etcd`          | `etcd-request-latency`, `etcd-leader-changes`                   |
+| `storage`       | `pvc-pending`                                                   |
+
+For every entry, Krkn-AI checks:
+
+- **Are the metrics available?** Every metric the query needs must be scraped by your Prometheus, otherwise the query is rejected.
+- **Which namespaces?** Namespace scoped queries are generated once per discovered namespace, named `<key>:<namespace>`, for example `pod-restarts:robot-shop`.
+- **Does it return a single value?** The query is run against Prometheus and must return one series, since a fitness function has to produce one number.
+- **How much should it count?** Accepted queries are given weights that add up to 1.
+
+Accepted queries are written under `items`. Rejected ones are commented out with the reason, so you can see what your cluster is missing.
+
+```yaml
+fitness_function:
+  include_krkn_failure: true
+  include_health_check_failure: true
+  include_health_check_response_time: true
+  # Fitness queries validated against the cluster's Prometheus.
+  items:
+  # pod-restarts:robot-shop
+  - query: '(sum(increase(kube_pod_container_status_restarts_total{namespace="robot-shop"}[$range$]))) or vector(0)'
+    type: range
+    weight: 0.5
+  # node-pressure
+  - query: '(sum(kube_node_status_condition{condition=~"MemoryPressure|DiskPressure|PIDPressure", status="true"})) or vector(0)'
+    type: range
+    weight: 0.5
+  # cpu-throttle:robot-shop (metric(s) not scraped: container_cpu_cfs_throttled_periods_total)
+  # - query: '...'
+  #   type: range
+```
+
+Every query is wrapped in `or vector(0)`. A Prometheus query that matches nothing returns an empty result, which would fail the scenario; the wrapper turns "nothing happened" into a score of `0`.
+
+### Prometheus Access
+
+Krkn-AI needs to reach Prometheus during `discover` to validate the queries.
+
+On OpenShift, the URL is discovered from the Thanos Query route and the token from your kubeconfig credentials. If token discovery comes back empty, as it does for exec or certificate-based auth, set `PROMETHEUS_TOKEN` explicitly. On other clusters, set the URL yourself:
+
+```bash
+export PROMETHEUS_URL="http://localhost:9090"
+export PROMETHEUS_TOKEN="<token>"
+```
+
+If Prometheus cannot be reached, `discover` still succeeds and writes a single default query that you can replace later.
+
+### Learned Weights
+
+Not every fitness query is equally useful. A query whose value is the same for every scenario tells the algorithm nothing.
+
+After a run, Krkn-AI writes `learned_weights.json` into the run's output directory, scoring each query by how much its value varied across scenarios. Feed that back into the next `discover` to bias the weights towards the queries that actually distinguish scenarios:
+
+```bash
+uv run krkn_ai discover -k ./tmp/kubeconfig.yaml -o ./krkn-ai.yaml \
+  --learned-weights ./results/<run-uuid>/learned_weights.json
+```
+
+Weights are matched per query and namespace, so they only apply when you discover the same namespaces again. They are used as a starting point and are still normalized to add up to 1.
+
+### Adding a Query to the Catalog
+
+To contribute a query, add an entry to [catalog.yaml](https://github.com/krkn-chaos/krkn-ai/blob/main/krkn_ai/utils/catalog.yaml):
+
+```yaml
+- key: my-metric
+  category: availability
+  name: Human readable name
+  query_template: 'sum(increase(my_metric_total{namespace="$ns"}[$range$]))'
+  requires: [my_metric_total]
+  scope: namespace
+```
+
+- `key` and `query_template` are the only required fields.
+- `$ns` is replaced with each discovered namespace and `$range$` with the scenario duration. Use `scope: cluster` for queries that are not namespace specific.
+- The query must aggregate to a single series, so wrap it in `sum()`, `max()` or `avg()`.
+- List every metric the query reads in `requires`, so Krkn-AI can skip it on clusters that do not scrape them.
+- Do not add `or vector(0)` yourself, Krkn-AI adds it.
+
+Run `discover` against a cluster that has the metric and check that your entry comes back enabled.
 
 ## How to Define a Good Fitness Function
 

--- a/content/en/docs/krkn_ai/config/health_check.md
+++ b/content/en/docs/krkn_ai/config/health_check.md
@@ -10,13 +10,17 @@ When defining the Chaos Config, you can provide details about your application e
 
 ### Configuration
 
-The following configuration options are available when defining an application for health checks:
+The `health_checks` block accepts:
+- **stop_watcher_on_failure**: This setting allows you to stop the health check watcher for an endpoint after it encounters a failure.
+- **stop_timeout**: How long to wait for the health check watcher to shut down at the end of a scenario.
+- **applications**: The list of endpoints to check.
+
+Each application accepts:
 - **name**: Name of the service.
 - **url**: Service endpoint; supports parameterization with "$<KEY>".
 - **status_code**: Expected status code returned when accessing the service.
 - **timeout**: Timeout period after which the request is canceled.
 - **interval**: How often to check the endpoint.
-- **stop_watcher_on_failure**: This setting allows you to stop the health check watcher for an endpoint after it encounters a failure.
 
 #### Example
 
@@ -50,6 +54,65 @@ In the previous example, the `$HOST` variable in the config can be dynamically r
 ```bash
 uv run krkn_ai run -c krkn-ai.yaml -o results/ -p HOST=http://example.cluster.url/nginx
 ```
+
+### Automatic Discovery
+
+Rather than writing these URLs by hand, [discover](../discover.md) can build them from the services it finds in the cluster.
+
+Krkn-AI only considers **`LoadBalancer` services** in the discovered namespaces. Ingress, OpenShift Routes, `NodePort` and `ClusterIP` services are not used, because they do not give Krkn-AI an address it can reach directly.
+
+For each service, the URL is built as `scheme://host:port/path`:
+
+- **host** comes from the load balancer's external address. Services whose load balancer is still pending are skipped.
+- **port**, **path** and **scheme** come from the `httpGet` readiness probe on the pod behind the service. If there is no readiness probe, the liveness probe is used instead.
+- Probes of type `exec` or `tcpSocket` are ignored, since they carry no URL.
+- If no usable probe is found, the URL falls back to the service's first port at `/`.
+
+Krkn-AI then sends a GET request to each URL and treats any response below HTTP 500 as reachable. This check runs from the machine where you run `discover`, not from inside the cluster, so an endpoint that only resolves within the cluster network is reported as unreachable.
+
+Only endpoints that have a probe **and** responded are written as active entries. The rest are commented out with the reason, so you can enable them once the cause is fixed.
+
+| Probe found | Reachable | Result |
+|-------------|-----------|------------------------------|
+| Yes         | Yes       | Active entry                 |
+| Yes         | No        | Commented, `# (unreachable)` |
+| No          | Any       | Commented, `# (no probe)`    |
+
+```yaml
+health_checks:
+  stop_watcher_on_failure: false
+  stop_timeout: 5
+  applications:
+  - name: "cart"
+    url: "http://192.0.2.10:80/health"
+  # (no probe)
+  # - name: "web"
+  #   url: "http://192.0.2.11:8080/"
+  # (unreachable)
+  # - name: "payment"
+  #   url: "https://192.0.2.12:443/ready"
+```
+
+If services were found but none qualified, the whole `health_checks` block is commented out, listing those services with the reason each was rejected. If no `LoadBalancer` service was found at all, a commented `$HOST` based example is left in its place as a starting point.
+
+Discovery only runs when the config is written fresh, either because the file does not exist yet or because you passed `--save-strategy overwrite`.
+
+#### Making Your Application Discoverable
+
+To have your application picked up automatically:
+
+1. Expose it with a service of `type: LoadBalancer`.
+2. Give the container an `httpGet` readiness probe pointing at a real health endpoint.
+3. Make sure the load balancer address is reachable from wherever you run `discover`.
+
+```yaml
+readinessProbe:
+  httpGet:
+    path: /healthz
+    port: 8080
+```
+
+The [nginx demo](https://github.com/krkn-chaos/krkn-ai/tree/main/scripts/nginx) in the Krkn-AI repository is set up this way and can be used as a reference.
 
 ### Configure Health Check Score into Fitness Function
 

--- a/content/en/docs/krkn_ai/config/scenarios.md
+++ b/content/en/docs/krkn_ai/config/scenarios.md
@@ -25,7 +25,27 @@ The following Krkn scenarios are currently supported by Krkn-AI.
 | [Storage Throttle](../../scenarios/storage-throttle/)       	| *scenario.storage-throttle*      	|
 
 
-By default, scenarios are not enabled. Depending on your use case, you can enable or disable these scenarios in the `krkn-ai.yaml` config file by setting the `enable` field to `true` or `false`.
+When you generate a config with [discover](../discover.md), Krkn-AI enables the scenarios your cluster can run and disables the rest. Each scenario needs certain components to be present:
+
+| **Scenario**        | **Requires**                               |
+|---------------------|--------------------------------------------|
+| Pod Scenario        | A running pod with at least one label      |
+| Application Outages | A running pod with at least one label      |
+| Container Scenario  | A running pod with at least one label      |
+| Node CPU Hog        | A schedulable, ready node                  |
+| Node Memory Hog     | A schedulable, ready node                  |
+| Node IO Hog         | A schedulable, ready node                  |
+| Time Scenario       | A namespace containing pods, and labels on pods or nodes |
+| Network Scenarios   | A node with a discovered network interface |
+| DNS Outage          | A running pod                              |
+| Syn Flood           | A service that exposes ports               |
+| PVC Scenario        | A PVC, or a pod in a discovered namespace  |
+| KubeVirt VM Outage  | A KubeVirt virtual machine instance        |
+| Storage Throttle    | A PVC, or a pod in a discovered namespace  |
+
+If nothing can be built, every scenario is disabled and Krkn-AI logs a warning. That usually means the filters were too narrow, so widen `-n` and run `discover` again.
+
+You can always override this. Depending on your use case, enable or disable these scenarios in the `krkn-ai.yaml` config file by setting the `enable` field to `true` or `false`.
 
 ```yaml
 scenario:

--- a/content/en/docs/krkn_ai/discover.md
+++ b/content/en/docs/krkn_ai/discover.md
@@ -26,11 +26,16 @@ Options:
   -v, --verbose           Increase verbosity of output.
   --skip-pod-name TEXT    Pod name to skip. Supports comma separated values
                           with regex.
-  --save-strategy [skip|overwrite|merge]
+  -S, --save-strategy [skip|overwrite|merge]
                           How to save: skip, overwrite (replace), or merge
-                          (add new).
+                          (add new components, keep your edits). Note: merge
+                          does not preserve comments.
+  --learned-weights TEXT  Path to a learned_weights.json from a previous run,
+                          to prioritize fitness queries.
   --help                  Show this message and exit.
 ```
+
+Alongside `cluster_components`, `discover` also fills in the [scenarios](./config/scenarios.md) your cluster can run, [health check URLs](./config/health_check.md) built from LoadBalancer services, and [fitness queries](./config/fitness_function.md) validated against your Prometheus.
 
 ### Example
 
@@ -70,24 +75,42 @@ output:
   graph_name_fmt: "scenario_%s.png"
   log_name_fmt: "scenario_%s.log"
 
-# Fitness function configuration for defining SLO
-# In the below example, we use Total Restarts in "robot-shop" namespace as the SLO
-fitness_function: 
-  query: 'sum(kube_pod_container_status_restarts_total{namespace="robot-shop"})'
-  type: point
+# Fitness queries recommended from the cluster's Prometheus
+fitness_function:
   include_krkn_failure: true
+  include_health_check_failure: true
+  include_health_check_response_time: true
+  items:
+  # pod-restarts:robot-shop
+  - query: '(sum(increase(kube_pod_container_status_restarts_total{namespace="robot-shop"}[$range$]))) or vector(0)'
+    type: range
+    weight: 0.5
+  # node-pressure
+  - query: '(sum(kube_node_status_condition{condition=~"MemoryPressure|DiskPressure|PIDPressure", status="true"})) or vector(0)'
+    type: range
+    weight: 0.5
 
-# Chaos scenarios to consider during testing
+# Application endpoints discovered from LoadBalancer services
+health_checks:
+  stop_watcher_on_failure: false
+  stop_timeout: 5
+  applications:
+  - name: "cart"
+    url: "http://192.0.2.10:80/health"
+
+# Chaos scenarios your cluster can run, decided during discovery
 scenario:
   pod-scenarios:
     enable: true
   application-outages:
     enable: true
   container-scenarios:
-    enable: false
+    enable: true
   node-cpu-hog:
-    enable: false
+    enable: true
   node-memory-hog:
+    enable: true
+  kubevirt-scenarios:
     enable: false
 
 # Cluster components to consider for Krkn-AI testing
@@ -167,3 +190,11 @@ uv run krkn_ai discover -k ./tmp/kubeconfig.yaml -o ./krkn-ai.yaml --save-strate
 `merge` preserves manual edits (e.g. `disabled: true`) and adds newly discovered components.
 
 > **Note:** Comments inside `cluster_components` are not preserved after a merge.
+
+The save strategy also decides how much of the config is regenerated. Scenario enablement and health checks are only worked out when the file is written fresh, either because it does not exist yet or because you passed `overwrite`. Fitness queries are also refreshed on `merge`.
+
+| Strategy | Cluster components | Scenarios and health checks | Fitness queries |
+|---|---|---|---|
+| `skip` (file exists) | unchanged | unchanged | unchanged |
+| `overwrite` | replaced | regenerated | regenerated |
+| `merge` | added to | unchanged | new ones added |


### PR DESCRIPTION
### Documentation Update
**Related Feature:** Dynamic `discover` in krkn-ai — krkn-chaos/krkn-ai#381, #396, #406, #456 (all merged)

**Changes:**
- New `dynamic/` section: how `discover` maps LoadBalancer services to health check URLs, and how it recommends fitness queries from the metrics catalog (including how to add one).
- Refreshed `discover.md`, `config/scenarios.md`, `config/health_check.md` and `config/fitness_function.md`, which still described the old hand written config.


