### PR TITLE
fix vsphere-username description on node-scenarios and power-outages

### DIFF
--- a/content/en/docs/scenarios/node-scenarios/_tab-krknctl.md
+++ b/content/en/docs/scenarios/node-scenarios/_tab-krknctl.md
@@ -20,7 +20,7 @@ Scenario specific parameters:  (be sure to scroll to right)
 `--timeout` | Duration to wait for completion of node scenario injection | number | No | 180| 
 `--duration` | Duration to wait for completion of node scenario injection | number | No | 120 | 
 `--vsphere-ip` | vSphere IP address | string | No | 
-`--vsphere-username` | vSphere IP address | string (secret)| No | 
+`--vsphere-username` | vSphere username | string (secret)| No | 
 `--vsphere-password` | vSphere password | string (secret)| No | 
 `--aws-access-key-id` | AWS Access Key Id | string (secret)| No | 
 `--aws-secret-access-key` | AWS Secret Access Key | string (secret)| No | 

--- a/content/en/docs/scenarios/power-outages/_tab-krknctl.md
+++ b/content/en/docs/scenarios/power-outages/_tab-krknctl.md
@@ -13,7 +13,7 @@ Scenario specific parameters:
 `--timeout` | Time in seconds to wait for each node to be stopped or running after the cluster comes back | number | No | 180| 
 `--shutdown-duration` | Duration in seconds to shut down the cluster | number | No | 1200 | 
 `--vsphere-ip` | vSphere IP address | string | No | 
-`--vsphere-username` | vSphere IP address | string (secret)| No | 
+`--vsphere-username` | vSphere username | string (secret)| No | 
 `--vsphere-password` | vSphere password | string (secret)| No | 
 `--aws-access-key-id` | AWS Access Key Id | string (secret)| No | 
 `--aws-secret-access-key` | AWS Secret Access Key | string (secret)| No | 


### PR DESCRIPTION
## Documentation Update

**Related Feature:**

Fixes #589. Source side is krkn-chaos/krkn-hub#369, so both copies end up saying the same thing.

**Changes:**

`--vsphere-username` said it takes an IP address. Now reads `vSphere username`, on node-scenarios and power-outages.
Two lines, one per page.

Full `hugo --minify` build is clean, 291 pages, 0 errors.
