### PR TITLE
add generate-html-report parameter documentation

### DIFF
--- a/content/en/docs/krkn/config.md
+++ b/content/en/docs/krkn/config.md
@@ -46,6 +46,9 @@ Refer to [signal.md](signal.md) for more details
 
 **generate_pdf_report**: Generates a PDF summary report after the run if set to True
 
+**generate_html_report**: Generates a HTML summary report after the run if set to True
+
+
 
 ### Auto Rollback
 
@@ -274,6 +277,7 @@ kraken:
     signal_address: 0.0.0.0                                # Signal listening address
     port: 8081                                             # Signal port
     generate_pdf_report: True                              # Generate a PDF summary report after the run
+    generate_html_report: True                             # Generate a HTML summary report after the run
     chaos_scenarios:
         # List of policies/chaos scenarios to load
         - hog_scenarios:

--- a/content/en/docs/scenarios/all-scenario-env-krknctl.md
+++ b/content/en/docs/scenarios/all-scenario-env-krknctl.md
@@ -62,6 +62,7 @@ General run settings. See [Kraken config](../krkn/config.md#kraken) for full det
 | `--uuid` | Sets krkn run uuid instead of generating it | string | - | - |
 | `--krkn-debug` | Enables debug mode for Krkn | enum | True/False | False |
 | `--generate-pdf-report` | When enabled, generates a PDF report summarizing the chaos run results at the end of each scenario | enum | True/False | False |
+| `--generate-html-report` | When enabled, generates an HTML report summarizing the chaos run results at the end of each scenario | enum | True/False | False |
 
 </div>
 

--- a/content/en/docs/scenarios/all-scenario-env.md
+++ b/content/en/docs/scenarios/all-scenario-env.md
@@ -26,6 +26,7 @@ Parameter | Description | Default
 `PORT` | Port to publish kraken status to | 8081
 `SIGNAL_STATE` | Waits for the RUN signal when set to PAUSE before running the scenarios, refer [docs](../krkn/signal.md) for more details | RUN
 `GENERATE_PDF_REPORT` | When enabled, generates a PDF report summarizing the chaos run results at the end of each scenario | False
+`GENERATE_HTML_REPORT` | When enabled, generates an HTML report summarizing the chaos run results at the end of each scenario | False
 
 ---
 


### PR DESCRIPTION
## Documentation Update
**Related Feature:** 

branch name: tejugang:single-run-resiliency-score
PR: https://github.com/krkn-chaos/krkn/pull/1555

**Changes:** 

Added generate_html_report parameter documentation across 3 files:

  1. content/en/docs/krkn/config.md — Added the generate_html_report field description and included it in the example YAML config block with generate_html_report: True
  2. content/en/docs/scenarios/all-scenario-env-krknctl.md — Added --generate-html-report to the Kraken section parameter table (enum, True/False, default False)
  3. content/en/docs/scenarios/all-scenario-env.md — Added GENERATE_HTML_REPORT environment variable to the Kraken section parameter table (default
  False)

 When enabled, this parameter generates an HTML summary report of the chaos run results at the end of each scenario — the same behavior as generate_pdf_report but outputting HTML instead of PDF.