### PR TITLE
redirect links to the blog post

### DIFF
--- a/assets/scss/_custom_docs.scss
+++ b/assets/scss/_custom_docs.scss
@@ -153,8 +153,6 @@
 }
 
 // Sidebar badges (e.g., beta, new, etc.)
-// Only show badge on main krkn-operator page, not sub-chapters
-.td-sidebar-nav a[href$="/krkn-operator/"],
 .td-sidebar-nav a[href$="/resiliency-score/"] {
   position: relative;
   display: inline-flex;

--- a/content/en/docs/krkn-operator/_index.md
+++ b/content/en/docs/krkn-operator/_index.md
@@ -5,7 +5,7 @@ weight: 8
 description: >
   A Kubernetes-native platform for orchestrating Chaos Engineering experiments through a web interface.
 ---
-<img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=b6153e03-2a9a-4d95-a2ce-89c05ede15f2" />
+<img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=b6153e03-2a9a-4d95-a2ce-89c05ede15f2" alt="" width="1" height="1" style="position:absolute; width:1px; height:1px; opacity:0; pointer-events:none;" />
 
 Krkn Operator is a Kubernetes-native platform to deploy, configure and orchestrate Chaos Engineering experiments through a web console. Instead of manually executing scenarios, the Operator provides a complete platform to manage users, clusters, permissions and experiment execution from a single place.
 

--- a/content/en/docs/krkn-operator/_index.md
+++ b/content/en/docs/krkn-operator/_index.md
@@ -5,6 +5,7 @@ weight: 8
 description: >
   A Kubernetes-native platform for orchestrating Chaos Engineering experiments through a web interface.
 ---
+<img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=b6153e03-2a9a-4d95-a2ce-89c05ede15f2" />
 
 Krkn Operator is a Kubernetes-native platform to deploy, configure and orchestrate Chaos Engineering experiments through a web console. Instead of manually executing scenarios, the Operator provides a complete platform to manage users, clusters, permissions and experiment execution from a single place.
 

--- a/content/en/docs/krkn-operator/compatibility/_index.md
+++ b/content/en/docs/krkn-operator/compatibility/_index.md
@@ -3,7 +3,7 @@ title: OCM/ACM Compatibility
 description: Supported platforms and ACM/OCM versions for Krkn Operator
 weight: 5
 ---
-<img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=718ce007-5ae3-4c7f-ae2c-571353cb6b86" />
+<img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=718ce007-5ae3-4c7f-ae2c-571353cb6b86" alt="" width="1" height="1" style="position:absolute; width:1px; height:1px; opacity:0; pointer-events:none;" />
 
 # OCM/ACM Compatibility
 

--- a/content/en/docs/krkn-operator/compatibility/_index.md
+++ b/content/en/docs/krkn-operator/compatibility/_index.md
@@ -3,6 +3,7 @@ title: OCM/ACM Compatibility
 description: Supported platforms and ACM/OCM versions for Krkn Operator
 weight: 5
 ---
+<img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=718ce007-5ae3-4c7f-ae2c-571353cb6b86" />
 
 # OCM/ACM Compatibility
 

--- a/content/en/docs/krkn-operator/installation/_index.md
+++ b/content/en/docs/krkn-operator/installation/_index.md
@@ -4,7 +4,7 @@ description: Install Krkn Operator using Helm
 weight: 1
 custom_js: ["/js/krkn-operator-version.js"]
 ---
-<img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=8544b80d-373c-4c02-b2f7-e25d80b51854" />
+<img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=8544b80d-373c-4c02-b2f7-e25d80b51854" alt="" width="1" height="1" style="position:absolute; width:1px; height:1px; opacity:0; pointer-events:none;" />
 
 # Installation <a href="/docs/krkn-operator/#permission-model"><span class="krkn-badge krkn-badge--admin">Admin</span></a>
 

--- a/content/en/docs/krkn-operator/installation/_index.md
+++ b/content/en/docs/krkn-operator/installation/_index.md
@@ -4,6 +4,7 @@ description: Install Krkn Operator using Helm
 weight: 1
 custom_js: ["/js/krkn-operator-version.js"]
 ---
+<img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=8544b80d-373c-4c02-b2f7-e25d80b51854" />
 
 # Installation <a href="/docs/krkn-operator/#permission-model"><span class="krkn-badge krkn-badge--admin">Admin</span></a>
 

--- a/data/roadmap.yaml
+++ b/data/roadmap.yaml
@@ -9,18 +9,18 @@ releases:
 
   - version: "v1.0.0"
     title: "OCM Cluster communication improvements"
-    date: "2026-08-09"
-    status: in-progress
+    date: "2026-08-17"
+    status: released
     tasks:
       - "Scenario Save/Replay"
       - "[Cluster Proxy](https://open-cluster-management.io/docs/getting-started/integration/cluster-proxy/) Support"
       - "Per node resiliency score"
       - "Save/Edit/Delete Workflow Templates"
 
-  - version: "v1.0.1"
+  - version: "v1.1.0"
     title: "Scenario Rollback"
-    date: "2026-09-09"
-    status: planned
+    date: "2026-09-17"
+    status: in-progress
     tasks:
       - "Scenario Rollback"
       - "Cluster liveness check"

--- a/netlify.toml
+++ b/netlify.toml
@@ -109,3 +109,10 @@ node_bundler = "esbuild"
   to = "https://krkn-chaos.gateway.scarf.sh/krkn-operator/launch?source=phoronix&campaign=1.0"
   status = 302
   force = true
+
+# catch trailing-slash variants of all /go/1.0/* short links
+[[redirects]]
+  from = "/go/1.0/*/"
+  to = "/go/1.0/:splat"
+  status = 302
+  force = true

--- a/netlify.toml
+++ b/netlify.toml
@@ -67,3 +67,33 @@ node_bundler = "esbuild"
   to = "https://krkn-chaos.gateway.scarf.sh/krkn-operator/launch?source=community&campaign=1.0"
   status = 302
   force = true
+
+[[redirects]]
+  from = "/go/1.0/cncf-slack"
+  to = "https://krkn-chaos.gateway.scarf.sh/krkn-operator/launch?source=cncf-slack&campaign=1.0"
+  status = 302
+  force = true
+
+[[redirects]]
+  from = "/go/1.0/cncf-slack-ocm"
+  to = "https://krkn-chaos.gateway.scarf.sh/krkn-operator/launch?source=cncf-slack-ocm&campaign=1.0"
+  status = 302
+  force = true
+
+[[redirects]]
+  from = "/go/1.0/devto"
+  to = "https://krkn-chaos.gateway.scarf.sh/krkn-operator/launch?source=devto&campaign=1.0"
+  status = 302
+  force = true
+
+[[redirects]]
+  from = "/go/1.0/x"
+  to = "https://krkn-chaos.gateway.scarf.sh/krkn-operator/launch?source=x&campaign=1.0"
+  status = 302
+  force = true
+
+[[redirects]]
+  from = "/go/1.0/facebook"
+  to = "https://krkn-chaos.gateway.scarf.sh/krkn-operator/launch?source=facebook&campaign=1.0"
+  status = 302
+  force = true

--- a/netlify.toml
+++ b/netlify.toml
@@ -97,3 +97,9 @@ node_bundler = "esbuild"
   to = "https://krkn-chaos.gateway.scarf.sh/krkn-operator/launch?source=facebook&campaign=1.0"
   status = 302
   force = true
+
+[[redirects]]
+  from = "/go/1.0/slashdot"
+  to = "https://krkn-chaos.gateway.scarf.sh/krkn-operator/launch?source=slashdot&campaign=1.0"
+  status = 302
+  force = true

--- a/netlify.toml
+++ b/netlify.toml
@@ -103,3 +103,9 @@ node_bundler = "esbuild"
   to = "https://krkn-chaos.gateway.scarf.sh/krkn-operator/launch?source=slashdot&campaign=1.0"
   status = 302
   force = true
+
+[[redirects]]
+  from = "/go/1.0/phoronix"
+  to = "https://krkn-chaos.gateway.scarf.sh/krkn-operator/launch?source=phoronix&campaign=1.0"
+  status = 302
+  force = true

--- a/netlify.toml
+++ b/netlify.toml
@@ -35,3 +35,35 @@ node_bundler = "esbuild"
 
 # Environment variables - set these in Netlify dashboard:
 # LLM_API_KEY, LLM_PROVIDER, LLM_MODEL, DAILY_CHAT_LIMIT
+
+# krkn-operator 1.0 launch TO BE REMOVED AFTER THE LAUNCH
+
+[[redirects]]
+  from = "/go/1.0/hackernews"
+  to = "https://krkn-chaos.gateway.scarf.sh/krkn-operator/launch?source=hackernews&campaign=1.0"
+  status = 302
+  force = true
+
+[[redirects]]
+  from = "/go/1.0/linkedin"
+  to = "https://krkn-chaos.gateway.scarf.sh/krkn-operator/launch?source=linkedin&campaign=1.0"
+  status = 302
+  force = true
+
+[[redirects]]
+  from = "/go/1.0/dailydev"
+  to = "https://krkn-chaos.gateway.scarf.sh/krkn-operator/launch?source=dailydev&campaign=1.0"
+  status = 302
+  force = true
+
+[[redirects]]
+  from = "/go/1.0/reddit"
+  to = "https://krkn-chaos.gateway.scarf.sh/krkn-operator/launch?source=reddit&campaign=1.0"
+  status = 302
+  force = true
+
+[[redirects]]
+  from = "/go/1.0/community"
+  to = "https://krkn-chaos.gateway.scarf.sh/krkn-operator/launch?source=community&campaign=1.0"
+  status = 302
+  force = true


### PR DESCRIPTION
## Documentation Update
**Related Feature:** 


This PR introduces Netlify redirects to provide clean, project-owned short links for the Krkn Operator 1.0 launch campaign.

The redirects act as a lightweight routing layer between public campaign links and our Scarf tracking endpoints:

`krkn-chaos.dev → Netlify redirect → Scarf → target`

This approach allows us to:

* Keep public campaign URLs short, readable, and under the `krkn-chaos.dev` domain.
* Use Scarf to track traffic sources and campaign attribution without exposing tracking URLs directly.
* Route different channels (Hacker News, LinkedIn, daily.dev, Reddit, community channels, etc.) independently.
* Change final destinations without changing already published campaign URLs.
* Keep tracking and routing logic separate from the website content and documentation.

No application logic or additional infrastructure is introduced: redirects are handled directly by Netlify.


**Changes:** 

Describe the documentation updates made for the feature.
