### PR TITLE
Replace Kraken dashboard to Operator in the Docs landing page

### DIFF
--- a/content/en/docs/_index.md
+++ b/content/en/docs/_index.md
@@ -345,7 +345,7 @@ type: "docs/scenarios"
           <div class="feature-card__icon">
             <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="7" height="9" x="3" y="3" rx="1"/><rect width="7" height="5" x="14" y="3" rx="1"/><rect width="7" height="9" x="14" y="12" rx="1"/><rect width="7" height="5" x="3" y="16" rx="1"/></svg>
           </div>
-          <h3 class="feature-card__title">Kraken Operator</h3>
+          <h3 class="feature-card__title">Krkn Operator</h3>
           <p class="feature-card__desc">A Kubernetes operator that simplifies running Krkn chaos scenarios.</p>
         </a>
         <a href="/docs/cerberus/" class="feature-card">

--- a/content/en/docs/_index.md
+++ b/content/en/docs/_index.md
@@ -341,12 +341,12 @@ type: "docs/scenarios"
           <h3 class="feature-card__title">krknctl</h3>
           <p class="feature-card__desc">CLI tool to run and orchestrate chaos scenarios.</p>
         </a>
-        <a href="/docs/krkn_dashboard/" class="feature-card">
+        <a href="/docs/krkn-operator/" class="feature-card">
           <div class="feature-card__icon">
             <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="7" height="9" x="3" y="3" rx="1"/><rect width="7" height="5" x="14" y="3" rx="1"/><rect width="7" height="9" x="14" y="12" rx="1"/><rect width="7" height="5" x="3" y="16" rx="1"/></svg>
           </div>
-          <h3 class="feature-card__title">Kraken Dashboard</h3>
-          <p class="feature-card__desc">Web UI to run and observe chaos scenarios.</p>
+          <h3 class="feature-card__title">Kraken Operator</h3>
+          <p class="feature-card__desc">A Kubernetes operator that simplifies running Krkn chaos scenarios.</p>
         </a>
         <a href="/docs/cerberus/" class="feature-card">
           <div class="feature-card__icon">


### PR DESCRIPTION
## Documentation Update
**Related Feature:** 

Branch name: krkn-chaos/website:main

**Changes:** 

- Renamed "Kraken Dashboard" to "Kraken Operator" in the Explore section of the docs landing page
- Updated the link from /docs/krkn_dashboard/ to /docs/krkn-operator/
- Updated the description from "Web UI to run and observe chaos scenarios" to "A Kubernetes operator that simplifies running Krkn chaos scenarios"

