### PR TITLE
fix delete permission naming in operator docs

### DIFF
--- a/assets/scss/_custom_docs.scss
+++ b/assets/scss/_custom_docs.scss
@@ -1955,7 +1955,7 @@ table tbody tr:hover {
   &--admin { background: var(--krkn-primary); color: var(--krkn-text-on-color); }
   &--view { background: var(--krkn-secondary); color: var(--krkn-text-on-color); }
   &--run { background: var(--krkn-success); color: var(--krkn-text-on-color); }
-  &--delete { background: var(--krkn-danger); color: var(--krkn-text-on-color); }
+  &--cancel { background: var(--krkn-danger); color: var(--krkn-text-on-color); }
 
   a & {
     text-decoration: none;

--- a/content/en/docs/krkn-operator/_index.md
+++ b/content/en/docs/krkn-operator/_index.md
@@ -44,7 +44,7 @@ Full access to the platform. Administrators configure the infrastructure that us
 
 Operational access scoped by group membership. Every user must belong to a group — the group determines which clusters, registries and features are accessible.
 
-- View and manage **jobs** (based on View/Delete permissions)
+- View and manage **jobs** (based on View/Cancel permissions)
 - Use the **cluster terminal** (requires Run permission)
 - **Run scenarios** on assigned clusters (requires Run permission)
 - Design workflows in **Chaos Studio** (requires Run permission)
@@ -70,7 +70,7 @@ Users only see jobs from their own group. A cluster-wide indicator shows the nam
   Clusters     Clusters
   Permissions  Permissions
   (View,Run,   (View)
-   Delete)
+   Cancel)
     │             │
   Users        Users
 ```
@@ -81,7 +81,7 @@ Permissions are assigned at the group level and determine what users can do on c
 
 <span class="krkn-badge krkn-badge--view">View</span>
 
-Allows users to see jobs and their execution results. Users with this permission can inspect single run outcomes, console logs, graph run nodes, and Resiliency Scores — but cannot execute or delete anything.
+Allows users to see jobs and their execution results. Users with this permission can inspect single run outcomes, console logs, graph run nodes, and Resiliency Scores — but cannot execute, cancel or remove anything.
 
 **Applies to:** [Jobs](/docs/krkn-operator/usage/jobs/)
 
@@ -93,11 +93,11 @@ Allows users to execute chaos experiments on the clusters assigned to their grou
 
 **Applies to:** [Run Scenarios](/docs/krkn-operator/usage/run-scenarios/) · [Chaos Studio](/docs/krkn-operator/usage/chaos-studio/) · [Cluster Terminal](/docs/krkn-operator/usage/cluster-terminal/)
 
-### Delete {#permission-delete}
+### Cancel {#permission-cancel}
 
-<span class="krkn-badge krkn-badge--delete">Delete</span>
+<span class="krkn-badge krkn-badge--cancel">Cancel</span>
 
-Allows users to remove completed jobs and their execution history. Without this permission, jobs remain visible but cannot be deleted.
+Allows users to cancel running scenarios and to remove scenario runs and their execution history. Without this permission, jobs remain visible but cannot be cancelled or removed.
 
 **Applies to:** [Jobs](/docs/krkn-operator/usage/jobs/)
 

--- a/content/en/docs/krkn-operator/administration/_index.md
+++ b/content/en/docs/krkn-operator/administration/_index.md
@@ -15,7 +15,7 @@ Administrators configure the platform infrastructure that users operate on. This
 The Admin creates **groups** that define what users can do on the platform. Each group specifies:
 
 - Which **clusters** are accessible
-- Which **permissions** are granted (View, Run, Delete)
+- Which **permissions** are granted (View, Run, Cancel)
 - Which **registries** are visible
 
 Users inherit all permissions from their assigned group.
@@ -24,7 +24,7 @@ Users inherit all permissions from their assigned group.
 Admin creates Group
       │
       ├── Assigns Clusters (target-1, target-2, ...)
-      ├── Assigns Permissions (View, Run, Delete)
+      ├── Assigns Permissions (View, Run, Cancel)
       └── Assigns Registry Visibility
             │
             └── Users in this group inherit everything

--- a/content/en/docs/krkn-operator/administration/user-management.md
+++ b/content/en/docs/krkn-operator/administration/user-management.md
@@ -30,7 +30,7 @@ Groups also receive permission flags that control what operations their members 
 |------------|---------------|
 | **View** | View jobs and execution results |
 | **Run** | Execute scenarios, use Chaos Studio, access cluster terminal |
-| **Delete** | Remove jobs and execution history |
+| **Cancel** | Cancel running jobs, and remove jobs and execution history |
 
 ---
 

--- a/content/en/docs/krkn-operator/usage/_index.md
+++ b/content/en/docs/krkn-operator/usage/_index.md
@@ -15,7 +15,7 @@ The operational features of Krkn Operator are available to all users, scoped by 
 | Feature | Required Permission |
 |---------|-------------------|
 | View Jobs | <a href="/docs/krkn-operator/#permission-view"><span class="krkn-badge krkn-badge--view">View</span></a> |
-| Delete Jobs | <a href="/docs/krkn-operator/#permission-delete"><span class="krkn-badge krkn-badge--delete">Delete</span></a> |
+| Cancel Jobs | <a href="/docs/krkn-operator/#permission-cancel"><span class="krkn-badge krkn-badge--cancel">Cancel</span></a> |
 | Cluster Terminal | <a href="/docs/krkn-operator/#permission-run"><span class="krkn-badge krkn-badge--run">Run</span></a> |
 | Run Scenarios | <a href="/docs/krkn-operator/#permission-run"><span class="krkn-badge krkn-badge--run">Run</span></a> |
 | Chaos Studio | <a href="/docs/krkn-operator/#permission-run"><span class="krkn-badge krkn-badge--run">Run</span></a> |

--- a/content/en/docs/krkn-operator/usage/jobs.md
+++ b/content/en/docs/krkn-operator/usage/jobs.md
@@ -4,7 +4,7 @@ description: Monitor and inspect chaos experiment execution
 weight: 1
 ---
 
-# Jobs <a href="/docs/krkn-operator/#permission-view"><span class="krkn-badge krkn-badge--view">View</span></a> <a href="/docs/krkn-operator/#permission-delete"><span class="krkn-badge krkn-badge--delete">Delete</span></a>
+# Jobs <a href="/docs/krkn-operator/#permission-view"><span class="krkn-badge krkn-badge--view">View</span></a> <a href="/docs/krkn-operator/#permission-cancel"><span class="krkn-badge krkn-badge--cancel">Cancel</span></a>
 
 The Jobs list is the home screen of the platform. It displays all scenario executions for your group, with real-time status updates and access to logs and results.
 
@@ -39,7 +39,7 @@ Graph runs can include a **Resiliency Score** — a calculated metric based on P
 
 - Only jobs from **your own group** are displayed
 - A cluster-wide tip shows the **names** of scenarios currently running across all groups (no details)
-- Deleting jobs requires <a href="/docs/krkn-operator/#permission-delete"><span class="krkn-badge krkn-badge--delete">Delete</span></a> permission
+- Cancelling or removing jobs requires <a href="/docs/krkn-operator/#permission-cancel"><span class="krkn-badge krkn-badge--cancel">Cancel</span></a> permission
 
 ![Jobs Dashboard](/images/krkn-operator/main-screen.png)
 


### PR DESCRIPTION
Fixes #595
The docs document a **Delete** permission that does not exist.

`pkg/groupauth/types.go` defines `view`, `run` and `cancel`, and the CRD enforces the same set, so a `KrknUserGroup` written from these pages is rejected by the API server.

This PR basically renames it to **Cancel** across the five content files and the badge style, and rewrites the section body to describe both things the permission grants: cancelling a running job, and removing a scenario run with its history.
- `#permission-delete` becomes `#permission-cancel`. 
- All inbound links are inside the operator docs and are updated here, checked against the rendered output. 

`hugo --minify` is clean, 291 pages and 32 aliases.
Please refer to #595 for the full reasoning.

