### PR TITLE
added repo redirect for hackernews

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -110,9 +110,21 @@ node_bundler = "esbuild"
   status = 302
   force = true
 
+[[redirects]]
+  from = "/repo/hn"
+  to = "https://krkn-chaos.gateway.scarf.sh/krkn-operator/repo?source=hackernews"
+  status = 302
+  force = true
+
 # catch trailing-slash variants of all /go/1.0/* short links
 [[redirects]]
   from = "/go/1.0/*/"
   to = "/go/1.0/:splat"
+  status = 302
+  force = true
+
+[[redirects]]
+  from = "/repo/*/"
+  to = "/repo/:splat"
   status = 302
   force = true


### PR DESCRIPTION
## Documentation Update
**Related Feature:** 

Adds a new Hacker News specific route for repo redirect 

**Changes:** 

Describe the documentation updates made for the feature.
