### PR TITLE
fix duplicate krkn-hub-scenario ids, and add guards for them in CI

### DIFF
--- a/.github/workflows/scenario-markers.yml
+++ b/.github/workflows/scenario-markers.yml
@@ -1,0 +1,39 @@
+name: Scenario Markers
+
+on:
+  pull_request:
+    paths:
+      - 'content/en/docs/scenarios/**'
+      - 'scripts/check-scenario-markers.py'
+      - '.github/workflows/scenario-markers.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'content/en/docs/scenarios/**'
+      - 'scripts/check-scenario-markers.py'
+      - '.github/workflows/scenario-markers.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: scenario-markers-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check-markers:
+    name: krkn-hub-scenario markers
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Check scenario markers
+        run: python scripts/check-scenario-markers.py

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ api/server.log
 screenshots/
 scripts/*
 !scripts/check-links.js
+!scripts/check-scenario-markers.py
 .beads
 
 # Local Netlify folder

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -228,6 +228,32 @@ weight: 3
 ---
 ```
 
+**`_index.md` must declare its krkn-hub scenario.** Place the marker under the front matter,
+wrapping the page's descriptive content:
+
+```html
+<krkn-hub-scenario id="<scenario-slug>">
+
+Description of what the scenario does.
+
+</krkn-hub-scenario>
+```
+
+The `id` is the krkn-hub directory name. It is how
+[krkn-doc-sync-bot](https://github.com/krkn-chaos/docsync-bot) decides which page a scenario's
+parameter tables belong on, and CI fails the PR if two pages claim the same id.
+
+If the page has no krkn-hub scenario of its own, for example because it runs another page's
+image with different parameters, replace the marker with an opt-out that gives the reason:
+
+```html
+<!-- krkn-hub-scenario: none. <why this page has none, and which page owns the id> -->
+```
+
+The reason is required; a bare `none` is rejected. See the "Scenario Page Markers" section in
+`CONTRIBUTING.md` for the full rules and worked examples. Verify with
+`python scripts/check-scenario-markers.py`.
+
 **`_index.md` must include the tabpane block** for the "How to Run" section:
 
 ```
@@ -322,6 +348,8 @@ Shareable tab URLs follow this format:
 
 - [ ] Created `content/en/docs/scenarios/<slug>/_index.md` with front matter and tabpane
 - [ ] Created `_tab-krkn.md`, `_tab-krkn-hub.md`, `_tab-krknctl.md` (no front matter)
+- [ ] Added `<krkn-hub-scenario id="<slug>">` to `_index.md`, or an opt-out comment saying why the page has none
+- [ ] Ran `python scripts/check-scenario-markers.py` and it passed
 - [ ] Added scenario card to `content/en/docs/scenarios/_index.md` in the right category
 - [ ] Added scenario link to `layouts/index.html` in the right homepage category
 - [ ] Updated scenario counts in homepage and docs landing if threshold crossed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,3 +112,70 @@ git checkout -b krkn/<your-feature-or-fix>
 2. Open a Pull Request against `krkn-chaos/website:main`
 3. Fill in the PR template with a clear description of your changes
 4. Ensure all CI checks pass before requesting a review
+
+---
+
+## Scenario Page Markers
+
+Every scenario page under `content/en/docs/scenarios/` declares which krkn-hub scenario it
+documents. The declaration is a marker in `_index.md`, placed under the front matter and
+wrapping the page's descriptive content:
+
+```html
+<krkn-hub-scenario id="node-scenarios">
+
+This scenario disrupts the node(s) matching the label or node name(s) on your cluster.
+
+</krkn-hub-scenario>
+```
+
+The `id` is the krkn-hub directory name for that scenario. The wrapper does not show up on the
+rendered page, and the prose inside it renders normally.
+
+This marker is how [krkn-doc-sync-bot](https://github.com/krkn-chaos/docsync-bot), the app that
+opens the `[docs-sync]` pull requests on this repo, finds which page documents which scenario.
+If it is missing or points at the wrong scenario, the generated parameter tables land on the
+wrong page.
+
+### One id, one page
+
+An id names a single krkn-hub scenario, so exactly one page may claim it. Two pages claiming
+the same id means the docs disagree about which page owns that scenario, and the bot has no
+way to pick.
+
+Some pages document a real scenario but run another page's image with different parameters.
+Those pages do not own the id, so they say so instead of claiming it. This is the opt-out on
+`aurora-disruption`:
+
+```html
+<!-- krkn-hub-scenario: none. This page runs the pod-network-filter image with
+     parameters tuned for AWS Aurora. The id belongs to
+     /docs/scenarios/network-chaos-ng-scenarios/pod-network-filter/ which documents the
+     image itself. Adding a marker here would make the id ambiguous and fail CI. -->
+```
+
+The reason is required. A bare `<!-- krkn-hub-scenario: none -->` is rejected, because an
+unexplained absence is exactly the ambiguity this is meant to prevent. A reader should never
+have to guess whether a marker was left out on purpose or simply forgotten.
+
+To find the current opt-outs and read why each one is there, grep for them:
+
+```bash
+grep -rl "krkn-hub-scenario: none" content/en/docs/scenarios/
+```
+
+### Check before you push
+
+```bash
+python scripts/check-scenario-markers.py
+```
+
+Standard library only, no dependencies. It enforces three rules:
+
+1. One page per id.
+2. One marker per page. Only the first is ever read, so a second one is dead.
+3. A page with no marker carries an opt-out that gives a reason.
+
+A page counts as a scenario page when its directory holds `_tab-*.md` files, so section
+landing pages are skipped. The same check runs in CI on any pull request touching
+`content/en/docs/scenarios/`.

--- a/content/en/docs/scenarios/aurora-disruption/_index.md
+++ b/content/en/docs/scenarios/aurora-disruption/_index.md
@@ -5,11 +5,13 @@ date: 2017-01-04
 weight: 3
 ---
 
-<krkn-hub-scenario id="pod-network-filter">
+<!-- krkn-hub-scenario: none. This page runs the pod-network-filter image with
+     parameters tuned for AWS Aurora. The id belongs to
+     /docs/scenarios/network-chaos-ng-scenarios/pod-network-filter/ which documents the
+     image itself. Adding a marker here would make the id ambiguous and fail CI. -->
 
 This scenario blocks a pod's outgoing MySQL and PostgreSQL traffic, effectively preventing it from connecting to any AWS Aurora SQL engine. It works just as well for standard MySQL and PostgreSQL connections too.
 
-</krkn-hub-scenario>
 
 This uses the pod network filter scenario but set with specific parameters to disrupt aurora
 

--- a/content/en/docs/scenarios/dns-outage/_index.md
+++ b/content/en/docs/scenarios/dns-outage/_index.md
@@ -5,11 +5,13 @@ date: 2017-01-04
 weight: 3
 ---
 
-<krkn-hub-scenario id="pod-network-filter">
+<!-- krkn-hub-scenario: none. This page runs the pod-network-filter image with
+     parameters tuned for DNS traffic. The id belongs to
+     /docs/scenarios/network-chaos-ng-scenarios/pod-network-filter/ which documents the
+     image itself. Adding a marker here would make the id ambiguous and fail CI. -->
 
 This scenario blocks all outgoing DNS traffic from a specific pod, effectively preventing it from resolving any hostnames or service names.
 
-</krkn-hub-scenario>
 
 ## How to Run DNS Outage Scenarios
 

--- a/content/en/docs/scenarios/efs-disruption/_index.md
+++ b/content/en/docs/scenarios/efs-disruption/_index.md
@@ -5,11 +5,13 @@ date: 2017-01-04
 weight: 3
 ---
 
-<krkn-hub-scenario id="node-network-filter">
+<!-- krkn-hub-scenario: none. This page runs the node-network-filter image with
+     parameters tuned for AWS EFS. The id belongs to
+     /docs/scenarios/network-chaos-ng-scenarios/node-network-filter/ which documents the
+     image itself. Adding a marker here would make the id ambiguous and fail CI. -->
 
 This scenario creates an outgoing firewall rule on specific nodes in your cluster, chosen by node name or a selector. This rule blocks connections to AWS EFS, leading to a temporary failure of any EFS volumes mounted on those affected nodes.
 
-</krkn-hub-scenario>
 
 ## How to Run EFS Disruption Scenarios
 

--- a/content/en/docs/scenarios/etcd-split-brain/_index.md
+++ b/content/en/docs/scenarios/etcd-split-brain/_index.md
@@ -5,11 +5,13 @@ date: 2017-01-04
 weight: 3
 ---
 
-<krkn-hub-scenario id="node-network-filter">
+<!-- krkn-hub-scenario: none. This page runs the node-network-filter image with
+     parameters tuned for etcd isolation. The id belongs to
+     /docs/scenarios/network-chaos-ng-scenarios/node-network-filter/ which documents the
+     image itself. Adding a marker here would make the id ambiguous and fail CI. -->
 
 This scenario isolates an etcd node by blocking its network traffic. This action forces an etcd leader re-election. Once the scenario concludes, the cluster should temporarily exhibit a split-brain condition, with two etcd leaders active simultaneously. This is particularly useful for testing the etcd cluster's resilience under such a challenging state.
 
-</krkn-hub-scenario>
 
 {{< notice type="danger" >}} This scenario carries a significant risk: it **might break the cluster API**, making it impossible to automatically revert the applied network rules. The `iptables` rules will be printed to the console, allowing for manual reversal via a shell on the affected node. This scenario is **best suited for disposable clusters** and should be **used at your own risk**. {{< /notice >}}
 

--- a/content/en/docs/scenarios/network-chaos-ng-scenarios/pod-network-chaos/_index.md
+++ b/content/en/docs/scenarios/network-chaos-ng-scenarios/pod-network-chaos/_index.md
@@ -5,11 +5,14 @@ date: 2017-01-04
 weight: 2
 ---
 
-<krkn-hub-scenario id="pod-network-chaos">
+<!-- krkn-hub-scenario: none. This page documents the network_chaos_ng module, which
+     has no krkn-hub image of its own. krkn-hub's pod-network-chaos image wraps the
+     legacy scenarios/pod_network_scenario.yaml, so the id belongs to
+     /docs/scenarios/pod-network-scenario/. Adding a marker here would make the id
+     ambiguous and fail CI. -->
 
 Injects network degradation (latency, packet loss, bandwidth restriction) into a target pod's network interfaces using Linux `tc` (traffic control) rules. Unlike pod-network-filter which blocks specific ports via iptables, this module shapes traffic at the interface level.
 
-</krkn-hub-scenario>
 
 ## How to Run Pod Network Chaos Scenarios
 

--- a/scripts/check-scenario-markers.py
+++ b/scripts/check-scenario-markers.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Guard the <krkn-hub-scenario id> markers on scenario pages. Refs #566.
+
+Three rules: one page per id, one marker per page, and a page with no marker must
+say why. Only the first marker on a page is ever read, so a second one is dead.
+
+A page counts as a scenario page when its directory holds _tab-*.md files.
+Section landing pages have none and are skipped.
+
+Exit 0 ok, 1 on a violation.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent / "content/en/docs/scenarios"
+MARKER = re.compile(r'<krkn-hub-scenario\s+id="([^"]+)"')
+# The reason is required: a bare "none" is the silence this check exists to stop.
+# re.S because real opt-outs wrap over several lines.
+OPT_OUT = re.compile(r'<!--\s*krkn-hub-scenario:\s*none\b[.:\s]*(.*?)-->', re.S)
+
+
+def opted_out(text):
+    """True only for an opt-out that gives a reason."""
+    found = OPT_OUT.search(text)
+    return bool(found and found.group(1).strip())
+
+
+def scenario_pages():
+    """(page, directory) for every page that documents a runnable scenario."""
+    for index in sorted(ROOT.rglob("_index.md")):
+        if any(index.parent.glob("_tab-*.md")):
+            yield index, index.parent
+
+
+def main() -> int:
+    claims: dict[str, list[str]] = {}
+    missing: list[str] = []
+    extra: list[tuple[str, list[str]]] = []
+
+    for index, directory in scenario_pages():
+        rel = directory.relative_to(ROOT).as_posix()
+        text = index.read_text(encoding="utf-8", errors="replace")
+        ids = MARKER.findall(text)
+        if ids:
+            # Claim on the first, the only one anything reads.
+            claims.setdefault(ids[0], []).append(rel)
+            if len(ids) > 1:
+                extra.append((rel, ids))
+        elif not opted_out(text):
+            missing.append(rel)
+
+    problems = []
+
+    # 1. One page per id.
+    for scenario_id, pages in sorted(claims.items()):
+        if len(pages) > 1:
+            problems.append(
+                f'id "{scenario_id}" is claimed by {len(pages)} pages: '
+                + ", ".join(pages)
+            )
+
+    # 2. One marker per page.
+    for rel, ids in extra:
+        problems.append(
+            f"{rel} declares {len(ids)} markers ({', '.join(ids)}). A page "
+            f'documents one scenario, and only "{ids[0]}" is ever read.'
+        )
+
+    # 3. Silence must be deliberate.
+    for rel in missing:
+        problems.append(
+            f"{rel} has no marker and no opt-out. Add the marker, or "
+            "<!-- krkn-hub-scenario: none. <reason> --> if the page has no "
+            "krkn-hub scenario of its own."
+        )
+
+    if problems:
+        print("Scenario marker check failed:\n", file=sys.stderr)
+        for p in problems:
+            print(f"  - {p}", file=sys.stderr)
+        print(
+            f"\n{len(problems)} problem(s). See "
+            "https://github.com/krkn-chaos/website/issues/566",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"Scenario markers ok: {len(claims)} ids across "
+          f"{sum(len(p) for p in claims.values())} pages, no duplicates.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Documentation Update

**Related Feature:** krkn-hub-scenario markers on scenario pages. Closes #566.

**Changes:**

Three ids are each claimed by more than one page today:

- `node-network-filter` on efs-disruption, etcd-split-brain, and [node-network-filter](https://krkn-chaos.dev/docs/scenarios/network-chaos-ng-scenarios/node-network-filter/), which should be the only one
- `pod-network-filter` on aurora-disruption, dns-outage, and [pod-network-filter](https://krkn-chaos.dev/docs/scenarios/network-chaos-ng-scenarios/pod-network-filter/), same
- `pod-network-chaos` on the NG pod-network-chaos page and [pod-network-scenario](https://krkn-chaos.dev/docs/scenarios/pod-network-scenario/)

An id names one krkn-hub scenario, so two pages claiming it means the docs disagree about which page documents that scenario. Actually I added those markers myself in #568, working from #545, and four of them name a scenario the page does not document.

And while clearing all the blockers I found that those five pages should never have carried one lose the marker and gain an explicit opt-out naming the page that does own the id, so absence is deliberate rather than possibly forgotten. 
That ambiguity is what caused #568 in the first place.

&ensp;

Two calls worth checking too, so that we are on the same page:-

- `pod-network-chaos` goes to pod-network-scenario because krkn-hub's image of that name wraps the legacy scenario:
  [`pod-network-chaos/env.sh#L15`](https://github.com/krkn-chaos/krkn-hub/blob/d9aa85ca76dfed82969170e380c0713478d55db8/pod-network-chaos/env.sh#L15) sets `SCENARIO_FILE=scenarios/pod_network_scenario.yaml`.
- `node-network-chaos` **keeps** its marker: 
In #566 I thought that neither NG page had a krkn-hub wrapper, but it has had its own image since then, [`node-network-chaos/env.sh#L24`](https://github.com/krkn-chaos/krkn-hub/blob/d9aa85ca76dfed82969170e380c0713478d55db8/node-network-chaos/env.sh#L24).

&ensp;

The new check does two things namely: 
- Tt fails if two pages claim the same id.
- It fails if a scenario page has neither a marker nor a comment saying why it has none. 

I've skipped section landing pages, since they have no tab files.

&ensp;

Also verified both ways, since a gate that passes on the broken tree is not a gate:

```
before  exit 1, naming all three duplicate ids
after   exit 0, "26 ids across 26 pages, no duplicates"
```

26 ids before and after, none were lost. 
Also did `hugo --minify` is clean on both, 291 pages and 32 aliases either way, and the prose that was inside the removed wrappers renders unchanged.


More Context:-
Clearing last upstream blocker for onboarding the [Dosc-Sync bot](https://github.com/krkn-chaos/website/issues/320)