### PR TITLE
html and pdf report summary parameter documentation, tejugang:html-format-for-scenario-runs

### DIFF
--- a/content/en/docs/krkn/config.md
+++ b/content/en/docs/krkn/config.md
@@ -44,7 +44,7 @@ Refer to [signal.md](signal.md) for more details
 
 **port**: port to listen/post the signal state to
 
-**generate_pdf_report**: Generates a PDF summary report after the run if set to True
+**report_formats**: List of report formats to generate after the run (e.g., `pdf`, `html`). Leave empty or omit to disable report generation.
 
 
 ### Auto Rollback
@@ -273,7 +273,9 @@ kraken:
     signal_state: RUN                                      # Will wait for the RUN signal when set to PAUSE before running the scenarios, refer docs/signal.md for more details
     signal_address: 0.0.0.0                                # Signal listening address
     port: 8081                                             # Signal port
-    generate_pdf_report: True                              # Generate a PDF summary report after the run
+    report_formats:                                          # List of report formats to generate (pdf, html)
+        - pdf
+        - html
     chaos_scenarios:
         # List of policies/chaos scenarios to load
         - hog_scenarios:

--- a/content/en/docs/scenarios/all-scenario-env-krknctl.md
+++ b/content/en/docs/scenarios/all-scenario-env-krknctl.md
@@ -61,7 +61,7 @@ General run settings. See [Kraken config](../krkn/config.md#kraken) for full det
 | `--krkn-kubeconfig` | Sets the path where krkn will search for kubeconfig in container | string | - | /home/krkn/.kube/config |
 | `--uuid` | Sets krkn run uuid instead of generating it | string | - | - |
 | `--krkn-debug` | Enables debug mode for Krkn | enum | True/False | False |
-| `--generate-pdf-report` | When enabled, generates a PDF report summarizing the chaos run results at the end of each scenario | enum | True/False | False |
+| `--report-formats` | List of report formats to generate after each scenario (e.g., `pdf`, `html`) | list | pdf, html | pdf, html |
 
 </div>
 

--- a/content/en/docs/scenarios/all-scenario-env.md
+++ b/content/en/docs/scenarios/all-scenario-env.md
@@ -25,7 +25,7 @@ Parameter | Description | Default
 `SIGNAL_ADDRESS` | Address to publish kraken status to | 0.0.0.0
 `PORT` | Port to publish kraken status to | 8081
 `SIGNAL_STATE` | Waits for the RUN signal when set to PAUSE before running the scenarios, refer [docs](../krkn/signal.md) for more details | RUN
-`GENERATE_PDF_REPORT` | When enabled, generates a PDF report summarizing the chaos run results at the end of each scenario | False
+`REPORT_FORMATS` | List of report formats to generate after each scenario (e.g., `pdf`, `html`) | pdf, html
 
 ---
 


### PR DESCRIPTION
## Documentation Update
**Related Feature:** 


branch name: tejugang:html-format-for-scenario-runs
PR: https://github.com/krkn-chaos/krkn/pull/1555


**Summary**

  - Replace the boolean generate_pdf_report and generate_html_report parameters with a new report_formats list parameter across all documentation
  - The new format accepts a YAML list of report types (e.g., pdf, html), enabling scalable support for multiple output formats
  - Default behavior generates both pdf and html reports


**Changes:** 

content/en/docs/krkn/config.md
  - Updated parameter description from generate_pdf_report and generate_html_report(boolean) to report_formats (list)
  - Updated sample config YAML to use the new list syntax

  content/en/docs/scenarios/all-scenario-env-krknctl.md
  - Replaced --generate-pdf-report and --generate-html-report (enum True/False) with --report-formats (list: pdf, html)

  content/en/docs/scenarios/all-scenario-env.md
  - Replaced GENERATE_PDF_REPORT and GENERATE_HTML_REPORT (boolean) with REPORT_FORMATS (list: pdf, html)