### PR TITLE
Add missing Krkn Operator + ACM developer preview article to blog

### DIFF
--- a/assets/scss/_custom_pages.scss
+++ b/assets/scss/_custom_pages.scss
@@ -117,6 +117,14 @@
   }
 }
 
+// Featured grid has 4 cards — use 2 columns on desktop for an even 2x2
+// instead of inheriting the 3-column layout, which would leave 1 card alone.
+.krkn-blog__grid--featured {
+  @media (min-width: 1024px) {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
 // Blog card
 .krkn-blog__card {
   display: flex;

--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -87,6 +87,15 @@
       <h2 class="krkn-blog__section-title">Articles &amp; Blog Posts</h2>
       <div class="krkn-blog__grid">
 
+        <a href="https://developers.redhat.com/articles/2026/08/17/krkn-operator-developer-preview-red-hat-acm" target="_blank" rel="noopener"
+           class="krkn-blog__card"
+           data-category="announcement" data-type="article">
+          <span class="krkn-blog__card-badge">Announcement</span>
+          <h3 class="krkn-blog__card-title">Krkn Operator Developer Preview in Red Hat Advanced Cluster Management</h3>
+          <p class="krkn-blog__card-desc">Run Kubernetes-native chaos engineering at scale with the Krkn Operator developer preview, now integrated with Red Hat Advanced Cluster Management and OCM.</p>
+          <span class="krkn-blog__card-source">Red Hat Developers</span>
+        </a>
+
         <a href="https://www.openshift.com/blog/introduction-to-kraken-a-chaos-tool-for-openshift/kubernetes" target="_blank" rel="noopener"
            class="krkn-blog__card"
            data-category="introduction" data-type="article">

--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -52,6 +52,15 @@
       <h2 class="krkn-blog__section-title">Featured</h2>
       <div class="krkn-blog__grid krkn-blog__grid--featured">
 
+        <a href="https://developers.redhat.com/articles/2026/08/17/krkn-operator-developer-preview-red-hat-acm" target="_blank" rel="noopener"
+           class="krkn-blog__card krkn-blog__card--featured"
+           data-category="announcement" data-type="featured">
+          <span class="krkn-blog__card-badge">Announcement</span>
+          <h3 class="krkn-blog__card-title">Krkn Operator Developer Preview in Red Hat Advanced Cluster Management</h3>
+          <p class="krkn-blog__card-desc">Run Kubernetes-native chaos engineering at scale with the Krkn Operator developer preview, now integrated with Red Hat Advanced Cluster Management and OCM.</p>
+          <span class="krkn-blog__card-source">Red Hat Developers</span>
+        </a>
+
         <a href="https://www.redhat.com/en/blog/krknchaos-joining-cncf-sandbox" target="_blank" rel="noopener"
            class="krkn-blog__card krkn-blog__card--featured"
            data-category="announcement" data-type="featured">
@@ -93,6 +102,33 @@
           <span class="krkn-blog__card-badge">Announcement</span>
           <h3 class="krkn-blog__card-title">Krkn Operator Developer Preview in Red Hat Advanced Cluster Management</h3>
           <p class="krkn-blog__card-desc">Run Kubernetes-native chaos engineering at scale with the Krkn Operator developer preview, now integrated with Red Hat Advanced Cluster Management and OCM.</p>
+          <span class="krkn-blog__card-source">Red Hat Developers</span>
+        </a>
+
+        <a href="https://www.redhat.com/en/blog/krknchaos-joining-cncf-sandbox" target="_blank" rel="noopener"
+           class="krkn-blog__card"
+           data-category="announcement" data-type="article">
+          <span class="krkn-blog__card-badge">Announcement</span>
+          <h3 class="krkn-blog__card-title">Krkn Joins CNCF Sandbox</h3>
+          <p class="krkn-blog__card-desc">Krkn is now a Cloud Native Computing Foundation Sandbox project, marking a major milestone for the community.</p>
+          <span class="krkn-blog__card-source">Red Hat Blog</span>
+        </a>
+
+        <a href="https://www.redhat.com/en/blog/supercharging-chaos-testing-using-ai" target="_blank" rel="noopener"
+           class="krkn-blog__card"
+           data-category="ai" data-type="article">
+          <span class="krkn-blog__card-badge">AI</span>
+          <h3 class="krkn-blog__card-title">Supercharging Chaos Testing with AI</h3>
+          <p class="krkn-blog__card-desc">How AI integration in Krkn helps predict failures, analyze patterns, and recommend chaos scenarios.</p>
+          <span class="krkn-blog__card-source">Red Hat Blog</span>
+        </a>
+
+        <a href="https://developers.redhat.com/articles/2025/08/21/unleash-controlled-chaos-krknctl" target="_blank" rel="noopener"
+           class="krkn-blog__card"
+           data-category="cli" data-type="article">
+          <span class="krkn-blog__card-badge">CLI</span>
+          <h3 class="krkn-blog__card-title">Unleashing Controlled Chaos with krknctl</h3>
+          <p class="krkn-blog__card-desc">A deep dive into krknctl — the CLI tool for running and orchestrating chaos scenarios with ease.</p>
           <span class="krkn-blog__card-source">Red Hat Developers</span>
         </a>
 


### PR DESCRIPTION
The Red Hat Developers article on the Krkn Operator developer preview in Red Hat Advanced Cluster Management was never added to the hand-curated blog card list, so it didn't appear on the Blog page.

## Documentation Update
**Related Feature:** 

Please include the branch name where you have made changes or added new features/scenario that we need on the website (e.g., `krkn/new_scenario`) in the title of this PR.

**Changes:** 

Describe the documentation updates made for the feature.
