### PR TITLE
Expand param-table and crd-ref when building the search index

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "helmet": "^7.1.0",
     "marked": "^10.0.0",
     "natural": "^6.10.0",
-    "winston": "^3.11.0"
+    "winston": "^3.11.0",
+    "yaml": "^2.9.0"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.14",

--- a/scripts/build-search-index.js
+++ b/scripts/build-search-index.js
@@ -41,9 +41,14 @@ function expandShortcodes(markdown) {
             const data = readData('params', a.scenario || '', `${a.source || ''}.yaml`);
             let rows = (data && data.params) || [];
             if (a.group) rows = rows.filter(r => r.group === a.group);
-            return rows
-                .map(r => `${a.prefix || ''}${r.name} ${r.description || ''}`)
-                .join(' ');
+            return rows.map(r => [
+                // flag when present, the same identifier the shortcode renders
+                `${a.prefix || ''}${r.flag || r.name}`,
+                r.description, r.type,
+                r.secret === undefined ? '' : 'secret',
+                r.default === undefined ? '' : String(r.default),
+                ...(r.possible_values || []),
+            ].filter(Boolean).join(' ')).join(' ');
         })
         .replace(CRD_REF, (_match, raw) => {
             const a = shortcodeAttrs(raw);

--- a/scripts/build-search-index.js
+++ b/scripts/build-search-index.js
@@ -6,10 +6,52 @@
  */
 
 const fs = require('fs').promises;
+const fsSync = require('fs');
 const path = require('path');
 const { marked } = require('marked');
 const cheerio = require('cheerio');
 const Fuse = require('fuse.js');
+const yaml = require('yaml');
+
+const DATA_PATH = path.join(__dirname, '../data');
+const PARAM_TABLE = /\{\{<\s*param-table\s+([^>]*?)>\}\}/g;
+const CRD_REF = /\{\{<\s*crd-ref\s+([^>]*?)>\}\}/g;
+
+function shortcodeAttrs(raw) {
+    const out = {};
+    for (const m of raw.matchAll(/(\w+)="([^"]*)"/g)) out[m[1]] = m[2];
+    return out;
+}
+
+function readData(...parts) {
+    try {
+        return yaml.parse(fsSync.readFileSync(path.join(DATA_PATH, ...parts), 'utf-8'));
+    } catch {
+        // Hugo already fails the build on a shortcode it cannot resolve.
+        return null;
+    }
+}
+
+// marked() leaves Hugo shortcodes alone, so a page using param-table would
+// index the literal "{{< param-table ... >}}" instead of its parameters.
+function expandShortcodes(markdown) {
+    return markdown
+        .replace(PARAM_TABLE, (_match, raw) => {
+            const a = shortcodeAttrs(raw);
+            const data = readData('params', a.scenario || '', `${a.source || ''}.yaml`);
+            let rows = (data && data.params) || [];
+            if (a.group) rows = rows.filter(r => r.group === a.group);
+            return rows
+                .map(r => `${a.prefix || ''}${r.name} ${r.description || ''}`)
+                .join(' ');
+        })
+        .replace(CRD_REF, (_match, raw) => {
+            const a = shortcodeAttrs(raw);
+            const index = readData('krkn_operator_crds.yaml');
+            const entry = index && index[a.crd];
+            return entry ? `${entry.kind || a.crd} ${entry.short || ''}` : (a.crd || '');
+        });
+}
 
 // Build-time version that reads markdown files directly
 class BuildTimeIndexer {
@@ -47,7 +89,7 @@ class BuildTimeIndexer {
     async processMarkdownFile(filePath) {
         try {
             const content = await fs.readFile(filePath, 'utf-8');
-            const parsed = this.parseMarkdown(content);
+            const parsed = this.parseMarkdown(expandShortcodes(content));
             
             if (parsed && parsed.title) {
                 const url = this.generateUrl(filePath);


### PR DESCRIPTION
## Documentation Update

**Related Feature:** search index, `scripts/build-search-index.js`

**Changes:**

Fixes #620, which has the full detail.

`build-search-index.js` parses raw markdown with `marked`, which leaves Hugo shortcodes as literal text. 
`param-table` renders its rows from `data/params/<scenario>/<source>.yaml`, so a page that moves its table into the shortcode loses every parameter from the index.

This PR will allow us to expand `param-table` and `crd-ref` to plain text before parsing, reading the same data files the shortcodes read. `crd-ref` is covered now because it has the same shape and the operator docs will use it.

&ensp;

**It changes nothing until a page uses a shortcode.**
- Nothing in `content/en/docs` does yet, and running the indexer on `main` before and after gives identical `documents` and `topics`, 233 either way.

Against the content on #616, the one the bot PRs to use `param-table`:

| Search for | before | after |
| --- | --- | --- |
| `TELEMETRY_ENABLED` | no match | `/docs/scenarios/all-scenario-env/` |
| `ES_SERVER` | no match | `/docs/scenarios/all-scenario-env/` |
| `cerberus-enabled` | no match | `/docs/scenarios/all-scenario-env-krknctl/` |

From local testing it still has 233 documents before and after, and no shortcode text left in the index.

`yaml` is added to `dependencies`. 
It is already in the tree as a transitive dependency of `postcss-cli` at the same 2.9.0, so nothing new is pulled in, and
there is no root `package-lock.json` to regenerate.

Also tested with `npm run _build:index` on both `main` and #616 content, and `hugo -e dev -DFE` builds cleanly.
