### PR TITLE
fix: resolve only stable krkn-operator versions

### DIFF
--- a/data/roadmap.yaml
+++ b/data/roadmap.yaml
@@ -19,7 +19,7 @@ releases:
 
   - version: "v1.1.0"
     title: "Scenario Rollback"
-    date: "2026-09-17"
+    date: "2026-10-20"
     status: in-progress
     tasks:
       - "Scenario Rollback"
@@ -28,4 +28,6 @@ releases:
       - "Chaos Studio scenario import"
       - "Elasticsearch views (summary charts, metric views, and alerts)"
       - "Signed krkn-hub images"
+      - "Operator Backup/Restore"
+      - "Krkn AI"
 


### PR DESCRIPTION
## Summary
- keep the GitHub web release flow without using api.github.com
- accept only tags matching the exact  format
- skip prerelease entries when falling back to the public releases page

## Validation
- node --check netlify/functions/krkn-operator-version.js
- git diff --check